### PR TITLE
XS✔ ◾ Remove link to Design Time Data rule

### DIFF
--- a/rules/use-hot-reload/rule.md
+++ b/rules/use-hot-reload/rule.md
@@ -20,13 +20,11 @@ Developing mobile apps presents unique challenges compared to web or desktop dev
 
 <!--endintro-->
 
-
 ::: bad  
 ![Figure: Bad Example - rebuilding your app every time to see small UI changes](hot-reload-bad.png)  
 :::
 
 To get around this problem use Hot Reload. This lets you make changes to your XAML while debugging your app - as soon as you save your UI will update, without having to stop and rebuild your app.
-
 
 ::: good  
 ![Figure: Good example - hot reload enable screenshot Windows](hot-reload-good.png)  

--- a/rules/use-hot-reload/rule.md
+++ b/rules/use-hot-reload/rule.md
@@ -25,8 +25,6 @@ Developing mobile apps presents unique challenges compared to web or desktop dev
 ![Figure: Bad Example - rebuilding your app every time to see small UI changes](hot-reload-bad.png)  
 :::
 
-This problem is partially solved by Design Time Data (see rule: [Do you use design time data?](/use-design-time-data)), but this still doesn't show you how things change as you interact with them.
-
 To get around this problem use Hot Reload. This lets you make changes to your XAML while debugging your app - as soon as you save your UI will update, without having to stop and rebuild your app.
 
 


### PR DESCRIPTION
XAML Previewer is deprecated

**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Outdated

> 2. What was changed?

✏️ Removed the link to the Design Time Data rule

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
