### PR TITLE
Update "brainstorming-day-retro/rule" and "do-you-return-a-resource-url/rule"

### DIFF
--- a/rules/brainstorming-day-retro/rule.md
+++ b/rules/brainstorming-day-retro/rule.md
@@ -26,7 +26,7 @@ Send out a Microsoft form with the following questions
 
 1. Did you watch the Brainstorming presentation (in person or live stream)?
 2. ✅ What went well?
-3. ❌ What went well?
+3. ❌ What didn't go so well?
 4. 💡 Any ideas to improve it?
 5. {{IDEA NAME}} - How good was the outcome of the Brainstorming session?
    - Rating /10

--- a/rules/do-you-return-a-resource-url/rule.md
+++ b/rules/do-you-return-a-resource-url/rule.md
@@ -27,8 +27,8 @@ public Product PostProduct(Product item)
  }
 ```
 
-::: bad
-Figure: Bad Example – The response does not contain a reference to the location of the new resource 
+::: bad  
+Figure: Bad Example – The response does not contain a reference to the location of the new resource  
 :::
 
 ```cs
@@ -51,6 +51,6 @@ public HttpResponseMessage PostProduct(Product item)
 }
 ```
 
-::: good
-Figure: Good Example – The response message contains a link in the header to the created resource (and the “Created” status code is returned )
+::: good  
+Figure: Good Example – The response message contains a link in the header to the created resource (and the “Created” status code is returned )  
 :::

--- a/rules/do-you-return-a-resource-url/rule.md
+++ b/rules/do-you-return-a-resource-url/rule.md
@@ -28,7 +28,7 @@ public Product PostProduct(Product item)
 ```
 
 ::: bad  
-Figure: Bad Example – The response does not contain a reference to the location of the new resource  
+Figure: Bad example – The response does not contain a reference to the location of the new resource  
 :::
 
 ```cs
@@ -52,5 +52,5 @@ public HttpResponseMessage PostProduct(Product item)
 ```
 
 ::: good  
-Figure: Good Example – The response message contains a link in the header to the created resource (and the “Created” status code is returned )  
+Figure: Good example – The response message contains a link in the header to the created resource (plus the “Created” status code is returned)  
 :::

--- a/rules/do-you-return-a-resource-url/rule.md
+++ b/rules/do-you-return-a-resource-url/rule.md
@@ -27,9 +27,9 @@ public Product PostProduct(Product item)
  }
 ```
 
-
+::: bad
 Figure: Bad Example – The response does not contain a reference to the location of the new resource 
-
+:::
 
 ```cs
 public HttpResponseMessage PostProduct(Product item)
@@ -51,5 +51,6 @@ public HttpResponseMessage PostProduct(Product item)
 }
 ```
 
-
+::: good
 Figure: Good Example – The response message contains a link in the header to the created resource (and the “Created” status code is returned )
+:::


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Sugar Learning item [make-a-small-content-change-to-ssw-rules](https://my.sugarlearning.com/SSW/items/13091/make-a-small-content-change-to-ssw-rules-check-in-publish) 

> 2. What was changed?
* Typo in "brainstorming day retro rule"
* "Good"- and "bad" container around figure text in "do you return a resource url rule" 


<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
