### PR TITLE
Adding redirects to Figma rule

### DIFF
--- a/rules/figma-uses/rule.md
+++ b/rules/figma-uses/rule.md
@@ -9,6 +9,9 @@ related:
   - when-do-you-need-a-ux-designer
 created: 2023-08-06T22:53:08.399Z
 guid: 6344c9aa-63bb-4d94-a15a-c1767a658c17
+redirects: 
+ - what-is-figma
+ - do-you-know-what-figma-is
 ---
 Figma is a cloud-based design and prototyping tool that enables designers, developers, and teams to collaborate in real-time on the same design files. 
 `youtube: https://www.youtube.com/embed/PaPIsyO1t3Q?si=WKI5lgm97260OFmD`


### PR DESCRIPTION
This change was initiated by @tiagov8 via email as there were broken google links.

     > What is the final Figma rule URL?
https://www.ssw.com.au/rules/figma-uses/

     > Please fix by adding the redirects for both links above 
     (see https://github.com/SSWConsulting/SSW.Rules.Content/wiki/How-to-Rename-Rules#step-2-update-the-uri--add-the-redirect-from-old-uri)

Done! Redirects added
 
     > Who changed it? Please cc in your fix
@2fernandez changed it.