### PR TITLE
Deleted email-should-be-email-without-the-hyphen

### DIFF
--- a/categories/communication/rules-to-better-technical-documentation.md
+++ b/categories/communication/rules-to-better-technical-documentation.md
@@ -33,7 +33,6 @@ index:
 - use-taskbar-instead-of-task-bar
 - use-username-instead-of-user-name
 - use-cannot-and-website-instead-of-separated-words
-- email-should-be-email-without-the-hyphen
 - commas-and-full-stops-always-should-have-1-space-after-them
 - avoid-using-that-when-its-not-needed
 - avoid-full-stops-in-bullet-point-lists


### PR DESCRIPTION
Deleted email-should-be-email-without-the-hyphen since this rule has been archived, in favour of do-you-write-the-word-email-in-the-correct-format