### PR TITLE
removed quotes from title

### DIFF
--- a/rules/azure-slots-deployment/rule.md
+++ b/rules/azure-slots-deployment/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: "Do you know how to use slot deployment on Azure? "
+title: Do you know how to use slot deployment on Azure?
 uri: azure-slots-deployment
 authors:
   - title: Patrick Zhao


### PR DESCRIPTION
cc @adamcogan @lukecookssw @JackDevAU 

-- 

Hi @pierssinclairssw  

FYI - This rule was created with quotes on the title (most likely by copy & paste) which generated a broken link on the homepage:
<img width="1440" alt="Screen Shot 2022-03-18 at 11 26 22 AM" src="https://user-images.githubusercontent.com/12601228/159061954-3da27746-e07a-4a8c-afe0-b9eef57a2336.png">

I assume this change will fix this, but wondering if we could create a unit test to get these errors. If so, please create an issue 

