### PR TITLE
fix broken image and shortening URL

### DIFF
--- a/rules/cta-banana-rule/rule.md
+++ b/rules/cta-banana-rule/rule.md
@@ -3,7 +3,7 @@ type: rule
 archivedreason: 
 title: Do you have a call to action on your web pages (aka The Banana Rule)?
 guid: 165b850d-886c-423e-99b8-77c33ff26a27
-uri: do-you-have-a-call-to-action-on-your-web-pages-aka-the-banana-rule
+uri: cta-banana-rule
 created: 2014-12-04T20:16:58.0000000Z
 authors:
 - title: Adam Cogan
@@ -11,7 +11,7 @@ authors:
 related: []
 redirects:
 - do-you-have-a-call-to-action-on-your-web-pages-(aka-the-banana-rule)
-
+- do-you-have-a-call-to-action-on-your-web-pages-aka-the-banana-rule
 ---
 
 If you want users to take action on the web page content, add a "banana" - something that makes it obvious what the user is supposed to do.
@@ -29,10 +29,10 @@ How would you get a monkey pay attention to something? You could lure him by tem
 This is how the "banana rule" should be applied:
 
 ::: bad  
-![Figure: Bad Example – "Points+Pay"button takes the attention over "Go" which should be the "banana"](BadBananaQantus.png)  
+![Figure: Bad Example – "Points+Pay"button takes the attention over "Go" which should be the "banana"](BadBananaQantas.png)  
 :::
 So, remember most pages need a "banana" to get them to where you want them. "Bananas" are big, simple and stand out from the rest of the page
 
 ::: good  
-![Figure: Great Example - SSW always have a good banana](GoodBananaSSWScrumPage.png)  
+![Figure: Good Example - SSW always have a good banana](GoodBananaSSWScrumPage.png)  
 :::


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️email:
1.	The image path is wrong, so the image is broken (Qantus instead of Qantas)
Please fix
 
2.	Update the SSW example caption to say “Good” instead of “Great” - for consistency with other rules
3.	I think this is a great opportunity to make the rule URL short and friendly as /cta-banana-rule
Please action


> 2. What was changed?

✏️ implemented the above

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
