### PR TITLE
XS✔ ◾ Clarifying Turn Emails Into PBIs

### DIFF
--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -66,26 +66,26 @@ It's important that you follow the right steps so that the PBI contains all the 
 
 2. Copy the **email header** into the top of the PBI, indent it and add the words "Based on email chain:" so that the email can be found later.
 
-3. Replace the users with GitHub usernames (where possible), if you'd like to keep those users informed.
+3. If possible, replace the users with @mentions, if you'd like to keep those users informed.
+  
+4. Fill out the Description
 
-4. Remove any remaining email addresses from the header.
+5. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to all emails mentioned in this PBI and @mention the sender with 'Done'"*
 
-5. Fill out the Description
-
-6. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to the email and also @mention them in the PBI with 'Done'"*
-
-7. Reply back to the original email saying: *"That's awesome feedback, I've moved it to a PBI for prioritization: {{ URL }}\
+6. Reply back to the original email saying: *"That's awesome feedback, we have a PBI: {{ URL }}\
    For future issues, if you have access, please add your comments to items in that backlog 🙂"*
 
 ::: greybox
+Based on email chain:
+
 **From:** Bob Northwind "<BobNorthwind@northwind.com>"\
 **Sent:** Thursday, 24 November 2023\
 **To:** Jane Doe "<JaneDoe@northwind.com>"\
 **Cc:** John Davis "<JohnDavis@northwind.com>"; Eliza Northwind "<ElizaNorthwind@northwind.com>"\
 **Subject:** TimePro PBI 50209: ☠️ Displaying past employees
 :::
-::: bad
-Figure: Including email addresses and not tagging GitHub users
+::: ok
+Figure: Okay example - Has the email header data but not @mentioning users
 :::
 
 ::: greybox
@@ -98,26 +98,18 @@ Based on email chain:
 **Subject:** TimePro PBI 50209: ☠️ Displaying past employees
 :::
 ::: good
-Figure: Email header with GitHub users tagged and no email addresses
+Figure: Good example - Has the email header data and @mentions users
 :::
 
 ::: info
 **Tip:** If the request from the client is too large for one PBI, then it will need to be turned into multiple PBIs as per the rule  [Do you keep your PBIs smaller than 2 days' effort?](/spec-do-you-create-tasks-under-4-hours) In this case, you will need to let the client know this and include URLs to each PBI
 :::
 
-### Steps to update a PBI with an email
+### Existing PBI - Steps to update a PBI according to an email comment
 
-Sometimes you will receive an email concerning a known issue. It is important to inform the sender and keep them up to date.
+Sometimes you will receive feedback on an existing PBI within an email. It is important to inform the sender and keep them up to date.
 
-1. Copy the **email header** into to a comment within the PBI, indent and add the words "Issue raised by {{ NAME }} separately in email chain:"
-
-2. Replace the users with GitHub usernames (where possible), if you'd like to keep those users informed.
-
-3. Remove any remaining email addresses from the header.
-
-4. Add to the Acceptance Criteria: *"Reply 'Done' to the email in the comment below by {{ SENDER }} and @mention them in the PBI with 'Done'"*
-
-5. Reply back to the original email saying: "PBI exists - see PBI: {{ URL }}"
+Follow the process above, but add the information to a comment instead.
 
 ### Keeping it up-to-date
 

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -58,7 +58,7 @@ Better Prioritization
 Easily accessible by anyone in the team
 :::
 
-### Steps to turn an email into a PBI
+### New PBI - Steps to turn an email into a PBI
 
 It's important that you follow the right steps so that the PBI contains all the information someone would need to find the original email thread, and also so that the original sender knows where the PBI is, and whether it has completed.
 

--- a/rules/turn-emails-into-pbis/rule.md
+++ b/rules/turn-emails-into-pbis/rule.md
@@ -70,9 +70,9 @@ It's important that you follow the right steps so that the PBI contains all the 
   
 4. Fill out the Description
 
-5. Fill out the Acceptance Criteria, adding: *"Reply 'Done' to all emails mentioned in this PBI and @mention the sender with 'Done'"*
+5. Add an Acceptance Criteria: *"Reply 'Done' to all emails mentioned in this PBI and @mention the sender with 'Done'"*
 
-6. Reply back to the original email saying: *"That's awesome feedback, we have a PBI: {{ URL }}\
+6. Reply back to the original email saying: *"That's awesome feedback, we have a PBI for prioritization: {{ URL }}\
    For future issues, if you have access, please add your comments to items in that backlog 🙂"*
 
 ::: greybox
@@ -109,7 +109,11 @@ Figure: Good example - Has the email header data and @mentions users
 
 Sometimes you will receive feedback on an existing PBI within an email. It is important to inform the sender and keep them up to date.
 
-Follow the process above, but add the information to a comment instead.
+1. Copy the **email header** into to a comment within the PBI, indent it and add the words "Based on email chain:"
+
+2. If possible, replace the users with @mentions, if you'd like to keep those users informed.
+
+3. Add an Acceptance Criteria: *"Reply 'Done' to all emails mentioned in this PBI and @mention the sender with 'Done'"*
 
 ### Keeping it up-to-date
 


### PR DESCRIPTION
**Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖**
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Piers was confused by the instructions, he thought he was meant to follow the second heading but was meant to follow the first heading.

> 2. What was changed?

✏️We cleaned up the instructions and tried to reduce duplication. There is still some duplicated text which sucks, but it's clearer.

We also fixed an issue with the mentions, we want to make sure this is as easy to follow as possible, so we made it clear that mentions are not mandatory. Also we changed it so emails are not removed as this makes it difficult to follow and we are not sure what the value add is.

> 3. Did you do pair or mob programming (list names)?

✏️ Nick C + Daniel M

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
