### PR TITLE
Adding Salary terminology rule to accounting category. 

### DIFF
--- a/categories/management/rules-to-better-accounting.md
+++ b/categories/management/rules-to-better-accounting.md
@@ -24,6 +24,7 @@ index:
 - how-to-enter-an-expensify-receipt
 - do-you-use-a-mobile-app-to-check-your-personal-payroll
 - do-you-take-advantage-of-salary-acrificing–electronic-devices
+- salary-terminology
 - do-you-calculate-payroll-tax-correctly
 - do-you-check-your-customers-organisation-age-for-prepaid
 - do-you-treat-freebies-as-real-customers


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

As per "Salary Packaging - Standardize language" email, rule was created to clarify salary terminology. Added to accounting category because it is mostly relevant for accountants. 

> 2. What was changed?

New rule + added to category after it was published. 

> 3. Did you do pair or mob programming (list names)?

worked with Levi, helped by Seth. 
