### PR TITLE
XS✔ ◾ Adjust "be specific in communication" section title to reference PBIs as well as emails

### DIFF
--- a/rules/communication-are-you-specific-in-your-requirements/rule.md
+++ b/rules/communication-are-you-specific-in-your-requirements/rule.md
@@ -20,40 +20,30 @@ When you're scoping the work to be completed, ensure you are as accurate as poss
 
 <!--endintro-->
 
-### Be Specific
-
-
+### Be specific
 
 ::: greybox
 "I want to keep contact details on my clients"
-
 :::
-
 
 ::: bad
 Figure: Bad example - likely to require later clarification
-
 :::
-
 
 ::: greybox
 "I want to record my clients' firstname, surname, mobile phone, email address & Instant Messenger address."  
 :::
 
-
 ::: good
 Figure: Good Example - You'll get exactly what you want. Even better, use screenshots or mock-ups
-
 :::
 
-### One Email per Item
-
+### One email (or Product Backlog Item) per task
 
 The best way for this to work is to break tasks into the smallest possible [bite-size pieces](/management-do-you-spec-in-bite-sized-pieces) and ensure that those pieces are in the project plan explicitly.
 
 Sometimes software developers miss a related item that you might consider 'blindingly obvious.' For example, you might ask them to fix a combo box on one form in a legacy application. But they mightn't know about the three other forms that the same type of combo appears on. So if you also want them fixed, then let them know about them!
 
-### Get Approval for UI Changes
-
+### Get approval for UI changes
 
 Insist your software consultants [conduct specifications by creating mock-ups](/storyboarding-do-you-conduct-specification-analysis-by-creating-mock-ups).

--- a/rules/communication-are-you-specific-in-your-requirements/rule.md
+++ b/rules/communication-are-you-specific-in-your-requirements/rule.md
@@ -38,7 +38,7 @@ Figure: Bad example - likely to require later clarification
 Figure: Good Example - You'll get exactly what you want. Even better, use screenshots or mock-ups
 :::
 
-### One email (or Product Backlog Item) per task
+### One email or Product Backlog Item per task
 
 The best way for this to work is to break tasks into the smallest possible [bite-size pieces](/management-do-you-spec-in-bite-sized-pieces) and ensure that those pieces are in the project plan explicitly.
 

--- a/rules/communication-are-you-specific-in-your-requirements/rule.md
+++ b/rules/communication-are-you-specific-in-your-requirements/rule.md
@@ -23,15 +23,15 @@ When you're scoping the work to be completed, ensure you are as accurate as poss
 ### Be specific
 
 ::: greybox
-"I want to keep contact details on my clients"
+_"I want to keep contact details on my clients"_
 :::
 
 ::: bad
-Figure: Bad example - likely to require later clarification
+Figure: Bad example - Likely to require later clarification
 :::
 
 ::: greybox
-"I want to record my clients' firstname, surname, mobile phone, email address & Instant Messenger address."  
+_"I want to record my clients' firstname, surname, mobile phone, email address & Instant Messenger address."_
 :::
 
 ::: good
@@ -40,10 +40,10 @@ Figure: Good Example - You'll get exactly what you want. Even better, use screen
 
 ### One email or Product Backlog Item per task
 
-The best way for this to work is to break tasks into the smallest possible [bite-size pieces](/management-do-you-spec-in-bite-sized-pieces) and ensure that those pieces are in the project plan explicitly.
+The best way for this to work is to break tasks into the smallest possible [bite-size pieces](/management-do-you-use-just-in-time-speccing) and ensure that those pieces are in the project plan explicitly.
 
-Sometimes software developers miss a related item that you might consider 'blindingly obvious.' For example, you might ask them to fix a combo box on one form in a legacy application. But they mightn't know about the three other forms that the same type of combo appears on. So if you also want them fixed, then let them know about them!
+Sometimes software developers miss a related item that you might consider 'blindingly obvious.' For example, you might ask them to fix a combo box on one form in a legacy application. But they mightn't know about the 3 other forms that the same type of combo appears on. So if you also want them fixed, then let them know about them!
 
 ### Get approval for UI changes
 
-Insist your software consultants [conduct specifications by creating mock-ups](/storyboarding-do-you-conduct-specification-analysis-by-creating-mock-ups).
+Make sure software consultants [conduct specifications by creating mock-ups](/storyboards).


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

While creating training material for Product Owners with @piers-sinclair, Pier's noted that the section title "One Email per Item" should mention PBIs as they are the preferred means of defining and allocating tasks.

> 2. What was changed?

- Section title "One Email per Item" changed to "One email (or Product Backlog Item) per task"
- Refactored spacing in `communication-are-you-specific-in-your-requirements/rule.md`
- Adjusted the capitalisation of section titles to use the "[Sentence case](https://en.wikipedia.org/wiki/Letter_case#Sentence_case)" capitalisation style used for most modern rules

> 3. Did you do pair or mob programming (list names)?

No
