### PR TITLE
Remove duplicate rules

### DIFF
--- a/categories/design-and-presentation/rules-to-better-interfaces-mobile.md
+++ b/categories/design-and-presentation/rules-to-better-interfaces-mobile.md
@@ -5,7 +5,7 @@ guid: 073cbcd8-c942-4a96-a54d-4682c4fc885e
 uri: rules-to-better-interfaces-mobile
 index:
 - do-you-design-for-touch-interfaces
-- do-you-know-to-hyperlink-your-phone-numbers-2
+- do-you-know-to-hyperlink-your-phone-numbers
 - do-you-know-what-guidelines-to-follow-for-wp
 - do-you-know-when-to-build-a-wp-app-over-an-iphone-app
 - do-you-know-when-to-build-an-iphone-app-over-an-iphone-web-app

--- a/categories/management/rules-to-successful-sales-and-account-management.md
+++ b/categories/management/rules-to-successful-sales-and-account-management.md
@@ -15,7 +15,7 @@ index:
 - meetings-do-you-know-the-agenda-for-the-initial-meeting
 - meetings-do-you-have-a-debrief-after-an-initial-meeting
 - do-you-incentivize-a-quick-spec-review-sale
-- do-you-schedule-a-followup-meeting-after-a-spec-review1
+- do-you-schedule-a-followup-meeting-after-a-spec-review
 - do-you-explain-the-cone-of-uncertainty-to-people-on-the-fence-about-agile
 - do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
 - do-you-get-a-signed-copy-of-the-whole-terms-and-conditions-document-not-just-the-last-page

--- a/categories/websites/rules-to-better-websites-navigation.md
+++ b/categories/websites/rules-to-better-websites-navigation.md
@@ -19,7 +19,7 @@ index:
 - do-you-make-your-pages-easy-to-access
 - do-you-avoid-redundant-linking-aka-single-link-to-single-location
 - do-you-avoid-linking-a-page-to-itself
-- do-you-know-to-hyperlink-your-phone-numbers-2
+- do-you-know-to-hyperlink-your-phone-numbers
 - do-your-wizards-include-a-wizard-breadcrumb
 - do-you-make-external-links-clear
 - external-links-open-on-a-new-tab

--- a/rules/do-you-know-to-hyperlink-your-phone-numbers/rule.md
+++ b/rules/do-you-know-to-hyperlink-your-phone-numbers/rule.md
@@ -11,7 +11,8 @@ authors:
 - title: Adam Cogan
   url: https://ssw.com.au/people/adam-cogan
 related: []
-redirects: []
+redirects: 
+- do-you-know-to-hyperlink-your-phone-numbers-2
 
 ---
 

--- a/rules/do-you-know-to-hyperlink-your-phone-numbers/rule.md
+++ b/rules/do-you-know-to-hyperlink-your-phone-numbers/rule.md
@@ -3,7 +3,7 @@ type: rule
 archivedreason: 
 title: Do you know to hyperlink your phone numbers?
 guid: 1c6d2736-acfa-49ee-9470-bb0414010ac8
-uri: do-you-know-to-hyperlink-your-phone-numbers-2
+uri: do-you-know-to-hyperlink-your-phone-numbers
 created: 2015-12-03T01:00:44.0000000Z
 authors:
 - title: Farrukh Khan
@@ -11,8 +11,7 @@ authors:
 - title: Adam Cogan
   url: https://ssw.com.au/people/adam-cogan
 related: []
-redirects:
-- do-you-know-to-hyperlink-your-phone-numbers
+redirects: []
 
 ---
 

--- a/rules/do-you-schedule-a-followup-meeting-after-a-spec-review/rule.md
+++ b/rules/do-you-schedule-a-followup-meeting-after-a-spec-review/rule.md
@@ -3,14 +3,13 @@ type: rule
 archivedreason: 
 title: Do you schedule a follow-up meeting after a Spec Review?
 guid: 53bd000d-4e45-46de-9ae1-752cb9f2bdd2
-uri: do-you-schedule-a-followup-meeting-after-a-spec-review1
+uri: do-you-schedule-a-followup-meeting-after-a-spec-review
 created: 2017-08-03T04:48:38.0000000Z
 authors:
 - title: Ulysses Maclaren
   url: https://ssw.com.au/people/ulysses-maclaren
 related: []
-redirects:
-- do-you-schedule-a-follow-up-meeting-after-a-spec-review
+redirects: []
 
 ---
 

--- a/rules/do-you-schedule-a-followup-meeting-after-a-spec-review/rule.md
+++ b/rules/do-you-schedule-a-followup-meeting-after-a-spec-review/rule.md
@@ -9,7 +9,8 @@ authors:
 - title: Ulysses Maclaren
   url: https://ssw.com.au/people/ulysses-maclaren
 related: []
-redirects: []
+redirects: 
+- do-you-schedule-a-followup-meeting-after-a-spec-review1
 
 ---
 


### PR DESCRIPTION
Addresses: https://github.com/SSWConsulting/SSW.Rules.Content/issues/2082

There are some straggler rules that only need to have the extra uri fluff removed from them there weren't included in Tiago's mass renaming.