### PR TITLE
Developers should make the judgement call when to escalate

### DIFF
--- a/rules/escalate-key-updates/rule.md
+++ b/rules/escalate-key-updates/rule.md
@@ -26,7 +26,7 @@ Key updates on projects may include Done Videos, critical text additions, or spe
 ![Figure: Good example - For visibility and to ensure all stakeholders are in the loop, you should also send an email to the relevant people](critical-update-good-example.jpg)  
 :::
 
-Not every PBI will require an email, but if it is a key update or deliverable, it should be escalated. This should be determined upfront and added to the Acceptance Criteria for the PBI. Here are the 3 scenarios:
+Not every PBI will require an email, but if it is a key update or deliverable, it should be escalated. The developers would make this judgement call, although this could also be added upfront by the Product Owner in the Acceptance Criteria for the PBI. Here are the 3 scenarios:
 
 1. **Standard PBI** - needed but the outcome is not very interesting: Do the PBI, just following the DoD
 2. **Interesting to someone** - @mention them, see [Do you know when you use @ mentions in a PBI?](https://www.ssw.com.au/rules/when-you-use-mentions-in-a-pbi/)


### PR DESCRIPTION
Feedback from @UlyssesMaclaren 

> 1. Would you say this should be determined upfront for when to mention in the PBI vs also sending an email by adding it as part of the acceptance criteria? 
> i.e.: [SSW.Rules | Do you turn an email into a PBI before starting work?](https://aus01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fssw.com.au%2Frules%2Fturn-emails-into-pbis%2F&data=05%7C01%7CGordonBeeming%40ssw.com.au%7Cc1827643a8e44b20b63808db93ce206a%7Cac2f7c34b93548e9abdc11e5d4fcb2b0%7C0%7C0%7C638266285734513969%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=YR%2F3sIu%2FJ88lIRsz1LpTxpiT4zlvQAtM%2FzPf%2BHHhlI4%3D&reserved=0) Says you should Fill out the Acceptance Criteria, adding: "Reply 'Done' to the email and also @mention them in the PBI with 'Done'" to make this clear

I think no, it’s not the PO’s responsibility to set this… although sometimes it might make sense if they do want to be prescriptive about a particular case… I think in general the dev should use a judgement call