### PR TITLE
Updated Rule “clean-git-history/rule” to include paragraph about descriptive commit messages

### DIFF
--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -71,7 +71,7 @@ Figure: Good example
 
 It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
 
-For more information about writing descriptive commit messages see this [rule](https://www.ssw.com.au/rules/use-emojis-in-your-commits/).
+For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](rules/use-emojis-in-your-commits/).
 ## Conclusion
 
 Maintaining a clean git history is important for readability and understanding the changes that have been made to a codebase over the lifetime of the repository.

--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -71,7 +71,7 @@ Figure: Good example
 
 It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
 
-For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](use-emojis-in-your-commits).
+Read more about [writing descriptive commit messages](use-emojis-in-your-commits).
 ## Conclusion
 
 Maintaining a clean git history is important for readability and understanding the changes that have been made to a codebase over the lifetime of the repository.

--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -71,7 +71,7 @@ Figure: Good example
 
 It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
 
-For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](use-emojis-in-your-commits/).
+For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](use-emojis-in-your-commits).
 ## Conclusion
 
 Maintaining a clean git history is important for readability and understanding the changes that have been made to a codebase over the lifetime of the repository.

--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -8,8 +8,8 @@ authors:
   - title: Daniel Mackay
     url: https://ssw.com.au/people/daniel-mackay
 related:
-    - use-squash-and-merge-for-open-source-projects
-    - write-a-good-pull-request
+  - use-squash-and-merge-for-open-source-projects
+  - write-a-good-pull-request
 redirects: []
 created: 2024-02-22T00:00:00.000Z
 guid: af3e6656-97b6-424c-b608-be3dd004ba89
@@ -67,7 +67,11 @@ It's important when combining git repositories that you bring all the history wi
 :::good
 Figure: Good example
 :::
+## Descriptive commit messages
 
+It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
+
+For more information about writing descriptive commit messages see this [rule](https://www.ssw.com.au/rules/use-emojis-in-your-commits/).
 ## Conclusion
 
 Maintaining a clean git history is important for readability and understanding the changes that have been made to a codebase over the lifetime of the repository.

--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -67,7 +67,7 @@ It's important when combining git repositories that you bring all the history wi
 :::good
 Figure: Good example
 :::
-## Descriptive commit messages
+## Writing descriptive commit messages
 
 It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
 

--- a/rules/clean-git-history/rule.md
+++ b/rules/clean-git-history/rule.md
@@ -71,7 +71,7 @@ Figure: Good example
 
 It's important to have descriptive names for commits so that you can easily keep track of what was achieved after each commit was applied. Knowing what was achieved when the commits were made will make it easier to retroactively squash related commits as you'll know what work was done. In addition having descriptive commit messages makes it easier for a reviewer to see what you were trying to achieve in your pull request. 
 
-For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](rules/use-emojis-in-your-commits/).
+For more information about writing descriptive commit messages see the rule [GitHub Repos - Do you write nice commit messages](use-emojis-in-your-commits/).
 ## Conclusion
 
 Maintaining a clean git history is important for readability and understanding the changes that have been made to a codebase over the lifetime of the repository.


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️Source Control History - Chewing the Fat 📈

> 2. What was changed?

✏️I added a paragraph talking about how descriptive commit names can make it easier to maintain a clean commit history

> 3. Did you do pair or mob programming (list names)?

✏️No

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
