### PR TITLE
Fix acknowledgement on “dotnet-upgrade-for-complex-projects/rule”

### DIFF
--- a/rules/dotnet-upgrade-for-complex-projects/rule.md
+++ b/rules/dotnet-upgrade-for-complex-projects/rule.md
@@ -11,7 +11,7 @@ authors:
   - title: Yazhi Chen
     url: https://www.ssw.com.au/people/yazhi-chen
   - title: Tom Iwainski
-    url: https://www.ssw.com.au/people/tom
+    url: https://www.ssw.com.au/people/tom/
 related:
   - dotnet-upgrade-assistant
   - migrate-from-system-web-to-modern-alternatives


### PR DESCRIPTION
Fix acknowledgement pointing to Tom B instead of Tom I.