### PR TITLE
XS✔ ◾ Update rules-for-error-handling.md - says error instead of application wrong meaning

### DIFF
--- a/categories/software-development/rules-for-error-handling.md
+++ b/categories/software-development/rules-for-error-handling.md
@@ -17,9 +17,9 @@ index:
 
 ---
 
-We're all aware how painful it can be when you see a nasty error message. In the best case it makes you feel uneasy and at worst it leaves you blocked. 
+We're all aware how painful it can be when you see a nasty error message. In the best case it makes you feel uneasy and at worst it leaves you blocked.
 
-The user experience should not be an incredibly jarring jumble of text that looks like it is designed for a computer 🤢. On the other hand, a developer should not be developing new features when they are oblivious to the unhealthy state of the application. 
+The user experience should not be an incredibly jarring jumble of text that looks like it is designed for a computer 🤢. On the other hand, a developer should not be developing new features when they are oblivious to the unhealthy state of the application.
 
 For developers, it is crucial to log errors, watch them daily and review the health of the application in the Sprint Review.
 

--- a/categories/software-development/rules-for-error-handling.md
+++ b/categories/software-development/rules-for-error-handling.md
@@ -21,7 +21,7 @@ We're all aware how painful it can be when you see a nasty error message. In the
 
 The user experience should not be an incredibly jarring jumble of text that looks like it is designed for a computer 🤢. On the other hand, a developer should not be developing new features when they are oblivious to the unhealthy state of the application. 
 
-For developers, it is crucial to log errors, watch them daily and review the health of the errors in the Sprint Review.
+For developers, it is crucial to log errors, watch them daily and review the health of the application in the Sprint Review.
 
 Let's jump in and look at some of the best practices.
 


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ In the text it says `For developers, it is crucial to log errors, watch them daily and review the health of the errors in the Sprint Review.` this gives the wrong meaning. here it should be `health of the application`.

> 2. What was changed?

✏️ text - semantic change.

> 3. Did you do pair or mob programming (list names)?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
