### PR TITLE
XS✔ ◾ Adjust "email-to-PBI rule" email reply to mention prioritization

### DIFF
--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -74,8 +74,8 @@ It's important that you follow the right steps so that the PBI contains all the 
 
 6. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
 
-7. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI: {{ URL }}\
-   For future ones, if you have access, please add your comments there 🙂"*
+7. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI for prioritization: {{ URL }}\
+   For future issues, if you have access, please add your comments to items in that backlog 🙂"*
 
 ::: greybox
 **From:** Bob Northwind "<BobNorthwind@northwind.com>"\


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Issue noticed by @piers-sinclair and I when working on Product Owner training material.

> 2. What was changed?

Adjusts the email response after creating a PBI:
-  Adds a mention that the PBI has been created for prioritization
-  Clarifies pronouns used in the 2nd line of the response.

> 3. Did you do pair or mob programming (list names)?

No