### PR TITLE
Improve capitalization of "Do you know how to render HTML strings?"

### DIFF
--- a/rules/do-you-know-how-to-render-html-strings/rule.md
+++ b/rules/do-you-know-how-to-render-html-strings/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Do You Know How To Render HTML Strings?
+title: Do you know how to render HTML strings?
 uri: do-you-know-how-to-render-html-strings
 authors:
   - title: Charles Vionnet


### PR DESCRIPTION
Modifies capitalization of heading to match that used through the rest of the rules.