### PR TITLE
XS✔ ◾ no . in lists - change from 'better example' to 'ok example'

### DIFF
--- a/rules/avoid-full-stops-in-bullet-point-lists/rule.md
+++ b/rules/avoid-full-stops-in-bullet-point-lists/rule.md
@@ -60,8 +60,8 @@ Figure: Bad example - Full stop is only used on multiple sentences, but not at t
 * Sentence 2. Sentence 3.
 * Sentence 4
 :::
-::: bad
-Figure: Better example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
+::: ok
+Figure: Ok example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
 :::
 
 ::: greybox

--- a/rules/avoid-full-stops-in-bullet-point-lists/rule.md
+++ b/rules/avoid-full-stops-in-bullet-point-lists/rule.md
@@ -61,7 +61,7 @@ Figure: Bad example - Full stop is only used on multiple sentences, but not at t
 * Sentence 4
 :::
 ::: ok
-Figure: Ok example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
+Figure: OK example - Full stop is used on multiple sentences, and at the end, but the bullets are inconsistent
 :::
 
 ::: greybox


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed it
we have an ok box, i think it makes sense to use it here

> 2. What was changed?

✏️

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
