### PR TITLE
CodeAuditor Scan - Fixed incorrect Scrum terms

### DIFF
--- a/rules/work-in-priority-order/rule.md
+++ b/rules/work-in-priority-order/rule.md
@@ -16,7 +16,7 @@ redirects:
 
 ---
 
-Although the team will always strive to complete all the items on the Sprint backlog within the Sprint, it’s not uncommon for them to not finish all of them. If this is the case, you want to at least make sure that the PO's (Product Owner)’s most important items are done. 
+Although the team will always strive to complete all the items on the Sprint Backlog within the Sprint, it’s not uncommon for them to not finish all of them. If this is the case, you want to at least make sure that the PO's (Product Owner)’s most important items are done. 
 <!--endintro-->
 
 Whenever you are choosing your next task, always work from the top down, only skipping items if there is a dependency or another good reason why a lower item needs to be done first.


### PR DESCRIPTION
<!---
Thanks for contributing to SSW.Rules!
-->
## Reason for change (Issue, Email, conversation + reason, etc)

Relates to rule https://ssw.com.au/rules/scrum-should-be-capitalized/

From latest [CodeAuditor Scan](https://codeauditor.com/htmlhint/24b72f7a-3937-4578-26f8-ee56020e8aba) on SSW Rule, I noticed that this page contains non-capitalized Scrum term

Changed from `Sprint backlog` to `Sprint Backlog`

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->