### PR TITLE
Fix good example box

### DIFF
--- a/history.json
+++ b/history.json
@@ -22114,9 +22114,9 @@
 	},
 	{
 		"file": "rules/architecture-diagram/rule.md",
-		"lastUpdated": "2021-05-17T08:10:14.661Z",
-		"lastUpdatedBy": "Adam Cogan [SSW]",
-		"lastUpdatedByEmail": "adamcogan@ssw.com.au",
+		"lastUpdated": "2021-05-18T01:48:23.026Z",
+		"lastUpdatedBy": "Brady Stroud [SSW]",
+		"lastUpdatedByEmail": "bradystroud@ssw.com.au",
 		"created": "2020-09-01T04:10:47+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -101,6 +101,7 @@ It should be easy to tell at a glance which direction data flows in your diagram
 Group components logically by enclosing them in a box. Components that operate independently can stand alone, and those that work together to deliver a logical function can be grouped together. Also show components that are out of scope, i.e. important for understanding the architecture but not necessarily part of it, e.g. legacy components, partner components, or components that have not been implemented yet.
 
 Note: for clarity, out of scope items whether one or many, should be in a box.
+
 ::: good
 ![Figure: Good example - SSW Rewards (Xamarin with Azure Active Directory B2C) - consistent styling is used, e.g. as well as all the icons and typography being consistent, you can see that data is a solid line and auth traffic is a dotted line](rewards-architecture-diagram.png)
 :::


### PR DESCRIPTION
There was no new line between the paragraph and 'good' box, which I think was breaking it.

![Screen Shot 2021-05-18 at 11 46 27 am](https://user-images.githubusercontent.com/38869720/118577974-af78af00-b7ce-11eb-86d3-1364a0239f3e.png)
**Figure: Broken 'good' box**
