### PR TITLE
Made opening sentence more clear

### DIFF
--- a/rules/port-forwarding/rule.md
+++ b/rules/port-forwarding/rule.md
@@ -10,7 +10,7 @@ guid: 44219801-42c9-4a90-ac22-5fefcf0cb365
 redirects: 
  - do-you-use-dev-tunnels-to-test-local-builds
 ---
-In the old days, you had to deploy your entire application to staging so you could share it with other members of your team. That process was a huge hassle and made it much harder to get feedback quickly. 
+In the old days, you had to deploy your entire application to a staging environment just so you could share it with other members of your team. That process was a huge hassle and made it much harder to get feedback quickly. 
 
 Luckily, port forwarding is the silver...errr...golden bullet that solves this issue. Port forwarding helps by exposing a locally running application over the internet for testing or other purposes. 
 


### PR DESCRIPTION
Just made the opening sentence clearer. "Staging" is a shorthand for "Staging Environment". Much like not using acronyms, just say the whole thing to avoid confusion. :)