### PR TITLE
XS✔ ◾ Commenting Code - Place 2nd half of split comment on separate line

### DIFF
--- a/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
+++ b/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
@@ -33,11 +33,10 @@ private void Command0_Click() {
     .....processing code
 }
 ```
+
 ::: bad
 Bad Example - Debug code has just been commented out
 :::
-
-
 
 ```cs
 private void Command0_Click() {
@@ -50,6 +49,7 @@ private void Command0_Click() {
     .....processing code
 }
 ```
+
 ::: good
 Good Example - the debug commands have been rafactored into meaningful comments for the next developer
 :::

--- a/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
+++ b/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
@@ -1,7 +1,7 @@
 ---
 type: rule
 archivedreason: 
-title: Comments - Do you know what to do with comments and Debug.Print statements
+title: Comments - Do you know what to do with comments and Debug.Print statements?
 guid: cebb6d03-5254-4e76-b6ac-5e0f62c8e9f8
 uri: what-to-do-with-comments-and-debug-print-statements
 created: 2018-04-25T18:12:19.0000000Z
@@ -35,7 +35,7 @@ private void Command0_Click() {
 ```
 
 ::: bad
-Bad Example - Debug code has just been commented out
+Bad example - Debug code has just been commented out
 :::
 
 ```cs
@@ -51,5 +51,5 @@ private void Command0_Click() {
 ```
 
 ::: good
-Good Example - the debug commands have been rafactored into meaningful comments for the next developer
+Good example - The debug commands have been rafactored into meaningful comments for the next developer
 :::

--- a/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
+++ b/rules/what-to-do-with-comments-and-debug-print-statements/rule.md
@@ -22,8 +22,6 @@ What do you do with your print statements? Sometimes a programmer will place pri
 
 Debugging print statements are paths that show where the programmer has been. **They should be commented out, but the statements should be left in the code in the form of comments.** Thus, if the code breaks down later, the programmers (who might not remember or even know the program to start with), will be able to see where testing has been done and where the fault is likely to be - i.e., elsewhere.
 
-
-
 ```cs
 private void Command0_Click() {
     rst.Open("SELECT * FROM Emp") // Open recordset with employee records
@@ -44,7 +42,8 @@ Bad Example - Debug code has just been commented out
 ```cs
 private void Command0_Click() {
     rst.Open("SELECT * FROM Emp")
-    // Count will exceed 1,000 during eighteenth century    // leap years, which we aren't prepared to handle.
+    // Count will exceed 1,000 during eighteenth century
+    // leap years, which we aren't prepared to handle.
     if (intCount > 1000) {
         return
     } else  {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Noticed issue while completing SugarLearning item ["📋 Commenting Code"](https://my.sugarlearning.com/SSW/items/8326/commenting-code)

> 2. What was changed?

- A newline was added before a set of '//', which should have been on a separate line
- Removed unnecessary newlines above code snippet

> 3. Did you do pair or mob programming (list names)?

❌ No
