### PR TITLE
XS✔ ◾ Improvements to @mentions in PBI rule

### DIFF
--- a/rules/when-you-use-mentions-in-a-pbi/rule.md
+++ b/rules/when-you-use-mentions-in-a-pbi/rule.md
@@ -7,7 +7,9 @@ authors:
     url: https://ssw.com.au/people/eric-phan
   - title: Adam Cogan
     url: https://ssw.com.au/people/adam-cogan
-related: []
+related:
+- know-that-im-interrupts
+- do-you-reply-to-the-correct-zendesk-email
 redirects:
   - when-you-use-@-mentions-in-a-pbi
   - do-you-know-when-you-use-mentions-in-a-pbi
@@ -23,9 +25,8 @@ When the Product Owner verbally requests a change to a PBI, how do you update th
 
 You could send yourself a "[To Myself](/dones-do-you-send-yourself-emails)" email and update the PBI description accordingly, but only those people included in the email chain are aware of the conversation. Only send a "To Myself" email when there is no Product Backlog that is related to the request, otherwise you should create or update a PBI and @ mention the Product Owner and other relevant people (@ mentioned people will still receive an email).
 
-
 ::: bad  
-![Figure: Bad Example – don't use emails to update tasks](bad-mention-pbi.jpg)  
+![Figure: Bad example – Don't use emails to update tasks](bad-mention-pbi.jpg)  
 :::
 
 Instead, what you should do is use the discussions feature in the PBI and mention the user using "@&lt;username&gt;". 
@@ -35,28 +36,35 @@ The benefits of using comments are:
 * History is visible to anyone looking at the PBI (with email, if you don’t cc them, they wouldn’t have a clue)
 * Easy to see all important notes/comments in one place instead of digging through email
 
-
-
-
-
 When someone (especially the PO) asks you to fix a PBI, mention that person in the PBI comments so they know when it’s fixed.
 
-Example: When replying to "Hey XXX, can you please fix PBI 123?"
+### Scenario
 
+You are replying to _"Hey, can you please fix PBI 123?"_
 
-
+::: greybox
+_"I have found the PBI and moved it near the top of our backlog"_
+:::
 ::: bad
-Bad example: "I have found the PBI and moved it near the top of our backlog"
-
+Bad example: No @mention used
 :::
 
-
+::: greybox
+"I have found the PBI, prioritized it near the top, and @mentioned you so you know when it is fixed"
+:::
 ::: good
-Good example: "I have found the PBI, prioritized it near the top, and @mentioned you so you know when it is fixed"
-
+Good example: @mention included
 :::
 
+### GitHub Issues
 
+::: good  
+![Figure: Good example – Using @ mentions in GitHub](MicrosoftTeams-image.png)  
+:::
+
+::: info
+**Tip:** You can @mention on your pull requests as well.
+:::
 
 ### Azure DevOps PBIs
 
@@ -66,37 +74,19 @@ To create a new PBI in your Azure DevOps project:
 3. @ mention your desired user in the description
 
 ::: good  
-![Figure: Good Example – Using @ mentions in Azure DevOps discussion](good-mention-pbi.jpg)  
+![Figure: Good example – Using @mentions in Azure DevOps discussion](good-mention-pbi.jpg)  
 :::
-
 
 ::: good  
-![Figure: Good Example – Email still gets sent to the users who are mentioned in the discussion, so they can still chime in if any details are incorrect](good-mention-pbi-2.jpg)  
+![Figure: Good example – Email still gets sent to the users who are mentioned in the discussion, so they can still chime in if any details are incorrect](good-mention-pbi-2.jpg)  
 :::
 
-It is also good practise to use @ mention in the discussion to track changes and request test pleases. Try formatting your mentions like an email to clarify both accountability and responsiblity and identify the current status of the project.
+It is also good practise to use @mention in the discussion to track changes and [request test pleases](/request-a-test-please). Try formatting your mentions like an email to clarify both accountability and responsiblity and identify the current status of the project.
 
 ::: good  
-![Figure: Good Example – Using "CC" and Greetings as you would in an email. Emojis are helpful too! 😊](pbi-formatting-mentions.png)  
+![Figure: Good example – Using "CC" and Greetings as you would in an email. Emojis are helpful too! 😊](pbi-formatting-mentions.png)  
 :::
 
-### GitHub Issues
+### Related Suggestion
 
-
-
-::: good  
-![Figure: Good Example – Using @ mentions in GitHub](MicrosoftTeams-image.png)  
-:::
-
-
-::: greybox
- **Tip:** You can @mention on your pull requests as well.
-
-:::
-
-### Related Links
-
-
-* [Interruptions - Do you know that IM interrupts?](/know-that-im-interrupts)
 * [Suggestion to Microsoft Azure DevOps - Help me know there is an image in the Work Item](https://bettersoftwaresuggestions.com/microsoft/azure-devops/help-me-know-there-is-an-image-in-the-work-item/)
-* [Zendesk - Do you reply to the correct Zendesk email?](/do-you-reply-to-the-correct-zendesk-email)

--- a/rules/when-you-use-mentions-in-a-pbi/rule.md
+++ b/rules/when-you-use-mentions-in-a-pbi/rule.md
@@ -29,7 +29,7 @@ You could send yourself a "[To Myself](/dones-do-you-send-yourself-emails)" emai
 ![Figure: Bad example – Don't use emails to update tasks](bad-mention-pbi.jpg)  
 :::
 
-Instead, what you should do is use the discussions feature in the PBI and mention the user using "@&lt;username&gt;". 
+Instead, what you should do is use the discussions feature in the PBI and mention the user using "@&lt;username&gt;".
 The benefits of using comments are:
 
 * Quick and easy, no need to compose an email
@@ -69,6 +69,7 @@ Good example: @mention included
 ### Azure DevOps PBIs
 
 To create a new PBI in your Azure DevOps project:
+
 1. Navigate to **Boards | + New Work Item** and select the type that best suits your item
 2. Enter your PBI title
 3. @ mention your desired user in the description


### PR DESCRIPTION
cc @adamcogan 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Re: PBI Mention Rule by @fenix2222 

> 2. What was changed?

1.	> Duplicated links - Should you also add a link to it in “Related Rules” section?
IMO not needed

2.	> Duplicated links - Is there a rule about this, because Adam wasn’t sure?
Yes – https://www.ssw.com.au/rules/avoid-redundant-links/
The rule says in the info box that it’s ok to have duplicates in different sections (e.g. sidebar) but I only do case by case, when the core of the rule is related. 

Note: I created this PR to include the word “Duplicated” to that rule: https://github.com/SSWConsulting/SSW.Rules.Content/pull/8002

3.	> Abbreviations - We shouldn’t use word “PO”, I wasn’t sure if it was Project or Product Owner
Partially disagree.
I think if we have mentioned “Product Owner” before in the content, it’s OK to have the abbreviation PO.

4.	> I think we should put good and bad example in two grey boxes so it is clearer, I thought good example was missing an image. For example change
Agreed and done

5.	> These days, we are GitHub–first company, so can you move GitHub examples before AzureDevOps.
Done

6.	Also, one image is old and has reference to VisualStudioOnline ([VisualStudioOnline@microsoft.com](mailto:VisualStudioOnline@microsoft.com)), which no longer exists and is replaced by AzureDevOps.
Not done yet. I will make another PR for this update

7.	The “test please” should be hyperlinked to a rule 
Done

8.	Duplicate links - We should probably add it to “Related Rules” section
Not done – as per #1 I don’t think the rules core are so directly related 

9.	At the bottom this rule has 3 related links, it should be on the right hand side.
Done – except for the suggestion because sidebar is for rules only

> 3. Did you do pair or mob programming (list names)?

no