### PR TITLE
reduced archived reason

### DIFF
--- a/rules/when-to-create-team-project-and-azure-devops-portal/rule.md
+++ b/rules/when-to-create-team-project-and-azure-devops-portal/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archived: Azure DevOps does not support SharePoint Team Sites (since 2018) - Discontinue SharePoint integration - TFS https://learn.microsoft.com/en-us/previous-versions/azure/devops/report/sharepoint-dashboards/deprecation/discontinue-pre-tfs-2017-sharepoint-integration?view=tfs-2017. Replaced by https://ssw.com.au/rules/connect-crm-to-microsoft-teams
+archived: Replaced by https://ssw.com.au/rules/connect-crm-to-microsoft-teams
 title: Do you know when to create the team project and Azure DevOps Portal for a prospect/client?
 uri: when-to-create-team-project-and-azure-devops-portal
 authors:
@@ -13,6 +13,11 @@ authors:
 created: 2021-08-31T18:11:04.052Z
 guid: 2a827a86-f4c9-496e-aba1-6b77ea2a1429
 ---
+
+::: info
+Azure DevOps does not support SharePoint Team Sites (since 2018) - Discontinue SharePoint integration - TFS https://learn.microsoft.com/en-us/previous-versions/azure/devops/report/sharepoint-dashboards/deprecation/discontinue-pre-tfs-2017-sharepoint-integration?view=tfs-2017.
+:::
+
 When a prospect/client is ready to move forward (typically after a Specification Review)...
 
 <!--endintro-->


### PR DESCRIPTION
Hey @bradystroud 

This rule was archived but didn't show accordingly (no box at the top)

The unusual thing was a really long reason.
Maybe there is a limitation of characters?

<img width="1410" alt="Screen Shot 2022-11-15 at 11 44 47 AM" src="https://user-images.githubusercontent.com/12601228/202011295-307e06eb-24ce-4812-b80c-42bd902d2c53.png">
