### PR TITLE
NextJS rule: Update order

### DIFF
--- a/categories/websites/rules-to-better-nextjs.md
+++ b/categories/websites/rules-to-better-nextjs.md
@@ -5,12 +5,11 @@ guid: 521392c1-62f3-40f0-93f0-49d683dcbf88
 uri: rules-to-better-nextjs
 index:
 - use-nextjs
-- the-best-package-manager-for-react
+- use-typescript
 - fetch-data-nextjs
 - fetch-data-react
-- migrate-react-to-nextjs
 - dynamically-load-components
 - next-dynamic-routes
-- use-typescript
 - do-you-use-these-useful-react-hooks
+- migrate-react-to-nextjs
 ---

--- a/categories/websites/rules-to-better-nextjs.md
+++ b/categories/websites/rules-to-better-nextjs.md
@@ -5,6 +5,7 @@ guid: 521392c1-62f3-40f0-93f0-49d683dcbf88
 uri: rules-to-better-nextjs
 index:
 - use-nextjs
+- the-best-package-manager-for-react
 - use-typescript
 - fetch-data-nextjs
 - fetch-data-react


### PR DESCRIPTION
~~Removing: the-best-package-manager-for-react~~
Moving: Use typescript to the beginning
Moving: Migrating reactJS to NextJs to the end