### PR TITLE
Change to add information about where to store architecture diagrams

### DIFF
--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T07:54:16.143Z",
+		"lastUpdated": "2021-05-17T08:04:16.368Z",
 		"lastUpdatedBy": "Adam Cogan [SSW]",
 		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T07:54:16.143Z",
+		"lastUpdated": "2021-05-17T08:04:16.367Z",
 		"lastUpdatedBy": "Adam Cogan [SSW]",
 		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2020-10-10T13:03:15+11:00",
-		"lastUpdatedBy": "Matt Goldman",
-		"lastUpdatedByEmail": "MattGoldman@ssw.com.au",
+		"lastUpdated": "2021-05-04T01:20:46.472Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-04T00:57:58.831Z",
+		"lastUpdated": "2021-05-04T01:20:46.472Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-04T01:20:46.472Z",
+		"lastUpdated": "2021-05-04T01:21:47.446Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-04T01:20:46.472Z",
+		"lastUpdated": "2021-05-04T01:21:47.446Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-03T23:48:43.017Z",
+		"lastUpdated": "2021-05-03T23:49:34.709Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T06:38:27.327Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T07:21:46.295Z",
+		"lastUpdatedBy": "Adam Cogan [SSW]",
+		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T06:38:27.327Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T07:21:46.295Z",
+		"lastUpdatedBy": "Adam Cogan [SSW]",
+		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T07:21:46.295Z",
-		"lastUpdatedBy": "Adam Cogan [SSW]",
-		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
+		"lastUpdated": "2021-05-17T07:29:44.673Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T07:21:46.295Z",
-		"lastUpdatedBy": "Adam Cogan [SSW]",
-		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
+		"lastUpdated": "2021-05-17T07:29:44.673Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-04-28T00:01:04.138Z",
-		"lastUpdatedBy": "Brady Stroud [SSW]",
-		"lastUpdatedByEmail": "bradystroud@ssw.com.au",
+		"lastUpdated": "2021-05-03T02:44:43.841Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-03T02:44:43.841Z",
+		"lastUpdated": "2021-05-03T23:48:43.017Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-10T05:21:01.241Z",
+		"lastUpdated": "2021-05-11T02:20:57.013Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-10T05:21:01.241Z",
+		"lastUpdated": "2021-05-11T02:20:57.013Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T06:20:59.669Z",
+		"lastUpdated": "2021-05-17T06:37:41.476Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T06:20:59.669Z",
+		"lastUpdated": "2021-05-17T06:37:41.476Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-11T02:25:15.113Z",
+		"lastUpdated": "2021-05-11T02:32:13.538Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-11T02:25:15.113Z",
+		"lastUpdated": "2021-05-11T02:32:13.538Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-07T07:29:18.583Z",
+		"lastUpdated": "2021-05-07T07:31:39.112Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-07T07:29:18.583Z",
+		"lastUpdated": "2021-05-07T07:31:39.112Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-11T04:45:06.024Z",
-		"lastUpdatedBy": "Matt Wicks [SSW]",
-		"lastUpdatedByEmail": "wicksipedia@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T06:20:59.669Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-11T04:45:06.024Z",
-		"lastUpdatedBy": "Matt Wicks [SSW]",
-		"lastUpdatedByEmail": "wicksipedia@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T06:20:59.669Z",
+		"lastUpdatedBy": "Piers Sinclair [SSW]",
+		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-11T02:20:57.013Z",
+		"lastUpdated": "2021-05-11T02:23:01.737Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-11T02:20:57.013Z",
+		"lastUpdated": "2021-05-11T02:23:01.736Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T08:04:16.368Z",
+		"lastUpdated": "2021-05-17T08:10:14.661Z",
 		"lastUpdatedBy": "Adam Cogan [SSW]",
 		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T08:04:16.367Z",
+		"lastUpdated": "2021-05-17T08:10:14.661Z",
 		"lastUpdatedBy": "Adam Cogan [SSW]",
 		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-04T01:25:18.564Z",
+		"lastUpdated": "2021-05-07T07:29:18.583Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-04T01:25:18.564Z",
+		"lastUpdated": "2021-05-07T07:29:18.583Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T06:37:41.476Z",
+		"lastUpdated": "2021-05-17T06:38:27.327Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T06:37:41.476Z",
+		"lastUpdated": "2021-05-17T06:38:27.327Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-03T23:49:34.709Z",
+		"lastUpdated": "2021-05-04T00:57:58.831Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-17T07:29:44.673Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T07:54:16.143Z",
+		"lastUpdatedBy": "Adam Cogan [SSW]",
+		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T07:29:44.673Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-17T07:54:16.143Z",
+		"lastUpdatedBy": "Adam Cogan [SSW]",
+		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-04T01:21:47.446Z",
+		"lastUpdated": "2021-05-04T01:25:18.564Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-04T01:21:47.446Z",
+		"lastUpdated": "2021-05-04T01:25:18.564Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,9 +9856,9 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-11T02:32:13.538Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-11T04:45:06.024Z",
+		"lastUpdatedBy": "Matt Wicks [SSW]",
+		"lastUpdatedByEmail": "wicksipedia@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-11T02:32:13.538Z",
-		"lastUpdatedBy": "Piers Sinclair [SSW]",
-		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
+		"lastUpdated": "2021-05-11T04:45:06.024Z",
+		"lastUpdatedBy": "Matt Wicks [SSW]",
+		"lastUpdatedByEmail": "wicksipedia@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-07T07:31:39.112Z",
+		"lastUpdated": "2021-05-10T05:21:01.241Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-07T07:31:39.112Z",
+		"lastUpdated": "2021-05-10T05:21:01.241Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/history.json
+++ b/history.json
@@ -9856,7 +9856,7 @@
 	},
 	{
 		"file": "rules/awesome-documentation/rule.md",
-		"lastUpdated": "2021-05-11T02:23:01.737Z",
+		"lastUpdated": "2021-05-11T02:25:15.113Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2013-07-16T02:37:37+10:00",
@@ -22114,7 +22114,7 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-11T02:23:01.736Z",
+		"lastUpdated": "2021-05-11T02:25:15.113Z",
 		"lastUpdatedBy": "Piers Sinclair [SSW]",
 		"lastUpdatedByEmail": "79821522+pierssinclairssw@users.noreply.github.com",
 		"created": "2020-09-01T04:10:47+10:00",

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -167,7 +167,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store your architecture diagram in the repo **/docs** folder. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **/docs** folder as the source of wiki documentation.
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store your architecture diagram in the repo **docs\\** folder. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -168,7 +168,7 @@ Maintain standards to keep your diagrams consistent:
 ![Figure: Good Example - SSW People (a Static Site - Gatsby and React with Dynamics 365 and SharePoint Online) - you can just as easily create colorful, engaging diagrams suitable for all of your project stakeholders](SSW.People-Architecture-Diagram.png)
 :::
 
-### Tip 9: Tip 9 – Where to store Diagrams?
+### Tip 9: Where to store Diagrams?
 
 Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagrams in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -170,7 +170,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagrams in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagrams in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a Wiki, we recommend you use the repo **docs\\** folder as the source of Wiki documentation.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -167,7 +167,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. We recommend that you store your architecture diagram in the "/docs" folder and use this location as the source code for your chosen wiki.
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store your architecture diagram in the repo **/docs** folder. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **/docs** folder as the source of wiki documentation.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -164,6 +164,19 @@ Maintain standards to keep your diagrams consistent:
 ![Figure: Good Example - SSW People (a Static Site - Gatsby and React with Dynamics 365 and SharePoint Online) - you can just as easily create colorful, engaging diagrams suitable for all of your project stakeholders](SSW.People-Architecture-Diagram.png)
 :::
 
+### Tip 9: Tip 9 – Where to store Diagrams?
+
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience amoung developers. There are a few options depending on which source control you use:
+
+Azure DevOps
+* [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)
+* [Wiki edited via the portal](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
+
+GitHub
+* In the repo "docs" folder (recommended)
+* On [GitHub Pages](https://pages.github.com/)
+* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
+
 ### Related links
 
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -10,7 +10,8 @@ authors:
   url: https://ssw.com.au/people/adam-cogan
 - title: Matt Goldman
   url: https://ssw.com.au/people/matt-goldman
-related: []
+related: 
+- awesome-documentation
 redirects:
 - have-an-architecture-diagram
 - do-you-have-an-architecture-diagram

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -66,7 +66,7 @@ At a minimum, your architecture diagram should include:
 Your diagram needs to include the relationships between these components, and how they share and process data.
 
 
-### Tip 2: Don't use a .NET Dependency Graph as a System Architecture Diagram
+### Tip 2: Don't use a .NET Dependency Graph as a Architecture Diagram
 
 
 The .NET dependency diagram is a useful tool, but it drills down into a specific component of the solution (the code) while ignoring the rest of it (the infrastructure). If it adds value to your documentation (i.e., there is a specific reason to include it) you can include the .NET dependency diagram, but don't use it here in place of the architecture diagram.
@@ -149,7 +149,7 @@ There are multiple extensions available that let you do this, the best one is [V
 
 
 ::: good
-![Figure: Good Example - Auctions (a Blazor + .NET + Cosmos DB project) - system architecture diagram created within VS Code and checked into the repo in the same commit as the relevant code changes. Blazor UI layer encapsulated in thematic color](architecture-2.png)
+![Figure: Good Example - Auctions (a Blazor + .NET + Cosmos DB project) - architecture diagram created within VS Code and checked into the repo in the same commit as the relevant code changes. Blazor UI layer encapsulated in thematic color](architecture-2.png)
 :::
 
 ### Tip 8: Polish up Diagrams.net

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -166,16 +166,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. There are a few options depending on which source control you use:
-
-Azure DevOps
-* [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)
-* [Wiki edited via the portal](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
-
-GitHub
-* In the repo "docs" folder (recommended)
-* On [GitHub Pages](https://pages.github.com/)
-* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. We recommend that you store your architecture diagram in the "/docs" folder and use this location as the source code for your chosen wiki.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -10,6 +10,8 @@ authors:
   url: https://ssw.com.au/people/adam-cogan
 - title: Matt Goldman
   url: https://ssw.com.au/people/matt-goldman
+- title: Piers Sinclair
+  url: https://ssw.com.au/people/piers-sinclair
 related: 
 - awesome-documentation
 - azure-resources-diagram

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -168,7 +168,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store your architecture diagram in the repo **docs\\** folder. Additionally, You should link to the architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagram in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -170,7 +170,8 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagrams in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a Wiki, we recommend you use the repo **docs\\** folder as the source of Wiki documentation.
+Standardizing where your organisation stores architecture diagrams ensures a consistent experience among developers. Therefore store your architecture diagrams in the repo **docs\\** folder. Additionally, the \README.md (in the root) should have a link and an embedded image of the high-level architecture diagram (from the **docs\\* folder). 
+Note: If you have a Wiki, for visibility add an architecture diagram page and embed the images from the **docs\\** folder.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -166,7 +166,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience amoung developers. There are a few options depending on which source control you use:
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. There are a few options depending on which source control you use:
 
 Azure DevOps
 * [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -168,7 +168,7 @@ Maintain standards to keep your diagrams consistent:
 
 ### Tip 9: Tip 9 – Where to store Diagrams?
 
-Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagram in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
+Standardizing where your organisation stores architecture diagrams is important to ensure a consistent experience among developers. We recommend that you store all your architecture diagrams in the repo **docs\\** folder. Additionally, You should link to the high-level architecture diagram in your README.md so future developers can locate it easily. If you have a wiki, we recommend you use the repo **docs\\** folder as the source of wiki documentation.
 
 ### Related links
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -12,6 +12,7 @@ authors:
   url: https://ssw.com.au/people/matt-goldman
 related: 
 - awesome-documentation
+- azure-resources-diagram
 redirects:
 - have-an-architecture-diagram
 - do-you-have-an-architecture-diagram
@@ -171,6 +172,4 @@ Standardizing where your organisation stores architecture diagrams is important 
 
 ### Related links
 
-
-* [Do you have an Azure resources diagram?](/azure-resources-visualizing)
 * [8 Tips to Better Architecture Diagrams](https://adamcogan.com/2020/10/07/8-tips-to-better-architecture-diagrams/)

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -98,12 +98,20 @@ There are 7 crucial documents for your project:
 
 **4. docs\Business** – explains the purpose of the application, including the problem, goals, and statement of intent.
 
-**5. docs\Technologies-and-Architecture** – Provides a technical overview of the solution, including any 3rd party libraries or utilities, patterns followed (e.g.        [https://rules.ssw.com.au/rules-to-better-clean-architecture](/rules-to-better-clean-architecture)), architecture decisions, etc. This document should cover software architecture and cloud architecture (or on-premises if you’re a dinosaur 🦕), and should \*always\* have a system architecture diagram (see:        [https://rules.ssw.com.au/have-an-architecture-diagram](/have-an-architecture-diagram)), as well as an Azure resources diagram, see: [https://rules.ssw.com.au/azure-resources-diagram/](/azure-resources-visualizing)
+**5. docs\Technologies-and-Architecture** – Provides a technical overview of the solution. There are four crucial areas to this part of the documentation
+* Architecture diagrams which should include the following
+  * [A system architecture diagram](https://www.ssw.com.au/rules/architecture-diagram) which outlines a high-level overview of the project
+  * Software architecture
+  * Cloud architecture (or on-premises if you’re a dinosaur 🦕) including an [Azure resources diagram](https://www.ssw.com.au/rules/azure-resources-diagram)
+* Patterns followed (e.g. [Clean Architecture](https://rules.ssw.com.au/rules-to-better-clean-architecture))
+* 3rd Party libraries or utilities used
+* Alternative solutions considered. For example
+  * We chose to use a code centric solution over a low code solution because we did not want to be locked into a specific vendor.
+  * We chose to use Angular over React because the developers on the project were more familiar with Angular.
 
 **6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
 
 **7. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see:        [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
-
 
 Keeping these documents in the repository means that you ensure that any documentation the developers need to work on or run the code is where they need it - with the code.
 
@@ -202,4 +210,4 @@ We can choose to continue paying the interest, or we can pay the debt in full by
 
 The same principle is true with documentation. Using the 'old school' method will leave you with a build-up of documentation that you will need to keep up to date as the project evolves.
 
-Warning: if you want to follow Scrum and have zero technical debt, then you must throw away all documentation at the end of each sprint. If you do want to keep it, make sure you add it to your [definition of done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)to keep it updated.
+Warning: if you want to follow Scrum and have zero technical debt, then you must throw away all documentation at the end of each sprint. If you do want to keep it, make sure you add it to your [definition of done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done) to keep it updated.

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -100,21 +100,21 @@ There are 7 crucial documents for your project:
 
 **4. docs\Business** – explains the purpose of the application, including the problem, goals, and statement of intent.
 
-**5. docs\Technologies-and-Architecture** – Provides a technical overview of the solution. There are four crucial areas to this part of the documentation
-* Architecture diagrams which should include the following
-  * [A system architecture diagram](https://www.ssw.com.au/rules/architecture-diagram) which outlines a high-level overview of the project
-  * Software architecture
-  * Cloud architecture (or on-premises if you’re a dinosaur 🦕) including an [Azure resources diagram](https://www.ssw.com.au/rules/azure-resources-diagram)
-* Patterns followed (e.g. [Clean Architecture](https://rules.ssw.com.au/rules-to-better-clean-architecture))
-* 3rd Party libraries or utilities used
-* Alternative solutions considered. For example
-  * We chose to use a code-centric solution over a low code solution because we did not want to be locked into a specific vendor.
-  * We chose to use Angular over React because the developers on the project were more familiar with Angular.
-  * We chose to use Azure over on-premises so we could avoid procurement of costly servers.
+**5. docs\Technologies-and-Architecture** – Provides a technical overview of the solution.
+* [An architecture diagram](https://www.ssw.com.au/rules/architecture-diagram) which outlines a high-level overview of the project. 
+* Lower level architecture diagrams of the system eg. [Azure resources diagram (auto generated)](https://www.ssw.com.au/rules/azure-resources-diagram)
+* Coding patterns followed (e.g. [Clean Architecture](https://rules.ssw.com.au/rules-to-better-clean-architecture))
+* 3rd party libraries used 
+* 3rd party services used 
+
+**6. docs\Alterative-Solutions-Considered** – explains other options that were discounted. For example
+  * We chose to use a code-centric .NET solution over a low code solution because we did not want to be locked into any specific vendor eg. Dynamics, Outsystems.
+  * We chose to use Angular over React because 5/6 developers on the project were more familiar with Angular.
+  * We chose to use Azure over on-premises to avoid procurement of costly servers.
 
 **6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
 
-**7. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see:        [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
+**7. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
 
 Keeping these documents in the repository means that you ensure that any documentation the developers need to work on or run the code is where they need it - with the code.
 
@@ -137,7 +137,7 @@ GitHub
 
 **Tip** : You can publish your documentation from the repo using [GitHub Pages](https://pages.github.com/)
 
-**Tip** : All of your documents (in your Wiki and your repository) should be written in Markdown (see: [https://rules.ssw.com.au/using-markdown-to-store-your-content](/using-github-and-markdown-to-store-you-content))
+**Tip** : All of your documents (in your Wiki and your repository) should be written in Markdown (see [https://rules.ssw.com.au/using-markdown-to-store-your-content](/using-github-and-markdown-to-store-you-content))
 
 
 ::: bad  

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -82,13 +82,10 @@ There may be exceptions – some situations benefit from this kind of documentat
 
 
 
-### Good example – The 7 Important Documents
+### Good example – The 8 Important Documents
 
 
 This style of documentation is used by modern teams who are Agile only.
-
-
-There are 7 crucial documents for your project:
 
 **In the repository (for developers):**
 
@@ -111,10 +108,11 @@ There are 7 crucial documents for your project:
   * We chose to use a code-centric .NET solution over a low code solution because we did not want to be locked into any specific vendor eg. Dynamics, Outsystems.
   * We chose to use Angular over React because 5/6 developers on the project were more familiar with Angular.
   * We chose to use Azure over on-premises to avoid procurement of costly servers.
+  * Note: If you decide that after the fact that the chosen solution is wrong, this should be explained. Include what led to the current circumstances and if there is a planned change.
 
-**6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
+**7. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
 
-**7. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
+**8. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
 
 Keeping these documents in the repository means that you ensure that any documentation the developers need to work on or run the code is where they need it - with the code.
 

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -88,8 +88,6 @@ This style of documentation is used by modern teams who are Agile only.
 
 There are 7 crucial documents for your project:
 
-
-
 **In the repository (for developers):**
 
 **1. README.md** – Explains the overview of the project and provides links to the rest of the documentation.
@@ -98,33 +96,33 @@ There are 7 crucial documents for your project:
 
 **3. docs\Instructions-Deployment.md** – Explains how to deploy the solution, including any additional processes (e.g. DevOps)
 
+**4. docs\Business** – explains the purpose of the application, including the problem, goals, and statement of intent.
+
+**5. docs\Technologies-and-Architecture** – Provides a technical overview of the solution, including any 3rd party libraries or utilities, patterns followed (e.g.        [https://rules.ssw.com.au/rules-to-better-clean-architecture](/rules-to-better-clean-architecture)), architecture decisions, etc. This document should cover software architecture and cloud architecture (or on-premises if you’re a dinosaur 🦕), and should \*always\* have a system architecture diagram (see:        [https://rules.ssw.com.au/have-an-architecture-diagram](/have-an-architecture-diagram)), as well as an Azure resources diagram, see: [https://rules.ssw.com.au/azure-resources-diagram/](/azure-resources-visualizing)
+
+**6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
+
+**7. docs\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see:        [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
+
+
 Keeping these documents in the repository means that you ensure that any documentation the developers need to work on or run the code is where they need it - with the code.
 
 It also means that when a developer makes a change to the code that needs an update to the documentation, the documentation changes can be checked in along with the code in the same commit.
 
 
+**Exposing documentation through a Wiki (for developers and other stakeholders):**
 
-**In the Wiki (for developers and other stakeholders):**
+Documents to be read or edited by the Product Owner (or other members of the Scrum team) should be exposed through a Wiki. The advantage of this approach is that the writing experience in the Wiki is more friendly for non-developers. We recommend that your Wiki is sourced from the repo **docs\\** folder to ensure documentation is kept up to date with development. There are several options for creating a Wiki:
 
+Azure DevOps
+* [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)
+* [Wiki edited via the portal](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
+* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
-::: greybox
- **Note:** When using a GitHub Wiki, it’s a separate repository. When using an Azure DevOps Wiki, it’s in the same repository.  
-:::
-
-**4. Wiki\Business** – explains the purpose of the application, including the problem, goals, and statement of intent.
-
-**5. Wiki\Technologies-and-Architecture** – Provides a technical overview of the solution, including any 3rd party libraries or utilities, patterns followed (e.g.        [https://rules.ssw.com.au/rules-to-better-clean-architecture](/rules-to-better-clean-architecture)), architecture decisions, etc. This document should cover software architecture and cloud architecture (or on-premises if you’re a dinosaur 🦕), and should \*always\* have a system architecture diagram (see:        [https://rules.ssw.com.au/have-an-architecture-diagram](/have-an-architecture-diagram)), as well as an Azure resources diagram, see: [https://rules.ssw.com.au/azure-resources-diagram/](/azure-resources-visualizing)
-
-**6. Wiki\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
-
-**7. Wiki\Definition-of-Ready** – Ensures that all your PBIs are well defined to an agreed standard before adding them to a sprint (see:        [https://rules.ssw.com.au/have-a-definition-of-ready](/have-a-definition-of-ready))
-
-
-
-Documents to be read or edited by the Product Owner (or other members of the Scrum team) are better kept out of the code repository, in the Wiki. The advantages of this approach are:
-
-* Updating the Wiki does not trigger the CI/CD pipeline
-* The writing experience in the Wiki is more friendly for non-developers (no need to clone the repo and submit a pull request; especially annoying for a minor change)
+GitHub
+* On [GitHub Pages](https://pages.github.com/) (recommended)
+* The [GitHub repo Wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)
+* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
 
 **Tip** : All of your documents (in your Wiki and your repository) should be written in Markdown (see:     [https://rules.ssw.com.au/using-markdown-to-store-your-content](/using-github-and-markdown-to-store-you-content))

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -110,7 +110,7 @@ There are 7 crucial documents for your project:
 * Alternative solutions considered. For example
   * We chose to use a code-centric solution over a low code solution because we did not want to be locked into a specific vendor.
   * We chose to use Angular over React because the developers on the project were more familiar with Angular.
-  * We chose to use Azure over On-premises so we could avoid procurement of costly servers.
+  * We chose to use Azure over on-premises so we could avoid procurement of costly servers.
 
 **6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
 
@@ -128,12 +128,12 @@ Documents to be read or edited by the Product Owner (or other members of the Scr
 Azure DevOps
 * [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)
 * [Wiki edited via the portal](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
-* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
+* An alternative Wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
 GitHub
 * [Markdown files edited via the repo](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository) (recommended)
 * The [GitHub repo Wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)
-* An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
+* An alternative Wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
 **Tip** : You can publish your documentation from the repo using [GitHub Pages](https://pages.github.com/)
 

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -131,14 +131,13 @@ Azure DevOps
 * An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
 GitHub
-* On [GitHub Pages](https://pages.github.com/) (recommended)
+* [Markdown files edited via the repo](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository) (recommended)
 * The [GitHub repo Wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)
 * An alternative wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
+**Tip** : You can publish your documentation from the repo using [GitHub Pages](https://pages.github.com/)
 
-**Tip** : All of your documents (in your Wiki and your repository) should be written in Markdown (see:     [https://rules.ssw.com.au/using-markdown-to-store-your-content](/using-github-and-markdown-to-store-you-content))
-
-
+**Tip** : All of your documents (in your Wiki and your repository) should be written in Markdown (see: [https://rules.ssw.com.au/using-markdown-to-store-your-content](/using-github-and-markdown-to-store-you-content))
 
 
 ::: bad  

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -121,14 +121,14 @@ It also means that when a developer makes a change to the code that needs an upd
 
 **Exposing documentation through a Wiki (for developers and other stakeholders):**
 
-Documents to be read or edited by the Product Owner (or other members of the Scrum team) should be exposed through a Wiki. The advantage of this approach is that the writing experience in the Wiki is more friendly for non-developers. We recommend that your Wiki is sourced from the repo **docs\\** folder to ensure documentation is kept up to date with development. There are several options for creating a Wiki:
+Documents to be read or edited by the Product Owner (or other members of the Scrum team) should be exposed through a Wiki. The advantage of this approach is that the writing experience in the Wiki is more friendly for non-developers. The Wiki should be sourced from the repo **docs\\** folder to ensure documentation is kept up-to-date. There are several options for creating a Wiki:
 
-Azure DevOps
+Azure DevOps wiki options:
 * [Wiki edited via the repo](https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser) (recommended)
 * [Wiki edited via the portal](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
 * An alternative Wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))
 
-GitHub
+GitHub wiki options:
 * [Markdown files edited via the repo](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-your-repository) (recommended)
 * The [GitHub repo Wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)
 * An alternative Wiki platform (e.g. [Confluence](https://www.atlassian.com/software/confluence))

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -18,6 +18,8 @@ authors:
   url: https://ssw.com.au/people/adam-stephensen
 - title: Matt Goldman
   url: https://ssw.com.au/people/matt-goldman
+- title: Piers Sinclair
+  url: https://ssw.com.au/people/piers-sinclair
 related:
 - reference-do-you-use-the-correct-symbols-when-documenting-instructions
 - reference-do-you-use-the-right-order-of-instructions

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -90,7 +90,7 @@ There are 7 crucial documents for your project:
 
 **In the repository (for developers):**
 
-**1. README.md** – Explains the overview of the project and provides links to the rest of the documentation.
+**1. README.md** – Explains the overview of the project and provides links to the rest of the documentation. It is important for the README.md to show a high-level architecture diagram that illustrates the overarching solution.
 
 **2. docs\Instructions-Compile.md** – Instructions on how to build and run the project (AKA the F5 experience).
 

--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -108,8 +108,9 @@ There are 7 crucial documents for your project:
 * Patterns followed (e.g. [Clean Architecture](https://rules.ssw.com.au/rules-to-better-clean-architecture))
 * 3rd Party libraries or utilities used
 * Alternative solutions considered. For example
-  * We chose to use a code centric solution over a low code solution because we did not want to be locked into a specific vendor.
+  * We chose to use a code-centric solution over a low code solution because we did not want to be locked into a specific vendor.
   * We chose to use Angular over React because the developers on the project were more familiar with Angular.
+  * We chose to use Azure over On-premises so we could avoid procurement of costly servers.
 
 **6. docs\Definition-of-Done** - Ensures that your team [maintains a high level of quality with a Definition of Done](/done-do-you-go-beyond-done-and-follow-a-definition-of-done)
 


### PR DESCRIPTION
Hi @wicksipedia , @william-liebenberg ,

1. Please review the GitHub and Azure DevOps changes.

Note: this rule is in relation to Architecture Diagram storage. We will have another rule which goes into the specifics of documentation (and link to Diagrams). @calumjs , myself and @tiagov8 are working on this.