### PR TITLE
Update "discuss the backlog" rule 

### DIFF
--- a/categories/application-lifecycle-management-alm/rules-to-better-scrum-using-github.md
+++ b/categories/application-lifecycle-management-alm/rules-to-better-scrum-using-github.md
@@ -11,7 +11,7 @@ index:
 - labels-in-github
 - use-emojis-in-your-commits
 - turn-emails-into-a-github-issue
-
+- discuss-the-backlog
 ---
 
 Learn more on [Rules to Better Scrum](/rules-to-better-scrum).

--- a/categories/software-development/rules-to-better-github.md
+++ b/categories/software-development/rules-to-better-github.md
@@ -15,7 +15,6 @@ index:
 - do-you-use-indentation-for-readability
 - do-you-know-the-correct-license-to-use-for-open-source-software
 - do-you-know-to-the-requirements-to-create-a-new-repository
-- discuss-the-backlog
 - sync-your-github-issues-to-azure-devops
 - use-emojis-in-your-commits
 - turn-emails-into-a-github-issue

--- a/rules/discuss-the-backlog/rule.md
+++ b/rules/discuss-the-backlog/rule.md
@@ -1,19 +1,18 @@
 ---
 type: rule
-archivedreason: 
-title: Do you know where to discuss the backlog?
-guid: de9846d4-5b51-417b-afdc-946cc096243e
+title: Scrum – Do you know where to discuss the backlog?
 uri: discuss-the-backlog
-created: 2020-09-24T03:52:45.0000000Z
 authors:
-- title: Adam Cogan
-  url: https://ssw.com.au/people/adam-cogan
-- title: Matt Goldman
-  url: https://ssw.com.au/people/matt-goldman
+  - title: Adam Cogan
+    url: https://ssw.com.au/people/adam-cogan
+  - title: Matt Goldman
+    url: https://ssw.com.au/people/matt-goldman
 related: []
 redirects:
-- do-you-know-where-to-discuss-the-backlog
-
+  - do-you-know-where-to-discuss-the-backlog
+created: 2020-09-24T03:52:45.000Z
+archivedreason: null
+guid: de9846d4-5b51-417b-afdc-946cc096243e
 ---
 
 When discussing a PBI/Issue, Pull Request, or a project in general, it is important to do it in the right place.


### PR DESCRIPTION
As per my conversation with Adam, Piers and Tylah.

- Update the rules name "Scrum – Do you know where to discuss the backlog?"
- Remove from "Rules to better GitHub" category
- Add to "Rules to Better Scrum using GitHub" category