### PR TITLE
XS✔ ◾ Update Rule "turn-emails-into-pbis" - Add section for pre-existing PBIs

### DIFF
--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -82,6 +82,14 @@ It's important that you follow the right steps so that the PBI contains all the 
 **Tip:** If the request from the client is too large for one PBI, then it will need to be turned into multiple PBIs as per the rule  [Do you keep your PBIs smaller than 2 days' effort?](/spec-do-you-create-tasks-under-4-hours) In this case, you will need to let the client know this and include URLs to each PBI
 :::
 
+### Steps to update a PBI with a email
+
+Sometimes you will receive an email concerning a known issue. It is important to inform the sender and keep them up to date.
+
+1. Copy the **email header** into to a comment within the PBI, indent and add the words "Issue raised by {{ NAME }} separately in email chain:"
+2. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
+3. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
+
 ### Keeping it up-to-date
 
 If there is more communication in emails at a later date, it's important to make sure the PBI stays in sync with the emails. Otherwise, the source of truth will become confusing since there will be differing information in 2 places.

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -82,7 +82,7 @@ It's important that you follow the right steps so that the PBI contains all the 
 **Tip:** If the request from the client is too large for one PBI, then it will need to be turned into multiple PBIs as per the rule  [Do you keep your PBIs smaller than 2 days' effort?](/spec-do-you-create-tasks-under-4-hours) In this case, you will need to let the client know this and include URLs to each PBI
 :::
 
-### Steps to update a PBI with a email
+### Steps to update a PBI with an email
 
 Sometimes you will receive an email concerning a known issue. It is important to inform the sender and keep them up to date.
 
@@ -97,7 +97,7 @@ If there is more communication in emails at a later date, it's important to make
 When there is a new update in emails do the following ASAP:
 
 1. Update the PBI with any relevant information
-2. Mention that it was updated as per the email thread in the discussion
+2. Mention that it was updated as per the email thread
 
 ::: bad
 ![Figure: Bad example - Don't work from your email inbox!](EmailExample.png)

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -97,7 +97,7 @@ If there is more communication in emails at a later date, it's important to make
 When there is a new update in emails do the following ASAP:
 
 1. Update the PBI with any relevant information
-2. Mention that it was updated as per the email thread
+2. Mention that it was updated as per the email thread in the discussion
 
 ::: bad
 ![Figure: Bad example - Don't work from your email inbox!](EmailExample.png)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

@GordonBeeming reported an error with SugarLearning via email that had been previously recorded in a [PBI](https://dev.azure.com/ssw/SSW.Induction/_workitems/edit/86819). @adamcogan requested that the response includes a link to the applicable rule, which would be [Do you turn an email into a PBI before starting work?](https://www.ssw.com.au/rules/turn-emails-into-pbis/).

Upon review, I noticed that the rule did not cover the situation where the PBI existed prior to the email.

> 2. What was changed?

A section was added to the above mentioned rule titled "Steps to update a PBI with an email". This new section contains 3 steps to record the email thread on the PBI and inform the recipients of the email chain of the existence of the PBI.

> 3. Did you do pair or mob programming (and list names)?

No - an over-the-shoulder review was conducted with @GordonBeeming in person prior to pushing to repository and creating the PR.

