### PR TITLE
XS✔ ◾ Encode text on use-async-await-for-all-io-bound-operations

### DIFF
--- a/rules/use-async-await-for-all-io-bound-operations/rule.md
+++ b/rules/use-async-await-for-all-io-bound-operations/rule.md
@@ -64,6 +64,6 @@ For more information on understanding and diagnosing thread pool starvation, rea
 
 ### Further Information
 
-* [Why would one use Task<T> over ValueTask<T> in C#?](https://stackoverflow.com/questions/43000520/why-would-one-use-taskt-over-valuetaskt-in-c)
+* [Why would one use Task&lt;T&gt; over ValueTask&lt;T&gt; in C#?](https://stackoverflow.com/questions/43000520/why-would-one-use-taskt-over-valuetaskt-in-c)
 * [Diagnosing issues in ASP.NET Core Applications - David Fowler & Damian Edwards](https://www.youtube.com/watch?v=RYI0DHoIVaA)
 * [Why your ASP.NET Core application won't scale - Damian Edwards, David Fowler](https://www.youtube.com/watch?v=J-xqz_ZM9Wg)


### PR DESCRIPTION
Encode "<" and ">" in the text so these aren't pixed up as HTML tags, as per a CodeAuditor error.

<!---
Thanks for contributing to SSW.Rules!

Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs
-->

