### PR TITLE
Update chatgpt-can-help-code rule

### DIFF
--- a/rules/chatgpt-can-help-code/rule.md
+++ b/rules/chatgpt-can-help-code/rule.md
@@ -36,7 +36,7 @@ ChatGPT can be used for:
 ### Try it yourself, copy and paste this
 
 
-`
+```
 What does this code do?
 [HttpPut("{id}")]
 public async Task<IActionResult> MoveRight(string id)
@@ -61,4 +61,4 @@ public async Task<IActionResult> MoveRight(string id)
 		return StatusCode(StatusCodes.Status500InternalServerError);
 	}
 }
-`
+```


### PR DESCRIPTION
Changes made:

- changed from one backtick to 3 e.g. ` -> ```

I know this will use the black code block, but I feel this will improve the look as the formatting will be prettier.