### PR TITLE
Update Rule “do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client/rule”

### DIFF
--- a/rules/do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client/rule.md
+++ b/rules/do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client/rule.md
@@ -12,22 +12,23 @@ guid: 6c65eb49-e31d-465d-9652-226b15e5d426
 
 A common mistake for developers is to say "See you later, call me sometime next month".  
 
-<!--endintro-->
-
 On your last day of consulting with a client, you should always book on the next date. Be aware of the main blockage people get, which the client is saying "How about I check my calendar and get back to you?". And often this never happens.
 
-A better approach is to reduce the risk by:  
-* saying that you are only penciling it in and it can be canceled, and
-* bringing some urgency (by saying your calendar fills up quick)
+A better approach is to reduce the risk by:
 
+<!--endintro-->
+
+* Saying that you are only penciling it in and it can be canceled, and
+* Bringing some urgency (by saying your calendar fills up quick)
 
 So try something like "My calendar fills up really quick, how about I pencil you in... How about we say 2 weeks' time? Don't forget you can cancel it anytime."
 
-
 ::: good  
-![Figure: Plan ahead at the end of your day eg. "How about we pencil in my next visit, say 2 weeks' time?"](mobile-calendar.jpg)  
+![Figure: Plan ahead at the end of your day. E.g. "How about we pencil in my next visit, say 2 weeks' time?"](mobile-calendar.jpg)  
 :::
 
-**Note:** If, at the end of the day, work hasn't been fully tested or is incomplete and you haven't been booked in for the next day, tell the Product Owner (PO) that issues may arise and further work is likely to be required. After the conversation, email the PO and CC your manager to confirm that further work is required.
+::: greybox
+**Note:** If, at the end of the day, work hasn't been fully tested or is incomplete and you haven't been booked in for the next day, tell the Product Owner (PO) that issues may arise and further work is likely to be required. After the conversation, email the PO and Cc your manager to confirm that further work is required.
 
 E.g. "As per our conversation, this work has not yet been tested and may still include bugs. At this stage, you would prefer if we did not continue to work tomorrow, but I do recommend that we come in and finish soon."
+:::

--- a/rules/do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client/rule.md
+++ b/rules/do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client/rule.md
@@ -1,14 +1,13 @@
 ---
 type: rule
-archivedreason: 
 title: Do you always pencil in the next date on your last day at the client?
-guid: 6c65eb49-e31d-465d-9652-226b15e5d426
 uri: do-you-always-pencil-in-the-next-date-on-your-last-day-at-the-client
-created: 2010-07-16T06:38:09.0000000Z
 authors: []
 related: []
 redirects: []
-
+created: 2010-07-16T06:38:09.000Z
+archivedreason: null
+guid: 6c65eb49-e31d-465d-9652-226b15e5d426
 ---
 
 A common mistake for developers is to say "See you later, call me sometime next month".  
@@ -16,7 +15,8 @@ A common mistake for developers is to say "See you later, call me sometime next 
 <!--endintro-->
 
 On your last day of consulting with a client, you should always book on the next date. Be aware of the main blockage people get, which the client is saying "How about I check my calendar and get back to you?". And often this never happens.
- A better approach is to reduce the risk by:  
+
+A better approach is to reduce the risk by:  
 * saying that you are only penciling it in and it can be canceled, and
 * bringing some urgency (by saying your calendar fills up quick)
 


### PR DESCRIPTION
Content changes for [Rules to Better Software Consultants - Dealing with Clients](https://www.ssw.com.au/rules/rules-to-better-software-consultants-dealing-with-clients) - Do you always pencil in the next date on your last day at the client?

Changes made:

- changed:
From:
And often this never happens.A better approach is to reduce the risk by:
To:
And often this never happens.

  A better approach is to reduce the risk by: