### PR TITLE
Update the broken link in the rule 'have-tests-for-performance'

### DIFF
--- a/rules/do-you-avoid-reviewing-performance-without-metrics/rule.md
+++ b/rules/do-you-avoid-reviewing-performance-without-metrics/rule.md
@@ -70,7 +70,7 @@ This is because performance is an emotional thing, sometimes it just \*feels\* s
 ### Samples
 
 
-For sample code on how to measure performance for Windows application form, please refer to rule [Do you have tests for Performance?](https://ssw.com.au/rules/have-tests-for-performance/) on [Rules To Better Unit Tests](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterUnitTests.aspx).
+For sample code on how to measure performance for Windows application form, please refer to rule [Do you have tests for Performance?](/have-tests-for-performance/) on [Rules To Better Unit Tests](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterUnitTests.aspx).
 
 ### Related Rule
 

--- a/rules/do-you-avoid-reviewing-performance-without-metrics/rule.md
+++ b/rules/do-you-avoid-reviewing-performance-without-metrics/rule.md
@@ -70,7 +70,7 @@ This is because performance is an emotional thing, sometimes it just \*feels\* s
 ### Samples
 
 
-For sample code on how to measure performance for Windows application form, please refer to rule [Do you have tests for Performance?](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterUnitTests.aspx#Performance) on [Rules To Better Unit Tests](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterUnitTests.aspx).
+For sample code on how to measure performance for Windows application form, please refer to rule [Do you have tests for Performance?](https://ssw.com.au/rules/have-tests-for-performance/) on [Rules To Better Unit Tests](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterUnitTests.aspx).
 
 ### Related Rule
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️While I was reading the rule and clicked on the link 'Do you have tests for Performance?', I was redirected to the 'Rules to Better Unit Tests' page and remained at the top.

> 2. What was changed?

✏️Updated the link for 'Do you have tests for Performance?'.
