### PR TITLE
Update "GitHub Issues – Do you sync to Azure DevOps?" rule

### DIFF
--- a/categories/application-lifecycle-management-alm/rules-to-better-scrum-using-github.md
+++ b/categories/application-lifecycle-management-alm/rules-to-better-scrum-using-github.md
@@ -11,7 +11,7 @@ index:
 - labels-in-github
 - use-emojis-in-your-commits
 - turn-emails-into-a-github-issue
-
+- sync-your-github-issues-to-azure-devops
 ---
 
 Learn more on [Rules to Better Scrum](/rules-to-better-scrum).

--- a/categories/software-development/rules-to-better-github.md
+++ b/categories/software-development/rules-to-better-github.md
@@ -16,7 +16,6 @@ index:
 - do-you-know-the-correct-license-to-use-for-open-source-software
 - do-you-know-to-the-requirements-to-create-a-new-repository
 - discuss-the-backlog
-- sync-your-github-issues-to-azure-devops
 - use-emojis-in-your-commits
 - turn-emails-into-a-github-issue
 - build-the-backlog

--- a/rules/sync-your-github-issues-to-azure-devops/rule.md
+++ b/rules/sync-your-github-issues-to-azure-devops/rule.md
@@ -1,17 +1,16 @@
 ---
 type: rule
-archivedreason: 
-title: Do you sync your GitHub Issues to Azure DevOps?
-guid: ef4ae2ef-b45d-4403-820e-e3374019bb1c
+title: GitHub Issues – Do you sync to Azure DevOps?
 uri: sync-your-github-issues-to-azure-devops
-created: 2020-10-18T22:36:33.0000000Z
 authors:
-- title: Christian Morford-Waite
-  url: https://ssw.com.au/people/christian-morford-waite
+  - title: Christian Morford-Waite
+    url: https://ssw.com.au/people/christian-morford-waite
 related: []
 redirects:
-- do-you-sync-your-github-issues-to-azure-devops
-
+  - do-you-sync-your-github-issues-to-azure-devops
+created: 2020-10-18T22:36:33.000Z
+archivedreason: null
+guid: ef4ae2ef-b45d-4403-820e-e3374019bb1c
 ---
 
 If you store all your code in GitHub, why not create all your issues there too?


### PR DESCRIPTION
As per my conversation with Adam, Piers and Tylah.

- Update the rules name "GitHub Issues – Do you sync to Azure DevOps?"
- Remove from "Rules to better GitHub" category
- Add to "Rules to Better Scrum using GitHub" category