### PR TITLE
XS✔ ◾ Including the relevant rules

### DIFF
--- a/rules/ask-clients-approval/rule.md
+++ b/rules/ask-clients-approval/rule.md
@@ -10,6 +10,8 @@ authors:
 related:
   - storyboarding-do-you-conduct-specification-analysis-by-creating-mock-ups
   - turn-emails-into-pbis
+  - checked-by-xxx
+  - conduct-a-test-please
 redirects:
   - do-you-ask-clients-to-initial-your-work
 created: 2009-03-17T07:27:19.000Z


### PR DESCRIPTION
<!--- Thanks for contributing to SSW.Rules! -->

<!-- 
- Example 1 - Relates to #{{ ISSUE NUMBER }}
- Example 2 - As per my conversation with...
- Example 3 - Based on email thread, subject...
- Example 4 - I noticed that... 
-->
We have this rule https://www.ssw.com.au/rules/ask-clients-approval/ in the CTF on 15th September, the rule is brilliant and it actually answers much of my confusion about the Check-by rule and the Test-pass rule.

These 2 rules are highly relevant, but their links are not visible enough
 
Suggestion - I think if there are some rules that are highly relevant, they should be mentioned in the list of Related Rules. This can quickly navigate the reader to the relevant rules and redirect people who cannot find the rule they are looking for.

<!-- 
Have you seen our Rules to Better Pull Requests?
https://www.ssw.com.au/rules/rules-to-better-pull-requests/

Please provide a good title and a short description of your pull request
See https://www.ssw.com.au/rules/write-a-good-pull-request/ for further guidance

Did you do an over the shoulder review?
https://www.ssw.com.au/rules/over-the-shoulder-prs 
-->