### PR TITLE
XS✔ ◾ Disable rule - no inline html

### DIFF
--- a/.markdownlint/config.json
+++ b/.markdownlint/config.json
@@ -6,12 +6,7 @@
     "MD004": {
         "style": "asterisk"
     },
-    "MD033": {
-        "allowed_elements": [
-            "details",
-            "summary"
-        ]
-    },
     "MD046": false,
-    "MD013": false
+    "MD013": false,
+    "MD033": false
 }


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

We allow HTML in markdown 

> 2. What was changed?

disable the rule in the markdown linter

> 3. Did you do pair or mob programming (list names)?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
