### PR TITLE
Updating examples to include the current SSW Standard for placeholder…

### DIFF
--- a/rules/placeholder-for-replaceable-text/rule.md
+++ b/rules/placeholder-for-replaceable-text/rule.md
@@ -39,7 +39,8 @@ Let's see these in action:
 - The quick brown fox [ action ] over the lazy dog
 - The quick brown fox « action » over the lazy dog
 - The quick brown fox { action } over the lazy dog
-- The quick brown fox {{ action }} over the lazy dog (currently the standard in SugarLearning and SSW Rules)
+- The quick brown fox {{ action }} over the lazy dog
+- The quick brown fox {{ ACTION }} over the lazy dog (currently the standard in SugarLearning and SSW Rules)
 - The quick brown fox TODO:action over the lazy dog
 
 ### More info on the origins
@@ -100,6 +101,6 @@ Regards,
 :::  
 :::  
 ::: good  
-Figure: Good example - Using double curly brackets for replaceable text
+Figure: Good example - Using double curly brackets with the action in UPPERCASE for replaceable text
 :::
 


### PR DESCRIPTION
On the rule: [https://ssw.com.au/rules/placeholder-for-replaceable-text/](https://aus01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fssw.com.au%2Frules%2Fplaceholder-for-replaceable-text%2F&data=05%7C01%7CGordonBeeming%40ssw.com.au%7C3f8e4d84bff949990dbe08dafe0d02b1%7Cac2f7c34b93548e9abdc11e5d4fcb2b0%7C0%7C0%7C638101629081114381%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=PdzpdgKhLaSFVELKX5R3UHZXOW9Upxw1j492FRvgoqg%3D&reserved=0)

The ACTION noted between the two moustache brackets should be in UPPERCASE. This makes it stand out more and less likely for someone (sales managers :)) to miss it.

- [x] 1. After the option:
•	The quick brown fox {{ action }} over the lazy dog (currently the standard in SugarLearning and SSW Rules)

Add the extra uppercase option for people to see:
•	The quick brown fox {{ ACTION }} over the lazy dog (currently the standard in SugarLearning and SSW Rules)

- [x] 2. Also, for the Good example figure
Change from:
•	Figure: Good example - Using double curly brackets for replaceable text
To:
•	Figure: Good example - Using double curly brackets with the action in UPPERCASE for replaceable text