### PR TITLE
Update Rule “salary-sacrifice-electronic-devices/rule”

### DIFF
--- a/rules/salary-sacrifice-electronic-devices/rule.md
+++ b/rules/salary-sacrifice-electronic-devices/rule.md
@@ -19,9 +19,7 @@ redirects:
   - salary-sacrificing-eletronic-devices
 created: 2023-12-11T00:10:16.831Z
 guid: 08919f62-423b-4734-b99e-54903108e240
-
 ---
-
 Are you planning to buy a cool laptop to boost your productivity? You can place your order from Apple or JB HiFi at full price. Or if your employer offers the ability to Salary Sacrifice, you can spend less by paying with your **pre-tax** money (rather than after-tax).
 
 `youtube: https://www.youtube.com/watch?v=ZLfPzCtTHPE`
@@ -34,13 +32,8 @@ In Australia, salary sacrificing is when your employer agrees to pay for your de
 Most companies will let you salary sacrifice FBT-exempted portable electronic devices that:
 
 * Are used predominantly for work-related purposes
-
 * Are easily portable and designed for use away from an office environment
-
-* Are small and light
-
 * Can operate without an external power supply
-
 * Are designed as a complete unit
 
 This provides you with a wide variety of work-related devices that you could salary sacrifice and save money on. Some devices such as laptops, tablets, phones, and headphones are just some of the examples.
@@ -67,20 +60,20 @@ Salary sacrificing has many awesome benefits:
 
 #### Scenario
 
-Bob is earning $111k per annum (salary package inclusive of Super). He wants to buy a $5,500 laptop.  
+Bob is earning $111k per annum (salary package inclusive of Super). He wants to buy a $5,500 laptop.\
 Let's look at how he saves **$2,500** on the new laptop.
 
 ![Figure: Without Salary Sacrificing vs Salary Sacrificing](https://github.com/SSWConsulting/SSW.Rules.Content/assets/115961605/3d97ac78-49c7-4045-8ab2-4d615de78c0a)
 
-|                                     | ❌ Without Salary Sacrificing | ✅ With Salary Sacrificing |
-|:-------------------------------------|-------------------------------:|-----------------------------:|
-| Salary package inclusive of Super   | $ 111k                    | $ 111k                   |
-| Less Super   | $ 11k   | $ 11k   |
-| Pre-tax deduction   | $ 0   | $ 5k  |
-| Gross Income   | $ 100k  | $ 95k   |
-| Less Tax  | $ 26k   | $ 24k   |
-| 💻 Purchase   | $ 5k   | $ 0  |
-| 💻 GST on Purchase | $ 0.5 | $ 0  |
-| **Take-home pay**   | **$ 68.5k**   | **$ 71k**   |
+|                                   | ❌ Without Salary Sacrificing | ✅ With Salary Sacrificing |
+| --------------------------------- | ---------------------------- | ------------------------- |
+| Salary package inclusive of Super | $ 111k                       | $ 111k                    |
+| Less Super                        | $ 11k                        | $ 11k                     |
+| Pre-tax deduction                 | $ 0                          | $ 5k                      |
+| Gross Income                      | $ 100k                       | $ 95k                     |
+| Less Tax                          | $ 26k                        | $ 24k                     |
+| 💻 Purchase                       | $ 5k                         | $ 0                       |
+| 💻 GST on Purchase                | $ 0.5                        | $ 0                       |
+| **Take-home pay**                 | **$ 68.5k**                  | **$ 71k**                 |
 
 **Figure: Bob saved $2,500 on take-home pay with salary sacrificing**


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️This was a point I overheard Matt Wicks discussing with someone else so it's not really my own original observation, but the ATO doesn't explicitly say that salary sacrificed devices need to be thin and light.

> 2. What was changed?

✏️I Removed the bullet point that says salary sacrificed devices need to be thin and light.

> 3. Did you do pair or mob programming (list names)?

✏️No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
