### PR TITLE
Fixed typos using a semi colon instead of a colon

### DIFF
--- a/rules/dont-push-your-pull-requests/rule.md
+++ b/rules/dont-push-your-pull-requests/rule.md
@@ -72,7 +72,7 @@ Figure: Bad Example - Poor early communication can lead to mis-directed work and
 
 
 ::: good
-Figure; Good  Example - Good communication leads to collaboration and better outcomes for the author and the project  
+Figure: Good  Example - Good communication leads to collaboration and better outcomes for the author and the project  
 :::
  
 

--- a/rules/how-to-use-ssw-style-in-radhtmlcontrol/rule.md
+++ b/rules/how-to-use-ssw-style-in-radhtmlcontrol/rule.md
@@ -23,7 +23,7 @@ First, the reason to cause the style issue is the style doesn’t apply to right
 
 * The “ms-rteCustom-ImageArea” style doesn’t apply to &lt;img&gt; tag, but wrapped by &lt;span&gt; with “ms-rteCustom-ImageArea” style;
 
-* There is no style apply to figure;
+* There is no style apply to Figure:
 
 ``` html
 <span class="ms-rteCustom-YellowBorderBox">We have a program called <a href="http://rules.ssw.com.au/WebSites/RulesToBetterWebsitesLayout"> SSW LookOut! for Outlook</a> to check for this rule.


### PR DESCRIPTION
Fixed 2 instances of **Figure;** instead of **Figure:**