### PR TITLE
CodeAuditor Scan - Fix tag names uppercase

### DIFF
--- a/rules/do-you-look-for-code-coverage/rule.md
+++ b/rules/do-you-look-for-code-coverage/rule.md
@@ -27,7 +27,7 @@ Code Coverage shows how much of your code is covered by tests and can be a usefu
 * You should focus more on the **quality** and less on the **quantity** of tests.
 * You should write tests for fragile code first and not waste time testing trivial methods.
 * Remember the 80-20 rule - very high test coverage is a noble goal, but there are diminishing returns.
-* If you're modifying code, write the test first, then change the code, then run the test to make sure it passes (aka [red-green-refactor](/make-sure-that-the-test-can-be-failed)).<BR>**Tip**: This is made very easy by the "Live Unit Testing" feature in Visual Studio - see [Do you use Live Unit Testing to see code coverage?](/use-live-unit-testing-to-see-code-coverage).
+* If you're modifying code, write the test first, then change the code, then run the test to make sure it passes (aka [red-green-refactor](/make-sure-that-the-test-can-be-failed)).<br>**Tip**: This is made very easy by the "Live Unit Testing" feature in Visual Studio - see [Do you use Live Unit Testing to see code coverage?](/use-live-unit-testing-to-see-code-coverage).
 * You should run your tests regularly (see [Do you follow a Test Driven Process?](/before-starting-do-you-follow-a-test-driven-process)) and, ideally, the tests will be part of your deployment pipeline.
 
 ![Figure: Code Coverage metrics in Visual Studio. This solution has high code coverage (around 80% on average)](CodeCoverage2010.png)  


### PR DESCRIPTION
<!--- Thanks for contributing to SSW.Rules! -->
## Reason for change (Issue, Email, conversation + reason, etc)
<!-- 
- Example 1 - Relates to #{{ ISSUE NUMBER }}
- Example 2 - As per my conversation with...
- Example 3 - Based on email thread, subject...
- Example 4 - I noticed that... 
-->
CodeAuditor detected tag names in uppercase in latest scan. 
See https://codeauditor.com/htmlhint/fe7dd6bd-900d-480a-0df2-12cfff5af056
To comply with rule https://htmlhint.com/docs/user-guide/rules/tagname-lowercase

Changed from `<BR>` to `<br>`

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->