### PR TITLE
Correct category reference to OWIN migration rule.

### DIFF
--- a/categories/software-development/rules-to-better-net-projects.md
+++ b/categories/software-development/rules-to-better-net-projects.md
@@ -9,7 +9,7 @@ index:
 - migrate-from-system-web-to-modern-alternatives
 - migrate-from-edmx-to-ef-core
 - know-how-to-migrate-global-asax-to-asp-net-core
-- know-how-to-migrate-owin-toasp-net-core
+- know-how-to-migrate-owin-to-asp-net-core
 - know-how-to-migrate-web-config-to-asp-net-core
 - do-you-have-a-consistent-net-solution-structure
 - do-you-name-your-startup-form-consistently

--- a/categories/software-development/rules-to-better-net-projects.md
+++ b/categories/software-development/rules-to-better-net-projects.md
@@ -8,6 +8,9 @@ index:
 - dotnet-upgrade-for-complex-projects
 - migrate-from-system-web-to-modern-alternatives
 - migrate-from-edmx-to-ef-core
+- know-how-to-migrate-global-asax-to-asp-net-core
+- know-how-to-migrate-owin-toasp-net-core
+- know-how-to-migrate-web-config-to-asp-net-core
 - do-you-have-a-consistent-net-solution-structure
 - do-you-name-your-startup-form-consistently
 - do-you-use-solution-folders-to-neatly-structure-your-solution


### PR DESCRIPTION
This PR corrects an error in [PR 6204 "Update category 'Rules to Better .NET Projects' to include new ASP.NET Core migration rules"](https://github.com/SSWConsulting/SSW.Rules.Content/pull/6204) where the [OWIN migration rule](https://www.ssw.com.au/rules/know-how-to-migrate-owin-to-asp-net-core/) was not referenced correctly.