### PR TITLE
update the workflow comment to trigger at 36 hours

### DIFF
--- a/.github/workflows/pr-manage-stale.yml
+++ b/.github/workflows/pr-manage-stale.yml
@@ -115,7 +115,7 @@ jobs:
               gh pr edit $number --add-label "$newLabel" --remove-label "$allLabels"
               Write-Output ""
 
-              if ($ageAsPoints -eq 5 -and $author.is_bot -eq $false) { # older than 32 hours
+              if ($ageInHours -eq 36 -and $author.is_bot -eq $false) { # 36 hours old
                   $comment = @"
           Howzit @$($author.login),
           


### PR DESCRIPTION
<!---
Thanks for contributing to SSW.Rules!

Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs
-->


Changed the logic to only trigger at 36 hours old
