### PR TITLE
Fix multiline YAML

### DIFF
--- a/rules/do-you-know-the-code-health-quality-gates-to-add/rule.md
+++ b/rules/do-you-know-the-code-health-quality-gates-to-add/rule.md
@@ -11,7 +11,8 @@ related: []
 redirects:
   - do-you-know-the-code-health-(quality-gates)-to-add
 created: 2017-02-20T22:26:58.000Z
-archivedreason: Content is covered in the following rules: https://ssw.com.au/rules/rules-to-better-code-quality
+archivedreason: |
+Content is covered in the following rules: https://ssw.com.au/rules/rules-to-better-code-quality
 guid: 316c617a-3636-4c40-85dc-c94fdc98fbfa
   
 ---


### PR DESCRIPTION
Hey @tiagov8 

YAML does support multiline strings, but you need to use this special syntax

```yaml
include_newlines: |
            exactly as you see
            will appear these three
            lines of poetry

fold_newlines: >
            this is really a
            single line of text
            despite appearances
```

See https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html