### PR TITLE
Updated rules/acceptance-criteria/

### DIFF
--- a/rules/acceptance-criteria/rule.md
+++ b/rules/acceptance-criteria/rule.md
@@ -88,6 +88,7 @@ Sometimes, the team may discuss including technical requirements in Acceptance C
 * The team has been misaligned in the past, and the future direction needs to be clear
 * The approach to take is complex or confusing
 * An abnormal approach is being taken to avoid a specific issue (e.g. Reducing readability to improve performance for a particularly critical query)
+* When the user Story is an Enabler (backlog items that extend the architectural runway of the solution under development or improve the performance of the development value stream)
 
 If technical requirements are added, it should be a discussion between all of the developers in the team. If the Product Owner is technical, they are welcome to join the conversation, but they should not be the primary decision maker in this case.
 

--- a/rules/acceptance-criteria/rule.md
+++ b/rules/acceptance-criteria/rule.md
@@ -88,7 +88,7 @@ Sometimes, the team may discuss including technical requirements in Acceptance C
 * The team has been misaligned in the past, and the future direction needs to be clear
 * The approach to take is complex or confusing
 * An abnormal approach is being taken to avoid a specific issue (e.g. Reducing readability to improve performance for a particularly critical query)
-* When the user Story is an Enabler (backlog items that extend the architectural runway of the solution under development or improve the performance of the development value stream)
+* When the User Story is an Enabler (backlog items that extend the architectural runway of the solution under development or improve the performance of the development value stream)
 
 If technical requirements are added, it should be a discussion between all of the developers in the team. If the Product Owner is technical, they are welcome to join the conversation, but they should not be the primary decision maker in this case.
 


### PR DESCRIPTION
Do your User Stories include Acceptance Criteria? | Technical Acceptance Criteria

- Added Enabler User Stories as a reason to have technical items in acceptance criteria