### PR TITLE
Updated to test frameworks that are used in recent years

### DIFF
--- a/rules/do-you-know-the-tools-you-need-before-a-test-please/rule.md
+++ b/rules/do-you-know-the-tools-you-need-before-a-test-please/rule.md
@@ -34,8 +34,8 @@ Don't let your client find bugs in production that they would have found if you 
     - Visual Studio Team System Code Analysis (optional)
 2. Perform automated testing via Unit Tests 
 
-    - nUnit (for Windows Apps), or
-
-    - Visual Studio Team System Unit Tests (for Web Apps)
+    - xUnit, or
+    
+    - nUnit
 3. Perform an internal "Test Please" (aka "Alpha Testing" e.g. only testing that pages or forms load, not checking the business rules)
 4. Then send a "Test Please" to the client (aka "Acceptance Testing" to check the business rules)


### PR DESCRIPTION
We don't use nUnit (or very rarely) and use xUnit instead. Both are for any .NET application.

I don't know what "Visual Studio Team System Unit Tests" is, but it still exists based on ChatGPT. It's either VSTest.exe (not used in modern development) or the MS Test framework which is also no longer recommended.

Google did not find anything for the last 12 months: https://www.google.com/search?q=%22Visual+Studio+Team+System+Unit+Tests%22

Most hits are from 2006 and only 1 page worth of results: https://www.google.com/search?q=%22Visual+Studio+Team+System+Unit+Tests%22