### PR TITLE
surrounded 'Guarantee' with mark tag

### DIFF
--- a/rules/change-from-x-to-y/rule.md
+++ b/rules/change-from-x-to-y/rule.md
@@ -73,7 +73,7 @@ To:
 
   &nbsp;&nbsp;&nbsp;&nbsp;Scan all your projects for coding errors
   
-  &nbsp;&nbsp;&nbsp;&nbsp;Guarantee industry best practices
+  &nbsp;&nbsp;&nbsp;&nbsp;<mark>Guarantee</mark> industry best practices
   
   &nbsp;&nbsp;&nbsp;&nbsp;Friendly licensing model<mark>, bloggers even pay $0</mark> for the full version!
 


### PR DESCRIPTION
The changing word "Guarantee" did not have a yellow color background.