### PR TITLE
Revert "Update Rule “azure-naming-resource-groups/rule”"

### DIFF
--- a/rules/azure-naming-resource-groups/rule.md
+++ b/rules/azure-naming-resource-groups/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Do you know how to group your Azure resources?
+title: Resource Groups - Do you know how to arrange your Azure resources?
 uri: azure-naming-resource-groups
 authors:
   - title: Adam Cogan


### PR DESCRIPTION
Reverts SSWConsulting/SSW.Rules.Content#3244

As per my conversation with Adam and Matt W, we are reverting this because Resource Group is a name of something in Azure that is relevant to the rule.