### PR TITLE
✅ Update trilom's file changes action to 1.2.4

### DIFF
--- a/.github/workflows/check-extension-case.yml
+++ b/.github/workflows/check-extension-case.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
           
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
 
       - name: test
         run: |


### PR DESCRIPTION
- Fix for https://github.com/SSWConsulting/SSW.Rules.Content/pull/2279 
- Update trilom/file-change-action version from `1.2.3` -> `1.2.4`