### PR TITLE
XS✔ ◾ Correct invalid archive links

### DIFF
--- a/rules/avoid-using-that-when-its-not-needed/rule.md
+++ b/rules/avoid-using-that-when-its-not-needed/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: superceded by [https://www.ssw.com.au/rules/avoid-using-unnecessary-words](/avoid-using-unnecessary-words)
+archivedreason: superceded by [https://www.ssw.com.au/rules/avoid-using-unnecessary-words](/rules/avoid-using-unnecessary-words)
 title: "Tiny: Do you avoid using \"that\" when it's not needed?"
 guid: d85380af-2f80-49d7-8f24-1e31330de764
 uri: avoid-using-that-when-its-not-needed

--- a/rules/continually-improve-ui/rule.md
+++ b/rules/continually-improve-ui/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: This generic rule has been replaced by [https://www.ssw.com.au/rules/rules-to-better-interfaces-general-usability-practices](/rules-to-better-interfaces-general-usability-practices)
+archivedreason: This generic rule has been replaced by [https://www.ssw.com.au/rules/rules-to-better-interfaces-general-usability-practices](/rules/rules-to-better-interfaces-general-usability-practices)
 title: Do you continually improve the user interface?
 guid: aa867304-2e79-4e25-a9da-622ed3ce7446
 uri: continually-improve-ui

--- a/rules/control-choice-do-you-use-bold-on-the-main-options-to-make-them-clearer/rule.md
+++ b/rules/control-choice-do-you-use-bold-on-the-main-options-to-make-them-clearer/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/highlight-items-in-your-document](/highlight-items-in-your-document)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/highlight-items-in-your-document](/rules/highlight-items-in-your-document)
 title: Control Choice - Do you use bold on the main options to make them clearer?
 guid: 177ecd2f-ec1c-49d2-9758-42352432aea0
 uri: control-choice-do-you-use-bold-on-the-main-options-to-make-them-clearer

--- a/rules/do-you-always-get-your-rules-proof-read/rule.md
+++ b/rules/do-you-always-get-your-rules-proof-read/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/rules-to-better-technical-documentation](/rules-to-better-technical-documentation)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/rules-to-better-technical-documentation](/rules/rules-to-better-technical-documentation)
 title: Do you always get your rules proof read?
 guid: 496e35c0-30d3-4f4e-8b70-58f37251405a
 uri: do-you-always-get-your-rules-proof-read

--- a/rules/do-you-avoid-the-first-person-narrative/rule.md
+++ b/rules/do-you-avoid-the-first-person-narrative/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/web-content-do-you-write-in-the-newsreader-and-eye-witness-style](/web-content-do-you-write-in-the-newsreader-and-eye-witness-style)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/web-content-do-you-write-in-the-newsreader-and-eye-witness-style](/rules/web-content-do-you-write-in-the-newsreader-and-eye-witness-style)
 title: Do you avoid the first person narrative?
 guid: 701d8bf5-410c-45b1-99c4-1b8530145fae
 uri: do-you-avoid-the-first-person-narrative

--- a/rules/do-you-choose-tfs-git-over-team-foundation-source-control/rule.md
+++ b/rules/do-you-choose-tfs-git-over-team-foundation-source-control/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: No longer relevant. See [https://www.ssw.com.au/rules/rules-to-better-version-control-with-git](/rules-to-better-version-control-with-git)
+archivedreason: No longer relevant. See [https://www.ssw.com.au/rules/rules-to-better-version-control-with-git](/rules/rules-to-better-version-control-with-git)
 title: Do You Choose TFS-Git Over Team Foundation Source Control?
 guid: 9a1642c8-3164-49b4-bd21-d81a014df14f
 uri: do-you-choose-tfs-git-over-team-foundation-source-control

--- a/rules/do-you-have-a-demo-script-for-your-sprint-review-meeting/rule.md
+++ b/rules/do-you-have-a-demo-script-for-your-sprint-review-meeting/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: This has been superseded by [https://www.ssw.com.au/rules/meeting-do-you-know-what-to-prepare-for-each-meeting](/meeting-do-you-know-what-to-prepare-for-each-meeting)
+archivedreason: This has been superseded by [https://www.ssw.com.au/rules/meeting-do-you-know-what-to-prepare-for-each-meeting](/rules/meeting-do-you-know-what-to-prepare-for-each-meeting)
 title: Do you have a demo script for your Sprint Review Meeting? *IMPORTANT*
 guid: 68d457fc-1bc4-43df-92b2-574fd22b1b0a
 uri: do-you-have-a-demo-script-for-your-sprint-review-meeting

--- a/rules/do-you-have-a-mobile-friendly-website1/rule.md
+++ b/rules/do-you-have-a-mobile-friendly-website1/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design](/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design](/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design)
 title: Do you have a Mobile friendly website?
 guid: 7bb5a699-0723-43e0-8479-ea6035e3a9e6
 uri: do-you-have-a-mobile-friendly-website1

--- a/rules/do-you-highlight-incomplete-work-with-red-text/rule.md
+++ b/rules/do-you-highlight-incomplete-work-with-red-text/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Covered by [https://www.ssw.com.au/rules/todo-tasks](/todo-tasks)
+archivedreason: Covered by [https://www.ssw.com.au/rules/todo-tasks](/rules/todo-tasks)
 title: Do you highlight incomplete work with red text?
 guid: a45d8542-685d-4774-9f28-da9a5022c75f
 uri: do-you-highlight-incomplete-work-with-red-text

--- a/rules/do-you-know-the-best-way-of-booking-flights/rule.md
+++ b/rules/do-you-know-the-best-way-of-booking-flights/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-know-the-general-tips-for-booking-flights](/do-you-know-the-general-tips-for-booking-flights)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-know-the-general-tips-for-booking-flights](/rules/do-you-know-the-general-tips-for-booking-flights)
 title: Do you know the best way of booking flights?
 guid: fad461f1-6741-4d9d-b5aa-909436afff42
 uri: do-you-know-the-best-way-of-booking-flights

--- a/rules/do-you-know-the-correct-way-to-develop-data-entry-forms/rule.md
+++ b/rules/do-you-know-the-correct-way-to-develop-data-entry-forms/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: This rule has been replaced with [https://www.ssw.com.au/rules/data-entry-forms-for-web](/data-entry-forms-for-web)
+archivedreason: This rule has been replaced with [https://www.ssw.com.au/rules/data-entry-forms-for-web](/rules/data-entry-forms-for-web)
 title: Do you know the correct way to develop Data Entry Forms?
 guid: 98e8f4b2-a989-46a1-bbe7-f453baa414ae
 uri: do-you-know-the-correct-way-to-develop-data-entry-forms

--- a/rules/do-you-know-to-slideshare-your-powerpoint-before-the-presentation/rule.md
+++ b/rules/do-you-know-to-slideshare-your-powerpoint-before-the-presentation/rule.md
@@ -13,7 +13,7 @@ related: []
 redirects:
   - do-you-know-to-slideshare-your-powerpoint-(before-the-presentation)
 created: 2010-10-22T03:28:45.000Z
-archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-keep-your-presentations-in-a-public-location](/do-you-keep-your-presentations-in-a-public-location)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-keep-your-presentations-in-a-public-location](/rules/do-you-keep-your-presentations-in-a-public-location)
 guid: 74d7a85f-9380-4c0c-bd11-c80ad4df475a
 ---
 

--- a/rules/do-you-know-what-a-story-owner-is-responsible-for/rule.md
+++ b/rules/do-you-know-what-a-story-owner-is-responsible-for/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Merged to [https://www.ssw.com.au/rules/tasks-do-you-know-that-every-user-story-should-have-an-owner](/tasks-do-you-know-that-every-user-story-should-have-an-owner)
+archivedreason: Merged to [https://www.ssw.com.au/rules/tasks-do-you-know-that-every-user-story-should-have-an-owner](/rules/tasks-do-you-know-that-every-user-story-should-have-an-owner)
 title: Do you know what a PBI Owner is responsible for?
 guid: 01c06c41-2fac-445d-8858-dc018f9262f4
 uri: do-you-know-what-a-story-owner-is-responsible-for

--- a/rules/do-you-know-when-to-versus-and-verses/rule.md
+++ b/rules/do-you-know-when-to-versus-and-verses/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/avoid-common-mistakes)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/rules/avoid-common-mistakes)
 title: 'Do you know when to use versus and verses?'
 guid: d64f97cc-4c8e-48be-8cbf-79c924d8c385
 uri: do-you-know-when-to-versus-and-verses

--- a/rules/do-you-label-your-example-with-a-tick-cross-followed-by-the-word-figure/rule.md
+++ b/rules/do-you-label-your-example-with-a-tick-cross-followed-by-the-word-figure/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/add-useful-and-concise-figure-captions](/add-useful-and-concise-figure-captions)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/add-useful-and-concise-figure-captions](/rules/add-useful-and-concise-figure-captions)
 title: Do you label your example with a tick/cross followed by the word Figure:?
 guid: f7c03829-af7f-4425-b52a-70c4c3593580
 uri: do-you-label-your-example-with-a-tick-cross-followed-by-the-word-figure

--- a/rules/do-you-make-sure-every-customers-and-prospects-email-is-in-your-company-database/rule.md
+++ b/rules/do-you-make-sure-every-customers-and-prospects-email-is-in-your-company-database/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Deprecated - See [https://www.ssw.com.au/rules/reasons-to-use-dynamics-365-crm ](/reasons-to-use-dynamics-365-crm )
+archivedreason: Deprecated - See [https://www.ssw.com.au/rules/reasons-to-use-dynamics-365-crm ](/rules/reasons-to-use-dynamics-365-crm )
 title: Do you make sure every customers' (and prospects') email is in your company database?
 guid: d754b936-e18d-42b2-a205-6d11c90bc1bb
 uri: do-you-make-sure-every-customers-and-prospects-email-is-in-your-company-database

--- a/rules/do-you-name-your-assemblies-consistently-companyname-componentname/rule.md
+++ b/rules/do-you-name-your-assemblies-consistently-companyname-componentname/rule.md
@@ -21,7 +21,7 @@ redirects:
 Assembly names should reflect the the functionality that it provides. For example,  
 <!--endintro-->
 
-```
+```cs
 System.IO
 ```
 

--- a/rules/do-you-name-your-assemblies-consistently-companyname-componentname/rule.md
+++ b/rules/do-you-name-your-assemblies-consistently-companyname-componentname/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: already covered by rule [https://www.ssw.com.au/rules/do-you-have-a-consistent-net-solution-structure](/do-you-have-a-consistent-net-solution-structure)
+archivedreason: already covered by rule [https://www.ssw.com.au/rules/do-you-have-a-consistent-net-solution-structure](/rules/do-you-have-a-consistent-net-solution-structure)
 title: Do you name your assemblies consistently (<CompanyName>.<ComponentName>)?
 guid: 30f404cf-bad3-4fee-8afd-c2e6a93635ca
 uri: do-you-name-your-assemblies-consistently-companyname-componentname

--- a/rules/do-you-pursue-short-or-long-term-relationships-with-clients/rule.md
+++ b/rules/do-you-pursue-short-or-long-term-relationships-with-clients/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: It is already covered by [https://www.ssw.com.au/rules/conduct-a-spec-review](/conduct-a-spec-review)
+archivedreason: It is already covered by [https://www.ssw.com.au/rules/conduct-a-spec-review](/rules/conduct-a-spec-review)
 title: Do you pursue short or long-term relationships with clients?
 guid: 8fd23958-f42d-42de-8c0e-67030c5cee9b
 uri: do-you-pursue-short-or-long-term-relationships-with-clients

--- a/rules/do-you-send-out-an-email-summary-after-each-meeting/rule.md
+++ b/rules/do-you-send-out-an-email-summary-after-each-meeting/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/share-the-action-items-that-came-up](/share-the-action-items-that-came-up)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/share-the-action-items-that-came-up](/rules/share-the-action-items-that-came-up)
 title: Do you send out an email summary after each meeting?
 guid: 853e5107-cffb-46a0-85f8-375095ef6313
 uri: do-you-send-out-an-email-summary-after-each-meeting

--- a/rules/do-you-underline-links-and-include-a-rollover/rule.md
+++ b/rules/do-you-underline-links-and-include-a-rollover/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Duplicate of [https://www.ssw.com.au/rules/do-you-use-underlines-only-on-links](/do-you-use-underlines-only-on-links)
+archivedreason: Duplicate of [https://www.ssw.com.au/rules/do-you-use-underlines-only-on-links](/rules/do-you-use-underlines-only-on-links)
 title: Do you underline links (and include a rollover)?
 guid: aaef4269-0a29-4752-b3eb-a6920b9bd373
 uri: do-you-underline-links-and-include-a-rollover

--- a/rules/do-you-underline-links-and-include-a-rollover/rule.md
+++ b/rules/do-you-underline-links-and-include-a-rollover/rule.md
@@ -35,7 +35,7 @@ Good Example: Obvious rollover. You can test it by hovering the links on the exa
 
 Example CSS for rollover:
 
-```
+```css
 a:hover { 
     color: #cc4141;
     cursor: pointer;

--- a/rules/do-you-use-a-single-general-bit-ly-account-for-all-shortening-in-your-company-department/rule.md
+++ b/rules/do-you-use-a-single-general-bit-ly-account-for-all-shortening-in-your-company-department/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: This rule has been merged as a "Tip" to [https://www.ssw.com.au/rules/do-you-use-bit-ly-to-manage-your-url-shortening](/do-you-use-bit-ly-to-manage-your-url-shortening)
+archivedreason: This rule has been merged as a "Tip" to [https://www.ssw.com.au/rules/do-you-use-bit-ly-to-manage-your-url-shortening](/rules/do-you-use-bit-ly-to-manage-your-url-shortening)
 title: Do you use a single general bit.ly account for all shortening in your company/department?
 guid: 88bc3862-272f-469c-8021-9e91b4ea8d13
 uri: do-you-use-a-single-general-bit-ly-account-for-all-shortening-in-your-company-department

--- a/rules/do-you-use-and-indentation-to-keep-the-context/rule.md
+++ b/rules/do-you-use-and-indentation-to-keep-the-context/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Merged with [https://www.ssw.com.au/rules/do-you-use-indentation-for-readability](/do-you-use-indentation-for-readability)
+archivedreason: Merged with [https://www.ssw.com.au/rules/do-you-use-indentation-for-readability](/rules/do-you-use-indentation-for-readability)
 title: Do you use > and indentation to keep the context?
 guid: 60f5de4c-c42c-41ff-8e48-3646b4347e31
 uri: do-you-use-and-indentation-to-keep-the-context

--- a/rules/do-you-use-exploratory-testing-to-create-acceptance-tests/rule.md
+++ b/rules/do-you-use-exploratory-testing-to-create-acceptance-tests/rule.md
@@ -9,7 +9,7 @@ related:
   - do-you-do-exploratory-testing
 redirects: []
 created: 2013-08-07T22:15:34.000Z
-archivedreason: "Microsoft Test Manager has been deprecated. Learn how to use the \"Test & Feedback\" extension for exploratory testing: [https://www.ssw.com.au/rules/do-you-do-exploratory-testing](/do-you-do-exploratory-testing)"
+archivedreason: "Microsoft Test Manager has been deprecated. Learn how to use the \"Test & Feedback\" extension for exploratory testing: [https://www.ssw.com.au/rules/do-you-do-exploratory-testing](/rules/do-you-do-exploratory-testing)"
 guid: fb39e79c-8749-4467-9327-518a768b0495
 ---
 

--- a/rules/do-you-use-expression-blend-sketchflow-to-create-mock-ups/rule.md
+++ b/rules/do-you-use-expression-blend-sketchflow-to-create-mock-ups/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/software-for-product-design](/software-for-product-design)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/software-for-product-design](/rules/software-for-product-design)
 title: Do you use Expression Blend + SketchFlow to create mock-ups?
 guid: ca54288b-c4f7-4894-bd83-c9df5902ee98
 uri: do-you-use-expression-blend-sketchflow-to-create-mock-ups

--- a/rules/do-you-use-hibernate/rule.md
+++ b/rules/do-you-use-hibernate/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Duplicate of [https://www.ssw.com.au/rules/do-you-use-suspend-on-your-notebook](/do-you-use-suspend-on-your-notebook)
+archivedreason: Duplicate of [https://www.ssw.com.au/rules/do-you-use-suspend-on-your-notebook](/rules/do-you-use-suspend-on-your-notebook)
 title: Do you use Hibernate?
 guid: 63b1412c-fd4d-431e-affd-b5cc47d43202
 uri: do-you-use-hibernate

--- a/rules/do-you-use-note-instead-of-nb/rule.md
+++ b/rules/do-you-use-note-instead-of-nb/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: superseded by [https://www.ssw.com.au/rules/avoid-acronyms](/avoid-acronyms)
+archivedreason: superseded by [https://www.ssw.com.au/rules/avoid-acronyms](/rules/avoid-acronyms)
 title: 'Do you use "Note" instead of "NB"?'
 guid: 343e5d79-2eea-4374-9b57-b178250ed5b4
 uri: do-you-use-note-instead-of-nb

--- a/rules/do-you-use-setfocusonerror-on-controls-that-fail-validation/rule.md
+++ b/rules/do-you-use-setfocusonerror-on-controls-that-fail-validation/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Merged to [https://www.ssw.com.au/rules/validation-do-you-put-focus-to-the-correct-control-on-validation-error](/validation-do-you-put-focus-to-the-correct-control-on-validation-error)
+archivedreason: Merged to [https://www.ssw.com.au/rules/validation-do-you-put-focus-to-the-correct-control-on-validation-error](/rules/validation-do-you-put-focus-to-the-correct-control-on-validation-error)
 title: Do you use SetFocusOnError on controls that fail validation?
 guid: 1fbc2d66-ec18-41b6-b995-82d097adb36f
 uri: do-you-use-setfocusonerror-on-controls-that-fail-validation

--- a/rules/do-you-use-the-search-tool-to-find-emails-in-outlook/rule.md
+++ b/rules/do-you-use-the-search-tool-to-find-emails-in-outlook/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/searching-outlook-effectively](/searching-outlook-effectively)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/searching-outlook-effectively](/rules/searching-outlook-effectively)
 title: Do you use the search tool to find emails in Outlook?
 guid: 6ca4add1-625c-4cb1-88b5-57a0e8d1f2a3
 uri: do-you-use-the-search-tool-to-find-emails-in-outlook

--- a/rules/does-your-applications-interface-fit-in-a-small-screen-resolution/rule.md
+++ b/rules/does-your-applications-interface-fit-in-a-small-screen-resolution/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design](/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design](/rules/design-web-pages-to-work-on-mobile-and-tablets-screens-aka-responsive-web-design)
 title: Does your application's interface fit in a small screen resolution?
 guid: 2e41f20a-377a-4142-95c7-b64cd5177871
 uri: does-your-applications-interface-fit-in-a-small-screen-resolution

--- a/rules/generate-ai-images/rule.md
+++ b/rules/generate-ai-images/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/rules-to-better-ai-image-generators/](/rules-to-better-ai-image-generators)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/rules-to-better-ai-image-generators/](/rules/rules-to-better-ai-image-generators)
 title: Do you know how and when to use AI generated images?
 guid: 61b75416-bbae-4aac-a929-c51e46ac7fb3
 uri: generate-ai-images

--- a/rules/less-is-more-do-you-realize-that-when-it-comes-to-interface-design-less-is-more/rule.md
+++ b/rules/less-is-more-do-you-realize-that-when-it-comes-to-interface-design-less-is-more/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/less-is-more](/less-is-more)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/less-is-more](/rules/less-is-more)
 title: Windows Forms - Do you realize that when it comes to interfaces 'less is more'?
 guid: 0505dd41-16a8-4b0d-8768-c4d76bd4e03e
 uri: less-is-more-do-you-realize-that-when-it-comes-to-interface-design-less-is-more

--- a/rules/management-do-you-use-xp-scrum-wisely/rule.md
+++ b/rules/management-do-you-use-xp-scrum-wisely/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-know-the-8-steps-to-scrum](/do-you-know-the-8-steps-to-scrum)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/do-you-know-the-8-steps-to-scrum](/rules/do-you-know-the-8-steps-to-scrum)
 title: Management - Do you use XP/Scrum wisely?
 guid: 159c6af7-7619-4f1c-8b15-63a99398b1bc
 uri: management-do-you-use-xp-scrum-wisely

--- a/rules/maximum-row-size-for-a-table/rule.md
+++ b/rules/maximum-row-size-for-a-table/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Duplicate of [https://ssw.com.au/rules/only-use-unicode-datatypes-in-special-circumstances](/only-use-unicode-datatypes-in-special-circumstances)
+archivedreason: Duplicate of [https://ssw.com.au/rules/only-use-unicode-datatypes-in-special-circumstances](/rules/only-use-unicode-datatypes-in-special-circumstances)
 title: Schema - Do you know the maximum row size for a table?
 guid: 80b9232f-ae71-436d-bd11-91b6d9530f67
 uri: maximum-row-size-for-a-table

--- a/rules/meetings-do-you-ask-clients-the-two-important-questions-at-the-beginning-of-each-meeting/rule.md
+++ b/rules/meetings-do-you-ask-clients-the-two-important-questions-at-the-beginning-of-each-meeting/rule.md
@@ -6,7 +6,7 @@ authors: []
 related: []
 redirects: []
 created: 2010-07-16T06:26:46.000Z
-archivedreason: Replaced by [https://www.ssw.com.au/rules/share-the-agenda and https://www.ssw.com.au/rules/start-and-finish-on-time](/share-the-agenda and https://www.ssw.com.au/rules/start-and-finish-on-time)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/share-the-agenda](/rules/share-the-agenda) and [https://www.ssw.com.au/rules/start-and-finish-on-time](/rules/start-and-finish-on-time)
 guid: a66eec23-db4f-4e2d-909e-353df8486e4b
 ---
 

--- a/rules/never-share-passwords/rule.md
+++ b/rules/never-share-passwords/rule.md
@@ -1,5 +1,5 @@
 ---
-archivedreason: This is too basic. Follow [https://www.ssw.com.au/rules/rules-to-better-security-end-users instead.](/rules-to-better-security-end-users instead.)
+archivedreason: This is too basic. Follow [https://www.ssw.com.au/rules/rules-to-better-security-end-users](/rules/rules-to-better-security-end-users) instead.
 type: rule
 title: Passwords - Do you know to NEVER share your password?
 uri: never-share-passwords

--- a/rules/post-production-do-you-add-content-to-youtube-to-feed-traffic-to-your-other-sites/rule.md
+++ b/rules/post-production-do-you-add-content-to-youtube-to-feed-traffic-to-your-other-sites/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Old content. See the rule [https://www.ssw.com.au/rules/videos-youtube-friendly about having shorter videos over larger ones](/videos-youtube-friendly about having shorter videos over larger ones)
+archivedreason: Old content. See the rule [https://www.ssw.com.au/rules/videos-youtube-friendly](/rules/videos-youtube-friendly) about having shorter videos over larger ones
 title: Post-Production - Do you add content to YouTube to feed traffic to your other sites?
 guid: b47a2051-826e-49d1-b1de-6683e045c863
 uri: post-production-do-you-add-content-to-youtube-to-feed-traffic-to-your-other-sites

--- a/rules/production-do-you-know-the-best-way-to-end-a-video/rule.md
+++ b/rules/production-do-you-know-the-best-way-to-end-a-video/rule.md
@@ -8,7 +8,7 @@ authors:
 related: []
 redirects: []
 created: 2011-10-19T15:48:28.000Z
-archivedreason: Replaced by [https://www.ssw.com.au/rules/production-do-you-add-a-call-to-action](/production-do-you-add-a-call-to-action)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/production-do-you-add-a-call-to-action](/rules/production-do-you-add-a-call-to-action)
 guid: 28d64ecd-0582-42c6-bf7a-f3f9ae6c17b8
 ---
 The ending of your video should contain a [call to action](/production-do-you-add-a-call-to-action), the logo of your company and a sign off from the speaker(s).

--- a/rules/the-right-mobile-tool-for-the-job/rule.md
+++ b/rules/the-right-mobile-tool-for-the-job/rule.md
@@ -9,7 +9,7 @@ related: []
 redirects:
   - do-you-know-the-right-mobile-tool-for-the-job
 created: 2017-06-26T22:09:02.000Z
-archivedreason: Replaced by [https://www.ssw.com.au/rules/net-maui-for-xplat-ui](/net-maui-for-xplat-ui)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/net-maui-for-xplat-ui](/rules/net-maui-for-xplat-ui)
 guid: dd8aa892-630e-4ab1-98c8-882af18c4374
 ---
 

--- a/rules/transcribe-videos/rule.md
+++ b/rules/transcribe-videos/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Merged to [https://www.ssw.com.au/rules/transcribe-your-videos](/transcribe-your-videos)
+archivedreason: Merged to [https://www.ssw.com.au/rules/transcribe-your-videos](/rules/transcribe-your-videos)
 title: Do you transcribe your videos for Google juice?
 guid: a0832aba-1281-40f5-8375-cae0afe6e02d
 uri: transcribe-videos

--- a/rules/use-net-maui/rule.md
+++ b/rules/use-net-maui/rule.md
@@ -12,7 +12,7 @@ redirects:
   - do-you-use-xamarin-forms
   - use-xamarin-forms
 created: 2020-10-05T22:18:32.000Z
-archivedreason: Replaced by [https://www.ssw.com.au/rules/build-cross-platform-apps](/build-cross-platform-apps)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/build-cross-platform-apps](/rules/build-cross-platform-apps)
 guid: 954d9b68-7185-472b-917c-407aa1a7df26
 ---
 Xamarin has evolved beyond simply being an abstraction of the platform native APIs for iOS, Android, and UWP. It is now the .NET Multi-platform App UI (.NET MAUI).

--- a/rules/use-setup-and-set-up-correctly/rule.md
+++ b/rules/use-setup-and-set-up-correctly/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/avoid-common-mistakes)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/rules/avoid-common-mistakes)
 title: 'Do you use "setup" and "set up" correctly?'
 guid: 71f9cfe5-82fd-455b-8b62-83dcddbd7a61
 uri: use-setup-and-set-up-correctly

--- a/rules/use-taskbar-instead-of-task-bar/rule.md
+++ b/rules/use-taskbar-instead-of-task-bar/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/avoid-common-mistakes)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/rules/avoid-common-mistakes)
 title: 'Do you use "Taskbar" instead of "Task bar"?'
 guid: f684c02d-8d04-43b4-914e-afba61ddb821
 uri: use-taskbar-instead-of-task-bar

--- a/rules/use-username-instead-of-user-name/rule.md
+++ b/rules/use-username-instead-of-user-name/rule.md
@@ -7,7 +7,7 @@ authors:
     url: https://www.ssw.com.au/people/adam-cogan
 created: 2022-06-01T18:20:22.290Z
 guid: 851e99f3-44e5-48e6-98e7-7e55eb57421a
-archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/avoid-common-mistakes)
+archivedreason: Replaced by [https://www.ssw.com.au/rules/avoid-common-mistakes](/rules/avoid-common-mistakes)
 
 ---
 This is a common item that trips people up: "Username" is one word, not two.

--- a/rules/using-field-validation/rule.md
+++ b/rules/using-field-validation/rule.md
@@ -9,7 +9,7 @@ related: []
 redirects: 
   - validation-do-you-put-focus-to-the-correct-control-on-validation-error
 created: 2012-11-27T09:05:50.000Z
-archivedreason: The rule has been made redundant by [Do you know the correct way to develop web-based data entry forms](/data-entry-forms-for-web/)
+archivedreason: The rule has been made redundant by [Do you know the correct way to develop web-based data entry forms](/rules/data-entry-forms-for-web/)
 guid: 43f993e2-8b11-4969-a246-a6bdd2679fb3
 ---
 Most fields require validation. There are three types of validation:

--- a/rules/when-to-use-react/rule.md
+++ b/rules/when-to-use-react/rule.md
@@ -1,6 +1,6 @@
 ---
 type: rule
-archivedreason: See [https://www.ssw.com.au/rules/rules-to-better-react](/rules-to-better-react)
+archivedreason: See [https://www.ssw.com.au/rules/rules-to-better-react](/rules/rules-to-better-react)
 title: Do you know when to use React?
 guid: f3b854c5-1fcd-47b4-9925-d452a8e83643
 uri: when-to-use-react


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed that I could not access current rules from archived items.

> 2. What was changed?

Relative links in the `archivedreason` field of archived rules were updated to ensure that they had "/rules/" in their path and that only URLs were provided between the brackets. This allows the links to function correctly.

> 3. Did you do pair or mob programming (list names)?

No
