### PR TITLE
Remove 3 rules from "Rules to better GitHub" 

### DIFF
--- a/categories/software-development/rules-to-better-github.md
+++ b/categories/software-development/rules-to-better-github.md
@@ -14,7 +14,6 @@ index:
 - do-you-know-how-to-write-a-good-pull-request
 - do-you-use-indentation-for-readability
 - do-you-know-to-the-requirements-to-create-a-new-repository
-- discuss-the-backlog
 - use-emojis-in-your-commits
 - turn-emails-into-a-github-issue
 - mention-when-you-make-a-pull-request-or-comment-on-github
@@ -27,8 +26,6 @@ index:
 - do-you-know-how-to-setup-github-notifications
 - github-issue-templates
 - do-you-know-how-to-set-up-github-workflow
-- do-you-know-how-to-handle-undone-work
-- todo-tasks
 
 ---
 


### PR DESCRIPTION
(These didn't merge correctly with my previous PR's since I decided to do them 1 by 1) 

- Removed "Scrum – Do you know where to discuss the backlog?" 
- Removed "Do you know how to handle Undone Work (aka V2 for PBIs)?" 
- Removed "Do you document "TODO" tasks?" 


