### PR TITLE
Fixed formatting of tick icons

### DIFF
--- a/history.json
+++ b/history.json
@@ -17956,9 +17956,9 @@
 	},
 	{
 		"file": "rules/use-using-statement-instead-of-use-explicitly-dispose/rule.md",
-		"lastUpdated": "2020-01-29T15:33:01+11:00",
-		"lastUpdatedBy": "Liam Elliott",
-		"lastUpdatedByEmail": "LiamElliott@ssw.com.au",
+		"lastUpdated": "2021-07-14T01:34:55.924Z",
+		"lastUpdatedBy": "Taine Riley",
+		"lastUpdatedByEmail": "40375803+taineriley1@users.noreply.github.com",
 		"created": "2018-04-27T06:56:48+10:00",
 		"createdBy": "Tiago Araujo",
 		"createdByEmail": "TiagoAraujo@ssw.com.au"

--- a/rules/use-using-statement-instead-of-use-explicitly-dispose/rule.md
+++ b/rules/use-using-statement-instead-of-use-explicitly-dispose/rule.md
@@ -121,15 +121,12 @@ static int WriteLinesToFile(IEnumerable<string> lines)
 
 
 ::: good
-Figure: Good example of dispose of resources, using c# 8.0 using declaration
+Figure: Good example of dispose of resources, using c# 8.0 using declaration  
+:::
 
 
 
-TIP:
-
-**Did you know it is not recommended to dispose HttpClient?**
+**Tip: Did you know it is not recommended to dispose HttpClient?**
 
 One last note is regarding disposing of HttpClient.  Yes, HTTPClient does implement IDisposable, however, I do not recommend creating a HttpClient inside a Using block to make a single request.  When HttpClient is disposed it causes the underlying connection to be closed also.  This means the next request has to re-open that connection.  You should try and re-use your HttpClient instances.  If the server really does not want you holding open it’s connection then it will send a header to request the connection be closed.
 http://www.bizcoder.com/httpclient-it-lives-and-it-is-glorious
-
-:::


### PR DESCRIPTION
The tick icon for the good example at the bottom was creating multiple ticks.
![image](https://user-images.githubusercontent.com/40375803/125546553-67958c9d-142b-4f6a-9094-f7e8914951b8.png)
**Figure: Multiple tick icons**

This has been changed to only use the tick icon for the figure caption.