### PR TITLE
XS✔ ◾ Update guidance on converting emails into PBIs

### DIFF
--- a/rules/cta-banana-rule/rule.md
+++ b/rules/cta-banana-rule/rule.md
@@ -36,5 +36,5 @@ This is how the "banana rule" should be applied:
 So, remember most pages need a "banana" to get them to where you want them. "Bananas" are big, simple and stand out from the rest of the page.
 
 ::: good  
-![Figure: Good example - SSW always have a good banana](GoodBananaSSWScrumPage.png)  
+![Figure: Good example - SSW always have a good "banana"](GoodBananaSSWScrumPage.png)  
 :::

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -110,11 +110,13 @@ Sometimes you will receive an email concerning a known issue. It is important to
 
 1. Copy the **email header** into to a comment within the PBI, indent and add the words "Issue raised by {{ NAME }} separately in email chain:"
 
-2. Strip out the email addresses from the header.
+2. Replace the users with GitHub usernames (where possible), if you'd like to keep those users informed.
 
-3. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
+3. Remove any remaining email addresses from the header.
 
-4. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
+4. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
+
+5. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
 
 ### Keeping it up-to-date
 

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -62,29 +62,43 @@ Easily accessible by anyone in the team
 It's important that you follow the right steps so that the PBI contains all the information someone would need to find the original email thread, and also so that the original sender knows where the PBI is, and whether it has completed.
 
 1. Create a PBI in the backlog and give it a name
-2. Copy the **email header** into the top of the PBI, indent it and add the words "Based on email chain:" so that the email can be found later. E.g.:
 
-   ::: greybox
-   Based on email chain:
+2. Copy the **email header** into the top of the PBI, indent it and add the words "Based on email chain:" so that the email can be found later.
 
-     **From:** Bob Northwind\
-     **Sent:** Thursday, 24 November 2023\
-     **To:** Jane Doe\
-     **Cc:** John Davis; Eliza Northwind\
-     **Subject:** TimePro PBI 50209: ☠️ Displaying past employees\
-   :::
+3. Replace the users with GitHub usernames (where possible), if you'd like to keep those users informed.
 
-3. Tag CC'ed users in the PBI.  E.g.:
+4. Remove any remaining email addresses from the header.
 
-   ::: greybox
-     CC: @John_Davis, @Eliza_Northwind
-   :::
+5. Fill out the Description 
 
-4. Fill out the Description 
+6. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
 
-5. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
-6. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI: {{ URL }}\
+7. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI: {{ URL }}\
    For future ones, if you have access, please add your comments there 🙂"*
+
+::: greybox
+**From:** Bob Northwind "BobNorthwind@northwind.com\
+**Sent:** Thursday, 24 November 2023\
+**To:** Jane Doe "JaneDoe@northwind.com"\
+**Cc:** John Davis "JohnDavis@northwind.com"; Eliza Northwind "ElizaNorthwind@northwind.com"\
+**Subject:** TimePro PBI 50209: ☠️ Displaying past employees\
+:::
+::: bad
+Figure: Including email addresses and not tagging GitHub users
+:::
+
+::: greybox
+Based on email chain:
+
+**From:** @BobNorthwind
+**Sent:** Thursday, 24 November 2023\
+**To:** @JaneDoe\
+**Cc:** @JohnDavis @ElizaNorthwind\
+**Subject:** TimePro PBI 50209: ☠️ Displaying past employees\
+:::
+::: good 
+Figure: Email header with GitHub users tagged and no email addresses
+:::
 
 ::: info
 **Tip:** If the request from the client is too large for one PBI, then it will need to be turned into multiple PBIs as per the rule  [Do you keep your PBIs smaller than 2 days' effort?](/spec-do-you-create-tasks-under-4-hours) In this case, you will need to let the client know this and include URLs to each PBI
@@ -95,8 +109,12 @@ It's important that you follow the right steps so that the PBI contains all the 
 Sometimes you will receive an email concerning a known issue. It is important to inform the sender and keep them up to date.
 
 1. Copy the **email header** into to a comment within the PBI, indent and add the words "Issue raised by {{ NAME }} separately in email chain:"
-2. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
-3. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
+
+2. Strip out the email addresses from the header.
+
+3. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
+
+4. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
 
 ### Keeping it up-to-date
 


### PR DESCRIPTION
Reason for change: Email - "Email header at the top"

The instructions for turning emails into product backlog items (PBIs) have been revised. These changes include additional steps on replacing email addresses with GitHub usernames, removing any remaining email addresses from headers, and handling situations where an email concerns a known issue.
