### PR TITLE
🐛  Fixed Script to Update Image Paths in the Correct rule.md

### DIFF
--- a/scripts/rename-duplicate-images/rename-duplicate-images.js
+++ b/scripts/rename-duplicate-images/rename-duplicate-images.js
@@ -33,8 +33,8 @@ function checkDuplicateImages(directory) {
       const newPath = firstPath.replace(fileName, newName);
       fs.renameSync(firstPath, newPath);
       totalModifiedFiles++;
-      if (fs.existsSync(path.dirname(paths[0]) + "/rule.md")) {
-        modifyRuleMd(path.dirname(paths[0]) + "/rule.md", fileName, newName);
+      if (fs.existsSync(path.dirname(firstPath) + "/rule.md")) {
+        modifyRuleMd(path.dirname(firstPath) + "/rule.md", fileName, newName);
       }
     }
   });


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Relates to https://github.com/SSWConsulting/SSW.Rules/issues/846
After renaming duplicate images, the script should update the old image paths in the rule.md file with the new ones. However I noticed that it is not updating the image paths in the correct rule.md file.
This bug was introduced in https://github.com/SSWConsulting/SSW.Rules.Content/pull/8091 🤦‍♀️

> 2. What was changed?

✏️ Fixed the bug - the renamed image and rule.md should be in the same folder

new PR example: https://github.com/Aibono1225/SSW.Rules.Content/pull/1
![image](https://github.com/SSWConsulting/SSW.Rules.Content/assets/127192800/4e286dfe-4df8-43f4-8882-d647c1026e97)


> 3. Did you do pair or mob programming (list names)?

✏️ No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
