### PR TITLE
XS✔ ◾ Add related rule `do-you-zz-old-files-rather-than-deleting-them` to `record-a-quick-and-dirty-done-video`

### DIFF
--- a/rules/record-a-quick-and-dirty-done-video/rule.md
+++ b/rules/record-a-quick-and-dirty-done-video/rule.md
@@ -16,6 +16,7 @@ authors:
 related:
   - do-you-send-done-videos
   - record-better-audio
+  - do-you-zz-old-files-rather-than-deleting-them
 redirects:
   - do-you-know-how-to-record-a-quick-and-dirty-done-video
 created: 2016-05-10T09:09:50.000Z


### PR DESCRIPTION
When recording a quick and dirty Done Video, people usually request a v2 of the video.

During Test Please, it often becomes confusing, and people can easily mix up v1 and v2.

Adding related rule `do-you-zz-old-files-rather-than-deleting-them` to ensure people are aware that v1 should be archived after v2 is completed.
