### PR TITLE
Add 'Sample Names' prefix to consistent examples rule

### DIFF
--- a/rules/use-generic-consistent-names-on-examples/rule.md
+++ b/rules/use-generic-consistent-names-on-examples/rule.md
@@ -16,7 +16,7 @@ redirects:
 
 ---
 
-It is a good idea to create a dummy company to represent all clients on internal/external documentation, including a made-up name for the person behind that company. 
+It is a good idea to create a dummy company to represent all clients on internal/external documentation, including a made-up name for the person behind that company.
 
 For example, anytime you need to show a scenario of dealing with clients, use the made-up company called "Northwind" which is managed by the also made-up client "Mr. Bob Northwind", often referred to as just "Bob".
 
@@ -36,7 +36,7 @@ Bad example - Using real people and real companies as examples
 :::
 
 ::: greybox
-**Hi Bob,** 
+**Hi Bob,**
 
 We need to make sure the project **Northwind app** will be approved before summer.
 

--- a/rules/use-generic-consistent-names-on-examples/rule.md
+++ b/rules/use-generic-consistent-names-on-examples/rule.md
@@ -1,7 +1,7 @@
 ---
 type: rule
 archivedreason: 
-title: Do you use generic and consistent names on examples?
+title: Sample Names - Do you use generic and consistent names on examples?
 guid: 19282a32-6634-44d7-950b-778d25b7f060
 uri: use-generic-consistent-names-on-examples
 created: 2019-04-23T20:09:58.0000000Z


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Requested in email "Rules - Do you use generic and consistent names on examples? | SSW.Rules" from @adamcogan

> 2. What was changed?

The prefix "Sample Names" was added to the rule.

> 3. Did you do pair or mob programming (list names)?

No - not required.
