### PR TITLE
XS✔ ◾ Adding the link of v2 rule to the recall rule

### DIFF
--- a/rules/do-you-know-how-to-recall-an-email/rule.md
+++ b/rules/do-you-know-how-to-recall-an-email/rule.md
@@ -14,7 +14,8 @@ related: []
 redirects: []
 
 ---
-
+Do you know it is better to send a v2 rather than recall the email, see SSW Rule [Do you know when and how to send a v2 of an email?](https://www.ssw.com.au/rules/email-send-a-v2)
+---
 Even though you may check your emails before sending, use SSW lookout to help you avoid mistakes, and even if you send/receive manually, there will still be times where you will send out an email with mistakes or incorrect content. 
 
 <!--endintro-->


### PR DESCRIPTION
At SSW we do not recall an email but instead, we send a v2. I will add a link to the v2 rule to tell the reader sending a v2 is better than recalling it.

<!--- Thanks for contributing to SSW.Rules! -->
In SSW, we do not recall email, but we still have this rule 5 years ago. It could be an instruction for the outsider to learn how to recall an email, but we also need let them know that sending a v2 is the better option.
<!-- 
- Example 1 - Relates to recall an email or sending a v2
- Example 2 - As per my conversation with Uly and Penny
- Example 3 - Based on email thread, subject RE: Annual Reviews coming up
- Example 4 - I noticed that even SSW do not suggest recall the email, but we still have a rule about that
-->
In SSW we do not recall email but sending a v2 instead. I would add a link to the v2 rule to tell the reader sending a v2 is better than recalling it.

Adding 
	Do you know it is better to send a v2 rather than recall the email, see SSW Rule https://www.ssw.com.au/rules/email-send-a-v2/

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->