### PR TITLE
XS✔ ◾ Induction PBIs - Remove join scrum team process

### DIFF
--- a/rules/track-induction-work-in-a-scrum-team/rule.md
+++ b/rules/track-induction-work-in-a-scrum-team/rule.md
@@ -21,22 +21,15 @@ redirects:
 
 Having a clear, concise method of tracking tasks and priorities is important.
 
-
 If you have a very lightweight induction system (a day or less to complete) it makes sense to get it done first and then join a Scrum team to start doing your normal work.
 
 If you have a more comprehensive induction system (that takes more than a day, and some take weeks or even months) then it can be isolating to be doing your induction alone and separated from the rest of the team you will be working with. In this scenario, it's recommended that you create an "Induction" PBI in the backlog to track your induction work. Then the new employees' induction activities will feel like part of the job.
 
 For more information, read [the 8 Steps to Scrum](https://www.ssw.com.au/rules/do-you-know-the-8-steps-to-scrum).
 
-
-
 <!--endintro-->
 
-To achieve that you should:
-
-1. Talk to your Manager to work out which Scrum team you'll be joining
-2. Either create OR if you don't have permissions, have someone on that team create a new PBI (e.g. "Induction") where you will add and track your induction work as tasks
-
+Once you join a Scrum team, create a new PBI (e.g. "Induction") where you will add and track your induction work as tasks.
 
 
 ::: good  


### PR DESCRIPTION


<!--- Thanks for contributing to SSW.Rules! -->
## Reason for change (Issue, Email, conversation + reason, etc)

This process doesn't fit into the rule, and the process is covered in SugarLearning now.

This rule isn't about how to join a team.
It's about when you have joined one, what to do with your induction work.

I also removed the bit about getting someone else to do it, I think its better to get access yourself (you'll need it eventually anyway) and creating it yourself.

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->