### PR TITLE
XS✔ ◾ Fix broken build - archived reason includes colon “:”

### DIFF
--- a/rules/avoid-using-non-strongly-typed-connection-strings/rule.md
+++ b/rules/avoid-using-non-strongly-typed-connection-strings/rule.md
@@ -6,7 +6,7 @@ authors:
   - title: Igor Goldobin
     url: https://ssw.com.au/people/alumni/igor-goldobin/
 created: 2024-03-09T06:15:30.110Z
-archivedreason: Update connection string management: favor IOptions pattern over Visual Studio's Application Settings. Offers robust, flexible config in .NET Core, aligning with modern development practices. Refer to Microsoft's IOptions pattern in .NET documentation for implementation guidance.
+archivedreason - Update connection string management - favor IOptions pattern over Visual Studio's Application Settings. Offers robust, flexible config in .NET Core, aligning with modern development practices. Refer to Microsoft's IOptions pattern in .NET documentation for implementation guidance.
 guid: 27abe1ac-b34a-4ea7-94e5-a3cd5ba5e10b
 ---
 Using non strongly typed connection strings means that you have to hard code at some point in your code. Once you change the name of your connection strings, you have to change the code that references them too.

--- a/rules/avoid-using-non-strongly-typed-connection-strings/rule.md
+++ b/rules/avoid-using-non-strongly-typed-connection-strings/rule.md
@@ -6,7 +6,7 @@ authors:
   - title: Igor Goldobin
     url: https://ssw.com.au/people/alumni/igor-goldobin/
 created: 2024-03-09T06:15:30.110Z
-archivedreason - Update connection string management - favor IOptions pattern over Visual Studio's Application Settings. Offers robust, flexible config in .NET Core, aligning with modern development practices. Refer to Microsoft's IOptions pattern in .NET documentation for implementation guidance.
+archivedreason: Update connection string management - favor IOptions pattern over Visual Studio's Application Settings. Offers robust, flexible config in .NET Core, aligning with modern development practices. Refer to Microsoft's IOptions pattern in .NET documentation for implementation guidance.
 guid: 27abe1ac-b34a-4ea7-94e5-a3cd5ba5e10b
 ---
 Using non strongly typed connection strings means that you have to hard code at some point in your code. Once you change the name of your connection strings, you have to change the code that references them too.


### PR DESCRIPTION

**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️build was breaking

@tiagov8 @fenix2222 FYI the YAML syntax is fussy - it didn't like the ":" in the archived reason because it thought it was a new key-value pair. 

> 2. What was changed?

✏️

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
