### PR TITLE
XS✔ ◾ Design patterns - Add redirect from old part 2 rule url

### DIFF
--- a/rules/common-design-patterns/rule.md
+++ b/rules/common-design-patterns/rule.md
@@ -20,6 +20,8 @@ related:
 redirects:
 - do-you-know-the-common-design-patterns-(part-1)
 - do-you-know-the-common-design-patterns-part-1
+- do-you-know-the-common-design-patterns-(part-2-example)
+- do-you-know-the-common-design-patterns-part-2-example
 
 ---
 

--- a/rules/dependency-injection/rule.md
+++ b/rules/dependency-injection/rule.md
@@ -19,8 +19,7 @@ authors:
 related:
 - do-you-name-your-dependencies-to-avoid-problems-with-minification
 - common-design-patterns
-redirects:
-- do-you-know-the-common-design-patterns-(part-2-example)
+redirects: []
 
 ---
 


### PR DESCRIPTION
So the old rule doesnt 404

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️
I saw bug

> 2. What was changed?

✏️

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
