### PR TITLE
🐛 Bug - Fix the vertical stretch on an image

### DIFF
--- a/rules/label-your-assets/rule.md
+++ b/rules/label-your-assets/rule.md
@@ -44,7 +44,7 @@ Tracking is all fun and games, but what about knowing which asset is which? You 
 
 This means that after creating the asset in the system, it generally gets a unique ID within it, and you should generate a label (preferably with a QR or bar code for easy scanning) and attach the label to the asset in question. This makes it super easy to see the asset ID and name at a glance, and, in the case the asset is lost somewhere, anyone can easily scan the QR code and be brought to a site with instructions on how to return or notify the company that asset is lost.
 
-::: good
+::: good  
 ![Figure: Good Example - A professional label printed with the important asset info e.g. ID, name and serial number](pxl_20211014_235412634.jpg)
 :::
 


### PR DESCRIPTION
There was an issue with an image having bad vertical stretching that ruined the image.

Changes:

- Re-wrote the Markdown for the image

If this doesn't fix it in production. The next step is to reupload the image to the repo and rewrite the markdown again.

Before:
![image](https://user-images.githubusercontent.com/17246482/143152643-251ff319-3e56-4a29-b131-41c5e2ed321d.png)


After:
![image](https://user-images.githubusercontent.com/17246482/143152664-bbc7039e-5c2e-4566-9362-064425fdde42.png)
