### PR TITLE
XS✔ ◾ Update full stops rule

### DIFF
--- a/rules/avoid-full-stops-in-bullet-point-lists/rule.md
+++ b/rules/avoid-full-stops-in-bullet-point-lists/rule.md
@@ -19,24 +19,77 @@ redirects:
 
 Excess punctuation without a purpose can make a document or web page look overly busy. This can add a surprising amount of visual clutter. 
 
-For **lists of short sentences** and **figure captions**, don't add full stops at the end. Of course when you have more than one sentence, add the full stops where necessary, then only avoid the full stop in the **last sentence**.
+
+**As a general rule, avoid full stops in lists and captions altogether.**
+
 
 <!--endintro-->
 
+
+Bullet points should be short and sharp, and should generally not require full stops **at all**. If your bullet point has more than one sentence, consider separating it into two bullet points instead. Alternatively, consider a different separator - like a dash; you could also consider a semicolon instead.
+
+
+However, if it *is* necessary for your bullet point to have more than one sentence (should be rare), you of course need the full stop. In this case, you must include the full stop at the end. And, for consistency, *all* the bullet points in that list should also end with a full stop.
+
+
+**Important:** Note the use of "in that list". The rest of the bullet points on your page **should not have full stops**; only those in that list or group. 
+
+
 ::: greybox
+
+
 * Sentence 1.
 * Sentence 2.
 * Sentence 3.
-:::
-::: bad
-Figure: Bad example - Too much punctuation  
-:::
+  :::
+  ::: bad
+  Figure: Bad example - Too much punctuation
+  :::
+
 
 ::: greybox
+
+
 * Sentence 1
 * Sentence 2. Sentence 3
 * Sentence 4
+  :::
+  ::: bad
+  Figure: Bad example - Full stop is only used on multiple sentences, but not at the end
+  :::
+
+
+::: greybox
+
+
+* Sentence 1
+* Sentence 2. Sentence 3.
+* Sentence 4
+  :::
+  ::: bad
+  Figure: Better example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
+  :::
+
+
+::: greybox
+
+
+Full stops should not be used in bullet lists, e.g.:
+
+
+*  In this list of bullet points there are no full stops
+* So this one doesn't have one either 
+* Or this one
+
+
+However, if you need full stops, make sure your bullets end with them and you maintain consistency, e.g.:
+
+
+* In this point, there is a full stop. Because of that, there needs to be one at the end too.
+* Because a bullet in this list has a full stop, they all need one.
+* Even this.
 :::
 ::: good
-Figure: Good example - Full stop is only used on multiple sentences, but not at the end
+Figure: Good example. Full stops are avoided where possible, but used correctly and consistently where necessary.
 :::
+

--- a/rules/avoid-full-stops-in-bullet-point-lists/rule.md
+++ b/rules/avoid-full-stops-in-bullet-point-lists/rule.md
@@ -17,26 +17,19 @@ redirects:
 
 ---
 
-Excess punctuation without a purpose can make a document or web page look overly busy. This can add a surprising amount of visual clutter. 
-
+Excess punctuation without a purpose can make a document or web page look overly busy. This can add a surprising amount of visual clutter.
 
 **As a general rule, avoid full stops in lists and captions altogether.**
 
-
 <!--endintro-->
-
 
 Bullet points should be short and sharp, and should generally not require full stops **at all**. If your bullet point has more than one sentence, consider separating it into two bullet points instead. Alternatively, consider a different separator - like a dash; you could also consider a semicolon instead.
 
-
 However, if it *is* necessary for your bullet point to have more than one sentence (should be rare), you of course need the full stop. In this case, you must include the full stop at the end. And, for consistency, *all* the bullet points in that list should also end with a full stop.
 
-
-**Important:** Note the use of "in that list". The rest of the bullet points on your page **should not have full stops**; only those in that list or group. 
-
+**Important:** Note the use of "in that list". The rest of the bullet points on your page **should not have full stops**; only those in that list or group.
 
 ::: greybox
-
 
 * Sentence 1.
 * Sentence 2.
@@ -46,9 +39,7 @@ However, if it *is* necessary for your bullet point to have more than one senten
   Figure: Bad example - Too much punctuation
   :::
 
-
 ::: greybox
-
 
 * Sentence 1
 * Sentence 2. Sentence 3
@@ -58,9 +49,7 @@ However, if it *is* necessary for your bullet point to have more than one senten
   Figure: Bad example - Full stop is only used on multiple sentences, but not at the end
   :::
 
-
 ::: greybox
-
 
 * Sentence 1
 * Sentence 2. Sentence 3.
@@ -70,20 +59,15 @@ However, if it *is* necessary for your bullet point to have more than one senten
   Figure: Better example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
   :::
 
-
 ::: greybox
-
 
 Full stops should not be used in bullet lists, e.g.:
 
-
-*  In this list of bullet points there are no full stops
-* So this one doesn't have one either 
+* In this list of bullet points there are no full stops
+* So this one doesn't have one either
 * Or this one
 
-
 However, if you need full stops, make sure your bullets end with them and you maintain consistency, e.g.:
-
 
 * In this point, there is a full stop. Because of that, there needs to be one at the end too.
 * Because a bullet in this list has a full stop, they all need one.
@@ -92,4 +76,3 @@ However, if you need full stops, make sure your bullets end with them and you ma
 ::: good
 Figure: Good example. Full stops are avoided where possible, but used correctly and consistently where necessary.
 :::
-


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ There was an older rule that was archived: https://www.ssw.com.au/rules/do-you-know-when-to-use-full-stops-at-the-end-of-bullet-points/

And replaced with a new rule: https://www.ssw.com.au/rules/avoid-full-stops-in-bullet-point-lists/

Both of these get aspects of it right but neither are quite there. This update to the new rule combines the best aspects of both rules to give a cohesive guide to using full stops in bullet points.

> 2. What was changed?

✏️ Part of the guidance from the archived rule, to keep bullets short, was lost in the new one. This update makes this guidance more explicit. It also explains that if you need an exception to this guidance, do it properly and consistently.

> 3. Did you do pair or mob programming (list names)?

✏️ I discussed these changes with @GordonBeeming and @Dhruv-0987.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
