### PR TITLE
XS✔ ◾ Migration tools update

### DIFF
--- a/rules/tools-database-schema-changes/rule.md
+++ b/rules/tools-database-schema-changes/rule.md
@@ -27,14 +27,14 @@ In the fast-evolving world of software development, it's crucial for your databa
 
 <!--endintro-->
 
-### ✅ Recommended Tools for Database Schema Updates:
+### ✅ Recommended Tools for Database Schema Updates
 
 * [Entity Framework Core Migrations](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/): EF Core Migrations has become the de facto standard for managing database schema changes. It offers robust, integrated support for versioning and deploying database changes, making it the preferred choice for both new and existing projects.
 
 * [DAC Support For SQL Server Objects and Versions](https://learn.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-ver16) (.dacpac files):  Still relevant for SQL Server database management, particularly in complex deployment scenarios.
 
+### ❌ Not Recommended
 
-### ❌ Not Recommended: 
 These methods are outdated and lack the comprehensive features required for modern database schema management, With no ability to validate that the database hasn't been tampered with:
 
 * [SQL Deploy](http://sqldeploy.com/) (This is the suggested tool if you are not using Entity Framework Code First)

--- a/rules/tools-database-schema-changes/rule.md
+++ b/rules/tools-database-schema-changes/rule.md
@@ -28,7 +28,8 @@ In the fast-evolving world of software development, it's crucial for your databa
 
 ### ✅ Recommended Tools for Database Schema Updates:
 
-* [Entity Framework Core Migrations](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/): With the introduction of .NET 8, EF Core Migrations has become the de facto standard for managing database schema changes. It offers robust, integrated support for versioning and deploying database changes, making it the preferred choice for both new and existing projects.
+* [Entity Framework Core Migrations](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/): EF Core Migrations has become the de facto standard for managing database schema changes. It offers robust, integrated support for versioning and deploying database changes, making it the preferred choice for both new and existing projects.
+
 :::
 
 ``` cs
@@ -62,19 +63,17 @@ public partial class AddUserTable : Migration
 ::: good
 Figure: Good example - EF Core Migration in a .NET 8 project
 :::
+
 * [DAC Support For SQL Server Objects and Versions](https://learn.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-ver16) (.dacpac files):  Still relevant for SQL Server database management, particularly in complex deployment scenarios.
 
 
-### ❌ Legacy full framework:
+### ❌ Not Recommended: 
+These methods are outdated and lack the comprehensive features required for modern database schema management, With no ability to validate that the database hasn't been tampered with:
 
 * [SQL Deploy](http://sqldeploy.com/) (This is the suggested tool if you are not using Entity Framework Code First)
 * [DbUp](https://dbup.readthedocs.io/en/latest/) + [SQL verify](https://www.nuget.org/packages/SSW.SqlVerify.Core/)
 * [Navicat for MySQL](https://navicat.com/manual/online_manual/en/navicat/win_manual/#/structure_sync)
 * [DataGrip](https://www.jetbrains.com/help/datagrip/differences-viewer-for-routines.html)
-
-### ❌ Not Recommended: 
-These methods are outdated and lack the comprehensive features required for modern database schema management, With no ability to validate that the database hasn't been tampered with:
-
 * SQL Management Studio + OSQL  (Free and roll your own)
 * Visual Studio + [SQL Server Data Tools](https://visualstudio.microsoft.com/vs/features/ssdt/) (Formerly Data Dude) + Deploy (post-development model)
 * Red Gate SQL Compare + Red Gate SQL Packager (post-development model)
@@ -100,7 +99,7 @@ CREATE TABLE OrderItems (
 
 ```
 ::: bad  
-Figure: Bad example - Schema Migration with SQL Script
+Figure: Bad example - Schema Migration with manually created SQL Script
 :::
 
 ``` cs

--- a/rules/tools-database-schema-changes/rule.md
+++ b/rules/tools-database-schema-changes/rule.md
@@ -15,6 +15,7 @@ authors:
     url: https://ssw.com.au/people/brendan-richards
 related:
   - the-application-do-you-make-sure-that-the-database-structure-is-handled-automatically-via-3-buttons-create-upgrade-and-reconcile
+  - use-code-migrations
 redirects:
   - do-you-know-the-tools-that-can-help
   - do-you-know-the-best-tools-for-database-schema-update
@@ -30,40 +31,6 @@ In the fast-evolving world of software development, it's crucial for your databa
 
 * [Entity Framework Core Migrations](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/): EF Core Migrations has become the de facto standard for managing database schema changes. It offers robust, integrated support for versioning and deploying database changes, making it the preferred choice for both new and existing projects.
 
-:::
-
-``` cs
-// Example of EF Core Migration in a .NET 8 project
-public partial class AddUserTable : Migration
-{
-    protected override void Up(MigrationBuilder migrationBuilder)
-    {
-        migrationBuilder.CreateTable(
-            name: "Users",
-            columns: table => new
-            {
-                Id = table.Column<int>(nullable: false)
-                    .Annotation("SqlServer:Identity", "1, 1"),
-                Name = table.Column<string>(nullable: true)
-            },
-            constraints: table =>
-            {
-                table.PrimaryKey("PK_Users", x => x.Id);
-            });
-    }
-
-    protected override void Down(MigrationBuilder migrationBuilder)
-    {
-        migrationBuilder.DropTable(
-            name: "Users");
-    }
-}
-
-```
-::: good
-Figure: Good example - EF Core Migration in a .NET 8 project
-:::
-
 * [DAC Support For SQL Server Objects and Versions](https://learn.microsoft.com/en-us/sql/relational-databases/data-tier-applications/data-tier-applications?view=sql-server-ver16) (.dacpac files):  Still relevant for SQL Server database management, particularly in complex deployment scenarios.
 
 
@@ -77,59 +44,3 @@ These methods are outdated and lack the comprehensive features required for mode
 * SQL Management Studio + OSQL  (Free and roll your own)
 * Visual Studio + [SQL Server Data Tools](https://visualstudio.microsoft.com/vs/features/ssdt/) (Formerly Data Dude) + Deploy (post-development model)
 * Red Gate SQL Compare + Red Gate SQL Packager (post-development model)
-
-``` sql
-CREATE TABLE Users (
-    UserId INT PRIMARY KEY IDENTITY,
-    Name NVARCHAR(100) NOT NULL
-);
-CREATE TABLE Orders (
-    OrderId INT PRIMARY KEY IDENTITY,
-    OrderDate DATETIME NOT NULL,
-    UserId INT NOT NULL,
-    FOREIGN KEY (UserId) REFERENCES Users(UserId)
-);
-CREATE TABLE OrderItems (
-    OrderItemId INT PRIMARY KEY IDENTITY,
-    Quantity INT NOT NULL,
-    Price DECIMAL(18, 2) NOT NULL,
-    OrderId INT NOT NULL,
-    FOREIGN KEY (OrderId) REFERENCES Orders(OrderId)
-);
-
-```
-::: bad  
-Figure: Bad example - Schema Migration with manually created SQL Script
-:::
-
-``` cs
-public class User
-{
-    public int UserId { get; set; }
-    public string Name { get; set; }
-    public List<Order> Orders { get; set; }
-}
-public class Order
-{
-    public int OrderId { get; set; }
-    public DateTime OrderDate { get; set; }
-    public int UserId { get; set; }
-    public User User { get; set; }
-    public List<OrderItem> OrderItems { get; set; }
-}
-public class OrderItem
-{
-    public int OrderItemId { get; set; }
-    public int Quantity { get; set; }
-    public decimal Price { get; set; }
-    public int OrderId { get; set; }
-    public Order Order { get; set; }
-}
-```
-``` bash
-dotnet ef migrations add CreateOrdersSchema
-dotnet ef database update
-```
-::: good
-Figure: Good example - Schema Migration with EF Core Migrations
-:::

--- a/rules/use-code-migrations/rule.md
+++ b/rules/use-code-migrations/rule.md
@@ -18,8 +18,8 @@ Entity Framework Code First Migrations allow you to update a database schema rat
 <!--endintro-->
 
 ## Database Schema Management Options
-Managing database schemas effectively is crucial for the smooth operation and evolution of software applications. For more options to manage database schemas, see [Do you know the best tools for updating database schemas?](https://rules.ssw.com.au/tools-database-schema-changes).
 
+Managing database schemas effectively is crucial for the smooth operation and evolution of software applications. For more options to manage database schemas, see [Do you know the best tools for updating database schemas?](https://rules.ssw.com.au/tools-database-schema-changes).
 
 ## Configuring Entity Framework Code First Migrations
 
@@ -37,7 +37,9 @@ The following assumes you have an existing project with a database context, enti
     ```bash
     dotnet ef migrations add InitialCreate
     ```
+
     This will create a migration file in your project.  This file contains the code to create the database schema.
+
     ``` cs
     // Example of EF Core Migration in a .NET 8 project
     public partial class AddUserTable : Migration

--- a/rules/use-code-migrations/rule.md
+++ b/rules/use-code-migrations/rule.md
@@ -5,7 +5,8 @@ uri: use-code-migrations
 authors:
   - title: Daniel Mackay
     url: https://www.ssw.com.au/people/daniel-mackay  
-related: []
+related: 
+    - tools-database-schema-changes
 created: 2021-12-13T17:27:38.786Z
 guid: 8284cedd-8eea-4e3b-b04b-451896a615c0
 ---
@@ -17,11 +18,8 @@ Entity Framework Code First Migrations allow you to update a database schema rat
 <!--endintro-->
 
 ## Database Schema Management Options
+Managing database schemas effectively is crucial for the smooth operation and evolution of software applications. For more options to manage database schemas, see [Do you know the best tools for updating database schemas?](https://rules.ssw.com.au/tools-database-schema-changes).
 
-1. Manually modify the database schema (not recommended)
-2. Manually creating SQL scripts (not recommended)
-3. DB Up
-4. Entity Framework Code First Migrations (recommended)
 
 ## Configuring Entity Framework Code First Migrations
 
@@ -38,6 +36,35 @@ The following assumes you have an existing project with a database context, enti
 
     ```bash
     dotnet ef migrations add InitialCreate
+    ```
+    This will create a migration file in your project.  This file contains the code to create the database schema.
+    ``` cs
+    // Example of EF Core Migration in a .NET 8 project
+    public partial class AddUserTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+
     ```
 
 3. Update database


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

A conversation with Adam about the progress of TimePro in the DB management migration (DbUp -> Ef core)

> 2. What was changed?

Changes to make DbUp no longer a recommended option. I also linked relevant rules to make sure that there is no duplicate information

https://www.ssw.com.au/rules/use-code-migrations/
https://www.ssw.com.au/rules/tools-database-schema-changes/

> 3. Did you do pair or mob programming (list names)?

I worked with @danielmackay 
