### PR TITLE
Update unit testing framework rule to more current one

### DIFF
--- a/categories/websites/rules-to-better-net-core.md
+++ b/categories/websites/rules-to-better-net-core.md
@@ -5,7 +5,7 @@ guid: 948973d9-f2a6-40d1-8e4d-90edb5e85416
 uri: rules-to-better-net-core
 index:
 - why-choose-dot-net-core
-- the-best-unit-testing-framework
+- the-most-popular-unit-testing-frameworks-for-net-core-applications
 - add-local-configuration-file-for-developer-specific-settings
 - when-to-target-lts-versions
 


### PR DESCRIPTION
Change from out-of-date "the-best-unit-testing-framework" rule to current "the-most-popular-unit-testing-frameworks-for-net-core-applications" rule