### PR TITLE
Update rule - Travel Insurance

### DIFF
--- a/rules/do-you-know-what-sort-of-insurance-to-buy-when-travelling/rule.md
+++ b/rules/do-you-know-what-sort-of-insurance-to-buy-when-travelling/rule.md
@@ -28,10 +28,11 @@ For example, if you're travelling  **within your home country** you might decide
 :::
 
 
-::: good  
+
 ![](575bdf\_private-travel-insurance.jpg)  
+::: good  
+ **Figure: Good example - Allianz travel insurance for within Australia covers up to AUD$6,000 excess on a rental vehicle – this works out to be about $5.15 a day for a 9-day trip**
 :::
- Figure: Good example: Allianz travel insurance for within Australia covers up to AUD$6,000 excess on a rental vehicle – this works out to be about $5.15 a day for a 9-day trip
 ### International travel:
 
 If you're  **travelling outside of the country** , you should definitely take out travel insurance. If you book and pay using a credit card, you might be eligible for free travel insurance through your credit card institution, but don't assume this cover will be right for your needs, or will necessarily cover the whole travel party.


### PR DESCRIPTION
Fixing formatting as "Figure" text was not bolded and colon was misused.
        
      From: 
"Figure: Good example: Allianz travel insurance for within Australia covers up to AUD$6,000 excess on a rental vehicle – this works out to be about $5.15 a day for a 9-day trip"

      To: 
"**Figure: Good example - Allianz travel insurance for within Australia covers up to AUD$6,000 excess on a rental vehicle – this works out to be about $5.15 a day for a 9-day trip**"

<!--- Thanks for contributing to SSW.Rules! -->
## Reason for change (Issue, Email, conversation + reason, etc)
<!-- 
- Example 1 - Relates to #{{ ISSUE NUMBER }}
- Example 2 - As per my conversation with...
- Example 3 - Based on email thread, subject...
- Example 4 - I noticed that... 
-->
{{ REASON FOR CHANGE - WHAT WAS THE TRIGGER FOR THIS CHANGE }}

{{ SUMMARY OF CHANGES }}

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->