### PR TITLE
XS✔ ◾ Removed 404 link - https://www.ssw.com.au/rules/screenshots-tools/

### DIFF
--- a/rules/screenshots-tools/rule.md
+++ b/rules/screenshots-tools/rule.md
@@ -42,7 +42,7 @@ There are heaps of great tools that provide much more advanced functionality. Th
 
 ❌ [Preview](https://support.apple.com/en-au/guide/preview/welcome/mac) (MacOS only - built-in)
 
-❌ [Snipping Tool](https://support.microsoft.com/en-AU/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b) (Windows only - built-in) 
+❌ [Snipping Tool](https://support.microsoft.com/en-AU/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b) (Windows only - built-in)
 :::
 
 ![Figure: Lightshot is the most popular screenshot tool](screen-shot-2022-06-09-at-16.38.10.png)

--- a/rules/screenshots-tools/rule.md
+++ b/rules/screenshots-tools/rule.md
@@ -36,8 +36,6 @@ There are heaps of great tools that provide much more advanced functionality. Th
 
 ✅ [Lightshot](https://app.prntscr.com/en/index.html)
 
-✅ [Fullshot](http://www.inbit.com/downloadfullshot.html)
-
 ✅ [Flameshot](https://flameshot.org)
 
 ✅ [Shottr](https://shottr.cc) (MacOS only)


### PR DESCRIPTION
Full software link is a 404!
Product last updated on 9/15/2013


> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

CodeAuditor

> 2. What was changed?

Removed 404 link 

> 3. Did you do pair or mob programming (list names)?

no