### PR TITLE
XS✔ ◾ Brainstorming teams - Add share team allocations bit

### DIFF
--- a/rules/brainstorming-team-allocation/rule.md
+++ b/rules/brainstorming-team-allocation/rule.md
@@ -72,3 +72,14 @@ In order to make the Brainstorming day as productive as possible, set up the Pow
 **Figure: Brainstorming powerpoint template (6 min)**
 
 Having all the presentations in one location (Teams team) makes it easy to collaborate and ensures they wont be lost. It also means all the presentations can happen on a single device, instead of switching laptop every presentation which can be slow and lead to AV issues.
+
+## Share the teams with the company
+
+Once the teams have been allocated, create a new GitHub Discussion with all the ideas and the teams with a link to the original idea Discussion.
+Share the Discussion in an email to the entire company.
+
+Putting the team allocations in a Discussion allows updates if attendees change or if the teams need to be updated.
+
+![Figure: GitHub Discussion - Team allocations](https://github.com/SSWConsulting/SSW.Rules.Content/assets/38869720/5c7a9a8f-24d8-4129-8060-c34f2cd3afb2)
+
+**Tip:** For extra visibility, also pin it on the repo.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ I saw it was missing

> 2. What was changed?

✏️ added that you share team allocations

> 3. Did you do pair or mob programming?

✏️ no
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
