### PR TITLE
generate-ai-images - fix greybox not rendering

### DIFF
--- a/rules/generate-ai-images/rule.md
+++ b/rules/generate-ai-images/rule.md
@@ -29,7 +29,7 @@ Prompts are the instructions that you input. They can be as simple or as complex
 “A brown dog on a skateboard” 
 :::
 
-::: good\
+::: good
 Figure: Good example - A basic prompt
 :::
 
@@ -47,7 +47,7 @@ Negative prompting is specifying what you don't want in your image. It can be an
 “An open highway --no cars” 
 :::
 
-::: good\
+::: good
 Figure: Good example - A prompt with a negative element in Midjourney format
 :::
 
@@ -65,7 +65,7 @@ Parameters allow you to control different aspects of the generated image via set
 “A scene”
 :::
 
-::: bad\
+::: bad
 Figure: Bad example - A vague prompt like this gives an ambiguous image
 :::
 
@@ -73,7 +73,7 @@ Figure: Bad example - A vague prompt like this gives an ambiguous image
 “A snowy mountain landscape at sunset: majestic peaks adorned with glistening snow, bathed in warm hues, creating an ethereal and serene atmosphere. The scene evokes awe as untouched slopes and frozen trees blend with the fading light, leaving an indelible impression of nature's grandeur. Two travelers cross a footbridge over a small creek in the foreground.” 
 :::
 
-::: bad\
+::: bad
 Figure: Bad example - this is too long 
 :::
 
@@ -81,7 +81,7 @@ Figure: Bad example - this is too long
 “A snowy mountain landscape at sunset with warm hues” 
 :::
 
-::: good\
+::: good
 Figure: Good example - a detailed description will provide the AI with specific elements to incorporate, resulting in a more accurate image
 :::
 
@@ -96,7 +96,7 @@ DALL-E 2 is an AI system capable of creating realistic images from a natural lan
 * DALLE-2 uses a credit system where users purchase credits to use the model
 * Some OpenAI users start with free DALLE-2 credits
 
-::: img-large\
+::: img-large
 ![Figure: "A red tree in a valley. Hi res" - by DALL-E2](red-tree-dalle.png)
 :::
 
@@ -118,7 +118,7 @@ Midjourney is used on Discord, where users interact with the Midjourney bot by t
   * Be colorful – /imagine {{ COLOR WORD }} colored cat 
   * Explore environments – /imagine {{ LOCATION }} cat 
 
-::: img-large\
+::: img-large
 ![Figure: "A red tree in a valley. Hi res" - by Midjourney](red-tree-midjourney.png)
 :::
 

--- a/rules/generate-ai-images/rule.md
+++ b/rules/generate-ai-images/rule.md
@@ -1,24 +1,22 @@
 ---
 type: rule
-archivedreason:
 title: Do you know how and when to use AI generated images?
-guid: 61b75416-bbae-4aac-a929-c51e46ac7fb3
 uri: generate-ai-images
-created: 2023-06-06T05:06:33.0000000Z
 authors:
- - title: Seth Daily
-   url: https://www.ssw.com.au/people/seth-daily/
- - title: Jayden Alchin
-   url: https://www.ssw.com.au/people/jayden-alchin
- - title: Jack Reimers
-   url: https://www.ssw.com.au/people/jack-reimers
- - title: Tiago Araujo
-   url: https://www.ssw.com.au/people/tiago-araujo
+  - title: Seth Daily
+    url: https://www.ssw.com.au/people/seth-daily/
+  - title: Jayden Alchin
+    url: https://www.ssw.com.au/people/jayden-alchin
+  - title: Jack Reimers
+    url: https://www.ssw.com.au/people/jack-reimers
+  - title: Tiago Araujo
+    url: https://www.ssw.com.au/people/tiago-araujo
 related: []
 redirects: []
-
+created: 2023-06-06T05:06:33.000Z
+archivedreason: null
+guid: 61b75416-bbae-4aac-a929-c51e46ac7fb3
 ---
-
 AI image generation is a rapidly evolving field that offers a novel way to produce images. This rule discusses different AI image generators and what we can use AI images for. 
 
 <!--endintro-->
@@ -30,7 +28,8 @@ Prompts are the instructions that you input. They can be as simple or as complex
 ::: greybox
 “A brown dog on a skateboard” 
 :::
-::: good  
+
+::: good\
 Figure: Good example - A basic prompt
 :::
 
@@ -40,7 +39,7 @@ You can add more detail to make a more effective prompt by following this templa
 **{{ ADJECTIVE }}, {{ EMOTION }}, {{ SUBJECT }}, {{ STYLE }}, {{ COLOR }}**
 :::
 
-## Negative Prompting 
+## Negative Prompting
 
 Negative prompting is specifying what you don't want in your image. It can be an effective way of guiding the AI away from certain features that you're not interested in. Some AI image generators (e.g. Midjourney and Dreamstudio) have this option. In others (e.g. DALLE-2), you can include it in your prompt. 
 
@@ -48,42 +47,41 @@ Negative prompting is specifying what you don't want in your image. It can be an
 “An open highway --no cars” 
 :::
 
-::: good  
+::: good\
 Figure: Good example - A prompt with a negative element in Midjourney format
 :::
 
-## Parameters 
+## Parameters
 
 Parameters allow you to control different aspects of the generated image via settings on the image generator. Most AI image generators have parameter options, and they can significantly affect the result. 
 
 * **Resolution:** This defines the quality of the generated image. Higher resolution values will result in higher-quality images. 
-
 * **Randomness:** This parameter influences the amount of random variation in the generated image. Higher randomness values may result in more unique or creative images, but they can also lead to images that deviate more from the initial prompt. 
-
 * **Aspect Ratio:** Aspect ratio dictates the proportions of the image. For instance, you might choose a square (1:1) aspect ratio for social media posts, a landscape (16:9) ratio for video thumbnails, or a portrait (3:4) ratio for smartphone screens. 
-
 * **Style:** Style refers to specifying a particular visual style for the image. This could be a certain artistic style (like "impressionistic" or "cubist"). The AI uses this information to guide the stylistic aspects of image generation.
-
 * **Uploading:** Most AI image generators allow you to upload an existing image so that the AI will create different variations of it.
 
 ::: greybox
 “A scene”
 :::
-::: bad  
+
+::: bad\
 Figure: Bad example - A vague prompt like this gives an ambiguous image
 :::
- 
+
 ::: greybox
 “A snowy mountain landscape at sunset: majestic peaks adorned with glistening snow, bathed in warm hues, creating an ethereal and serene atmosphere. The scene evokes awe as untouched slopes and frozen trees blend with the fading light, leaving an indelible impression of nature's grandeur. Two travelers cross a footbridge over a small creek in the foreground.” 
 :::
-::: bad  
+
+::: bad\
 Figure: Bad example - this is too long 
 :::
 
 ::: greybox
 “A snowy mountain landscape at sunset with warm hues” 
 :::
-::: good  
+
+::: good\
 Figure: Good example - a detailed description will provide the AI with specific elements to incorporate, resulting in a more accurate image
 :::
 
@@ -92,48 +90,40 @@ Figure: Good example - a detailed description will provide the AI with specific 
 As of now, the top contenders are DALL-E 2, Midjourney, and DreamStudio. Each of these has features that make them stand out.  
 
 ### DALL-E 2
+
 DALL-E 2 is an AI system capable of creating realistic images from a natural language description. You can use it here: [DALL-E](https://openai.com/dall-e-2)
+
 * DALLE-2 uses a credit system where users purchase credits to use the model
 * Some OpenAI users start with free DALLE-2 credits
 
-::: img-large  
+::: img-large\
 ![Figure: "A red tree in a valley. Hi res" - by DALL-E2](red-tree-dalle.png)
 :::
 
 ### Midjourney
+
 Midjourney is used on Discord, where users interact with the Midjourney bot by typing /imagine. You can use it here: [Midjourney](https://www.midjourney.com/home/) (you need [Discord](https://discord.com/) first).
 
 * Cost: $8USD/month 
-
 * Images can be reiterated on 
-
 * Many parameters: [Midjourney Parameter List](https://docs.midjourney.com/docs/parameter-list) e.g. “--aspect” 
-
 * Prompting in Midjourney: 
 
   * Even short prompts can produce beautiful images 
-
   * Basic - /imagine cat 
-
   * Specify an artistic medium – /imagine {{{ ANY ART STYLE }} style cat 
-
   * Get specific – /imagine {{ STYLE }} sketch of a cat 
-
   * Time travel – /imagine {{ DECADE }} cat illustration 
-
   * Emote – /imagine {{ EMOTION }} cat 
-
   * Be colorful – /imagine {{ COLOR WORD }} colored cat 
-
   * Explore environments – /imagine {{ LOCATION }} cat 
 
-
-::: img-large  
+::: img-large\
 ![Figure: "A red tree in a valley. Hi res" - by Midjourney](red-tree-midjourney.png)
 :::
-  
 
-### DreamStudio 
+### DreamStudio
+
 DreamStudio is made by StabilityAI and is used, like DALLE2, on a web interface. It is based on the Stable Diffusion model of image generation. You can use the demo here for free [Stable Diffusion Web](https://stablediffusionweb.com/#demo), or you can use it through the [DreamStudio](https://beta.dreamstudio.ai/dream) interface (starting with a free trial).
 
 * You can use the web demo without signing up
@@ -143,14 +133,11 @@ DreamStudio is made by StabilityAI and is used, like DALLE2, on a web interface.
 ![Figure: "A red tree in a valley. Hi res" - by DreamStudio ](red-tree-dreamstudio.png)
 :::
 
-## Where should you use AI-generated images? 
+## Where should you use AI-generated images?
 
 * ✅ **Content Creation:** AI-generated images can be used for content creation in blogs, websites, magazines, and social media posts. They can help fill gaps where stock images or professional photography might be expensive or unavailable. 
-
 * ✅ **Ideation:** Artists and designers can use AI to generate concept art or design ideas, helping them visualize and brainstorm more effectively. 
-
 * ✅ **Education:** In an educational context, AI can be used to create images that help illustrate complex concepts. 
-
 * ✅ **Communication:** In an increasingly digital world, AI-generated images are a fun and interesting way to supplement your communications. Communicating with friends and colleagues is a great opportunity to experiment. 
 
 ## Videos


### PR DESCRIPTION
Markdown was not rendering correctly - added carriage returns to try to help it out

<img width="1145" alt="CleanShot 2023-06-23 at 09 01 40@2x" src="https://github.com/SSWConsulting/SSW.Rules.Content/assets/600044/cd054088-fb45-4644-aa5f-c3039679e096">
