### PR TITLE
Removed link to channel since we have the video /seal-classes

### DIFF
--- a/rules/seal-your-classes-by-default/rule.md
+++ b/rules/seal-your-classes-by-default/rule.md
@@ -22,7 +22,7 @@ On the surface it appears that you are just preventing someone from inheriting f
 - Inheritance can be easily abused and as a result is considered a minor anti-pattern
 - Composition is preferred over inheritance
 
-Watch this video by [Nick Chapsas](https://www.youtube.com/@nickchapsas), to see the performance benefits of sealing your classes for different usage scenarios.
+Watch this video by Nick Chapsas, to see the performance benefits of sealing your classes for different usage scenarios:
 
 `youtube: https://www.youtube.com/embed/d76WWAD99Yo`
 **Video: Why all your classes should be sealed by default in C# by Nick Chapsas (11 min)**


### PR DESCRIPTION
as per @DevStarOps email:

> - There was a formatting issue when I accepted 1 of the suggestions in the PR I think. ‘Watch’ onwards is meant to be a short blurb before the video,
> - Also Nick Chapsas links to his channel on YouTube and the video is below that blurb, it’s not linking to the video specifically which is why I’ve only linked the name. I’m not sure if that changes anything, should I rather not link the name at all?

I don't think we need the link to his channel