### PR TITLE
Lowercased name of "employee-yolo-day" rule

### DIFF
--- a/categories/others/rules-to-better-offices.md
+++ b/categories/others/rules-to-better-offices.md
@@ -6,7 +6,7 @@ uri: rules-to-better-offices
 index:
 - do-you-colour-code-your-keys
 - do-you-identify-your-online-purchases
-- Employee-YOLO-Day
+- employee-yolo-day
 - reduce-office-noise
 - build-inter-office-interaction
 


### PR DESCRIPTION
Lowercased naming of "employee-yolo-day" rule so it can be edited in the SSW Rules markdown editor. Rule itself has been updated and a redirect from the old rule name added.