### PR TITLE
Add related rules

### DIFF
--- a/rules/awesome-documentation/rule.md
+++ b/rules/awesome-documentation/rule.md
@@ -28,6 +28,7 @@ related:
   - user-journey-mapping
   - package-audit-log
   - technical-debt
+  - do-you-use-architectural-decision-records
 redirects:
   - do-you-review-the-documentation
   - do-you-make-awesome-documentation

--- a/rules/do-you-use-architectural-decision-records/rule.md
+++ b/rules/do-you-use-architectural-decision-records/rule.md
@@ -9,6 +9,7 @@ related:
   - checked-by-xxx
   - conduct-a-test-please
   - over-the-shoulder
+  - awesome-documentation
 created: 2023-06-26T06:03:20.995Z
 guid: a131455c-96db-4c0d-829c-20a506c1bcc8
 ---


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️As per conversation with @danielmackay, we wanted to add ADRs as a Related Rule to the Awesome Documentation Rule and, at the same time, add Awesome Documentation as a Related Rule to the ADRs Rule.

> 2. What was changed?

✏️
1. Added ADRs as a Related Rule to the Awesome Documentation Rule
2. Added Awesome Documentation as a Related Rule to the ADRs Rule