### PR TITLE
Adding missing example prefixes

### DIFF
--- a/rules/write-a-good-pull-request/rule.md
+++ b/rules/write-a-good-pull-request/rule.md
@@ -124,7 +124,7 @@ Try to make generic comments that objectively summarize your changes. This way t
 **PR description:** Added missing video caption + removed unnecessary brackets
 :::
 ::: ok
-Figure: Clear and concise description, however it's not clear what task triggered the change
+Figure: OK example - Clear and concise description, however it's not clear what task triggered the change
 :::
 
 ::: greybox
@@ -135,7 +135,7 @@ Based on email thread, subject: SSW.Rules - Video caption missing
 Added missing video caption + removed unnecessary brackets
 :::
 ::: good
-Figure: It's clear what changes are being made and where the task came from
+Figure: Good example - It's clear what changes are being made and where the task came from
 :::
 
 ::: info


### PR DESCRIPTION
<!---
Thanks for contributing to SSW.Rules!
-->
## Reason for change (Issue, Email, conversation + reason, etc)

I noticed that the prefix ok and good example text was missing

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->