### PR TITLE
Update Rule “turn-emails-into-pbis/rule”

### DIFF
--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -27,7 +27,7 @@ created: 2013-06-27T18:28:23.000Z
 archivedreason: null
 guid: 98d88bcd-85a4-4b7a-8612-2affd49021d5
 ---
-Emails are a natural way for people to give feedback about a product. Unfortunately, they also serve as a poor mechanism for performing work. As work is done, the thread can become untennable by splitting off into multiple different threads and becoming buried amoung other emails.
+Emails are a natural way for people to give feedback about a product. Unfortunately, they also serve as a poor mechanism for performing work. As work is done, the thread can become untenable by splitting off into multiple different threads and becoming buried among other emails.
 
 That's why when a feedback email is received, it is important to turn it into a Product Backlog Item (PBI) and communicate that back to the sender.
 
@@ -73,9 +73,17 @@ It's important that you follow the right steps so that the PBI contains all the 
      **Cc:** John Davis; Eliza Northwind\
      **Subject:** TimePro PBI 50209: ☠️ Displaying past employees\
    :::
-3. Fill out the Description 
-4. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
-5. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI: {{ URL }}\
+
+3. Tag CC'ed users in the PBI.  E.g.:
+
+   ::: greybox
+     CC: @John_Davis, @Eliza_Northwind
+   :::
+
+4. Fill out the Description 
+
+5. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
+6. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI: {{ URL }}\
    For future ones, if you have access, please add your comments there 🙂"*
 
 ::: info


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email - Email header at the top 

From: Adam Cogan [SSW] <AdamCogan@ssw.com.au> 
Sent: Sunday, November 12, 2023 5:30 PM
To: Daniel Mackay [SSW] <DanielMackay@ssw.com.au>
Subject: Email header at the top 

> 2. What was changed?

✏️ Added a point to tag users in the PBI that were originally in the email CC list

> 3. Did you do pair or mob programming?

✏️ No