### PR TITLE
XS✔ ◾ Added experts and consutling info to CRM category

### DIFF
--- a/categories/management/rules-to-better-crm.md
+++ b/categories/management/rules-to-better-crm.md
@@ -1,6 +1,8 @@
 ---
 type: category
 title: Rules to Better CRM
+experts: https://www.ssw.com.au/people/?skill=Dynamics-365-CRM
+consulting: https://www.ssw.com.au/consulting/dynamics-365
 guid: bcd95052-5d7e-4734-b5b1-2f508f376398
 uri: rules-to-better-crm
 index:


### PR DESCRIPTION
cc @UlyssesMaclaren @jaydenalchin

as per https://github.com/SSWConsulting/SSW.Rules/issues/956

> What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Re: Link from the Rules back to the Consulting pages

> What was changed?

Added experts and consutling info

> Did you do pair or mob programming (list names)?

no