### PR TITLE
XS✔ ◾ Update Contact before work rule and add related rules

### DIFF
--- a/categories/management/rules-to-better-sales.md
+++ b/categories/management/rules-to-better-sales.md
@@ -20,7 +20,7 @@ index:
   - connect-client-im
   - schedule-followup-meeting-after-spec-review
   - do-you-explain-the-cone-of-uncertainty-to-people-on-the-fence-about-agile
-  - do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
+  - contract-before-work
   - do-you-get-a-signed-copy-of-the-whole-terms-and-conditions-document-not-just-the-last-page
   - do-you-present-project-proposals-as-lots-of-little-releases-rather-than-one-big-price
   - do-you-aim-for-an-advancement-rather-than-a-continuance

--- a/rules/do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work/rule.md
+++ b/rules/do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work/rule.md
@@ -3,32 +3,48 @@ type: rule
 archivedreason: 
 title: Do you enter into a binding written contract with a client before doing any billable work?
 guid: f8340f9c-bf29-4e05-ad09-615e3ae7450d
-uri: do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
+uri: contract-before-work
 created: 2012-08-30T13:01:02.0000000Z
 authors:
 - title: Adam Cogan
   url: https://ssw.com.au/people/adam-cogan
 - title: Ulysses Maclaren
   url: https://ssw.com.au/people/ulysses-maclaren
-related: []
-redirects: []
+- title: Tylah Kapa
+  url: https://ssw.com.au/people/tylah-kapa
+related: 
+- conduct-a-spec-review
+- do-you-prepare-then-confirm-conversations-decisions
+- dones-do-you-send-yourself-emails
+- document-discoveries 
+- scrum-in-github
+- use-devops-scrum-template
+redirects: 
+- do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
 
 ---
 
-Before you engage in any billable work, the two parties must enter into a binding  written contract. This ensures contractual obligations are clear on both sides,    mitigating the potential for disagreements down the line and protecting both you and the client in the event of a disagreement. Binding contracts can take the form of Terms and Conditions, Emails and Instant Messenger or even verbal agreements.
+Before you engage in any billable work, the two parties must enter into a binding  written contract. This ensures contractual obligations are clear on both sides, mitigating the potential for disagreements down the line and protecting both you and the client in the event of a disagreement. Binding contracts can take the form of Terms and Conditions, Emails and Instant Messenger or even verbal agreements.
 
 <!--endintro-->
 
 * **Terms and Conditions** - A signed copy of [standard Terms and Conditions](https://www.ssw.com.au/SSW/Standards/Forms/ConsultingOrderTermsConditions.aspx) are mandatory before billable work commences as they explain the terms on which you work and the rates which will be billed. Some clients may also have their own set of Terms and Conditions which you should consider signing if agreeable. It is also common for clients to ask you to sign a Non-Disclosure Agreement (NDA) which you should always consider. Long term clients should re-sign the Terms and Conditions every couple of years. Signed Terms and Conditions should be stored in your CRM system against the relevant client (you could enter it in as an attachment to a note).
 
-* **Proposals** - At the conclusion of a [Specification Review](/conduct-a-spec-review), you should provide a proposal to the client. This will include all of the relevant information you have discovered during the Specification Review process. The proposal may take         the form of a PowerPoint presentation (preferred) or a Word doc. However, the proposal is not a contract. It does not supersede the Terms and Conditions. In effect,  the proposal is a sales document which describes broadly the scope of the work to be done and our capacity to complete that work. In an Agile project, it is not a working document from which the project is managed. The project will generally be managed using Scrum, with a backlog in TFS.
+* **Proposals** - At the conclusion of a [Specification Review](/conduct-a-spec-review), you should provide a proposal to the client. This will include all of the relevant information you have discovered during the Specification Review process. The proposal may take the form of a PowerPoint presentation (preferred) or a Word doc. However, the proposal is not a contract. It does not supersede the Terms and Conditions. In effect,  the proposal is a sales document which describes broadly the scope of the work to be done and your capacity to complete that work. In an Agile project, it is not a working document from which the project is managed. The project will generally be managed using Scrum, with a backlog in GitHub or Azure DevOps.
+
+::: greybox
+**Note:** You can learn more about using Scrum with your preferred platform with these rules:
+* [GitHub Projects - Do you know how to do scrum?](/scrum-in-github)
+* [Do you use the Scrum template with Azure DevOps?](/use-devops-scrum-template)
+:::
 
 * **Ad Hoc Emails, Instant Messenger and Verbal Agreements** - The most common form of mini-contract is a confirmation email.
-Electronic communication such as email and Instant Messenger are extremely useful in getting decisions confirmed quickly but it is important to follow strict standards to ensure any agreements are clear to everyone. You should not generally rely upon verbal agreements, always confirm anything agreed verbally in writing. 
+Email and Instant Messenger are extremely useful in getting decisions confirmed quickly but it is important to follow strict standards to ensure any agreements are clear to everyone. You should not generally rely upon verbal agreements, always confirm anything agreed verbally in writing. 
 
 The following are important rules to follow:
 
 * [Do you prepare then confirm conversations/decisions?](/do-you-prepare-then-confirm-conversations-decisions)
+* [Do you document discoveries and decisions](/document-discoveries)
 * [Do you send yourself emails?](/dones-do-you-send-yourself-emails)
 
 **Email**, **IM** and (confirmed) **verbal agreements** are utilized extensively during a project where newly discovered work, delays, or other work outside the initial scope is required.

--- a/rules/do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work/rule.md
+++ b/rules/do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work/rule.md
@@ -34,12 +34,13 @@ Before you engage in any billable work, the two parties must enter into a bind
 
 ::: greybox
 **Note:** You can learn more about using Scrum with your preferred platform with these rules:
+
 * [GitHub Projects - Do you know how to do scrum?](/scrum-in-github)
 * [Do you use the Scrum template with Azure DevOps?](/use-devops-scrum-template)
 :::
 
 * **Ad Hoc Emails, Instant Messenger and Verbal Agreements** - The most common form of mini-contract is a confirmation email.
-Email and Instant Messenger are extremely useful in getting decisions confirmed quickly but it is important to follow strict standards to ensure any agreements are clear to everyone. You should not generally rely upon verbal agreements, always confirm anything agreed verbally in writing. 
+Email and Instant Messenger are extremely useful in getting decisions confirmed quickly but it is important to follow strict standards to ensure any agreements are clear to everyone. You should not generally rely upon verbal agreements, always confirm anything agreed verbally in writing.
 
 The following are important rules to follow:
 

--- a/rules/do-you-treat-freebies-as-real-customers/rule.md
+++ b/rules/do-you-treat-freebies-as-real-customers/rule.md
@@ -8,7 +8,12 @@ created: 2009-03-10T09:07:23.0000000Z
 authors:
 - title: Adam Cogan
   url: https://ssw.com.au/people/adam-cogan
-related: []
+related: 
+- meetings-are-you-prepared-for-the-initial-meeting
+- do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
+- conduct-a-spec-review
+- estimating-do-you-know-what-tasks-are-involved-in-addition-to-just-development-work-items
+- management-do-you-have-a-release-update-debrief-meeting-on-a-weekly-basis
 redirects: []
 
 ---

--- a/rules/do-you-treat-freebies-as-real-customers/rule.md
+++ b/rules/do-you-treat-freebies-as-real-customers/rule.md
@@ -22,7 +22,7 @@ In the course of business, you may occasionally provide some services or product
 
 <!--endintro-->
 
-#### 1. Freebies/discounts need just as strict controls as regular projects 
+#### 1. Freebies/discounts need just as strict controls as regular projects
 
 When you are giving something away at a discount or for free you are expecting a loss compared with a regular client. If you fail to follow regular processes not only will you incur an even greater loss you provide a lesser standard of service and put greater risk on the success of the project.
 A discount or freebie should follow all the standard processes such as:
@@ -36,14 +36,14 @@ A discount or freebie should follow all the standard processes such as:
 * Issue a Discount Code for a free ticket to our regular events
 
 ::: greybox
-**Consider the follow scenario:** 
+**Consider the follow scenario:**
 
-You have a concreter buddy who offers to do your driveway for mate's rates. He won't accept full price (because you're friends) and he thinks he's doing you a favour. The problem is, he won't commit to a timeframe because he has customers that ARE paying full price. You're quite happy to pay full price, because you know he does great work and you want to support his business. In the end, no one is happy. You have an extended wait to get the job done for a discount you don't want and he feels pressured to do extra work in his spare time. 
+You have a concreter buddy who offers to do your driveway for mate's rates. He won't accept full price (because you're friends) and he thinks he's doing you a favour. The problem is, he won't commit to a timeframe because he has customers that ARE paying full price. You're quite happy to pay full price, because you know he does great work and you want to support his business. In the end, no one is happy. You have an extended wait to get the job done for a discount you don't want and he feels pressured to do extra work in his spare time.
 
 A better approach is for the concreter to offer the discount AND book you in as a normal customer. He can give dedicated time and professional service and you get the job done with minimal delay. You can also provide excellent feedback and suggestions on the service he delivers, being both a friend and a customer. It is a much better outcome.  
 :::
 
-#### 2. Feedback on events, products, or services 
+#### 2. Feedback on events, products, or services
 
 Often the people you choose to provide a freebie are the best people to provide feedback on your product or services. When you waive all your standard processes, they have no opportunity to review how you conduct your business. So if you're offering a freebie (or any discount), you should ensure every normal standard of business is followed (including sending $0 invoices!) and make sure you get valuable feedback to help you run your company better.
 
@@ -54,11 +54,12 @@ Often the people you choose to provide a freebie are the best people to provide 
 | Cc:      | Adam |
 | Subject: | Glad to have you + feedback |  
 ::: email-content  
-### Hi Bob,  
 
-Sure we would love to have you at our event for no charge. You may register just like a real client. 
-         
-You will receive an invoice with the items on it at $0. 
+### Hi Bob  
+
+Sure we would love to have you at our event for no charge. You may register just like a real client.
+
+You will receive an invoice with the items on it at $0.
 
 It would be great if you could give us **feedback** on anything that could improve the experience (just as if you were a normal client).
 
@@ -71,7 +72,7 @@ Adam
 Figure: Good Example - Asking for feedback
 :::
 
-**Zero Invoices:** 
+**Zero Invoices:**
 
 When entering timesheets for free work, set your rate to $0.
 


### PR DESCRIPTION
(Checked by Uly)
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email - SSW Rules - modernize the rule - Enter into a binding written contract with a client before doing any billable work

> 2. What was changed?

✏️ 
Rule uri (in Rule and category)
From 
    do-you-enter-into-a-binding-written-contract-with-a-client-before-doing-any-billable-work
To 
    contract-before-work

Update rule to reference GitHub and Azure DevOps

Update related rules for this rule and a related rule

> 3. Did you do pair or mob programming (list names)?

✏️ Worked with @UlyssesMaclaren to confirm the Rule content
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
