### PR TITLE
trying to fix captions

### DIFF
--- a/history.json
+++ b/history.json
@@ -7453,7 +7453,7 @@
 	},
 	{
 		"file": "rules/spec-do-you-effectively-present-the-outcomes-at-the-specification-review-presentation/rule.md",
-		"lastUpdated": "2021-08-06T16:49:17.994Z",
+		"lastUpdated": "2021-08-09T15:34:49.448Z",
 		"lastUpdatedBy": "Tiago Araújo [SSW]",
 		"lastUpdatedByEmail": "tiagov8@gmail.com",
 		"created": "2015-04-09T18:07:29+10:00",

--- a/rules/spec-do-you-effectively-present-the-outcomes-at-the-specification-review-presentation/rule.md
+++ b/rules/spec-do-you-effectively-present-the-outcomes-at-the-specification-review-presentation/rule.md
@@ -48,7 +48,6 @@ Figure: Good example – this is an appointment with a specific time for the nex
 * All parties benefit while the information is fresh in their minds
 * The client won't experience the inevitable delays when you go back to the office and get stuck on other client issues that appear more urgent
 
-
 ### What does the client get at the conclusion of the Spec Review? 
    
 * **Option A** - Email (if they want to minimize documentation time), or
@@ -64,23 +63,27 @@ Make sure to name your video according to the rules on [How to Include Version N
 ### Video Examples 
   
 `youtube: https://www.youtube.com/embed/sPMT6Udh7rQ`
+
 ::: good
-Good Example: FireBootCamp - Scrum Commitments Specification Video        
+Figure: Good example – FireBootCamp - Scrum Commitments Specification Video        
 :::
 
 `youtube: https://www.youtube.com/embed/nywSzMhkZV4`
+
 ::: good
-Good Example: FireBootCamp - SugarLearning Specification Video      
+Figure: Good example – FireBootCamp - SugarLearning Specification Video      
 :::
 
 `youtube: https://www.youtube.com/embed/VhWPZERUiYg`
+
 ::: good
-Good Example: FireBootCamp - TimePro Invoicing Specification Video  
+Figure: Good example – FireBootCamp - TimePro Invoicing Specification Video  
 :::
 
 `youtube: https://www.youtube.com/embed/vpFCtChJPVA`
+
 ::: good
-Good Example: FireBootCamp - Code Auditor Specification Video
+Figure: Good example – FireBootCamp - Code Auditor Specification Video
 :::
 
 Once again, the presentation needs to pass a '[test please](/conduct-a-test-please-internally-and-then-with-the-client)' from another senior employee before the meeting takes place.


### PR DESCRIPTION
The markdown seemed alright, but I added a space between video and caption to try to fix this:

<img width="768" alt="Screen Shot 2021-08-09 at 8 33 17 AM" src="https://user-images.githubusercontent.com/12601228/128732936-8e454d67-c936-4a1b-9bfe-ab8037125041.png">
