### PR TITLE
Adding a warning message to a tip around linking issues & archiving another rule

### DIFF
--- a/rules/useful-information-on-changes/rule.md
+++ b/rules/useful-information-on-changes/rule.md
@@ -1,5 +1,6 @@
 ---
 type: rule
+archivedreason: Duplicate of https://www.ssw.com.au/rules/write-a-good-pull-request/
 title: Do you include a useful description of your changes?
 uri: useful-information-on-changes
 authors:

--- a/rules/write-a-good-pull-request/rule.md
+++ b/rules/write-a-good-pull-request/rule.md
@@ -91,3 +91,10 @@ Linking an issue to a pull request can serve as documentation on which developme
 ![Figure: Linking a pull request to the related issue](better-pr-link-issues.png)  
 
 ![Figure: A pull request is now associated with the related issue](better-pr-link-issues-linked.png)
+
+
+::: info
+**Warning:** In GitHub, you should avoid linking any issues that you do not want to close.
+
+see [Do you avoid linking issues to PRs in GitHub?](https://www.ssw.com.au/rules/avoid-auto-closing-issues/)
+:::


### PR DESCRIPTION
<!---
Thanks for contributing to SSW.Rules!

Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs
-->

**Note:** I should have made this 2 PRs but I added the changes to the existing branch.

1. Adding a warning message to a tip around linking issues

We have a rule warning against closing PRs by accident. 

I've added a warning in to let people know about this rule and the side effects of linking issues to PRs 

2. Archivng a rule that is a duplicate of the rule edited