### PR TITLE
XS✔ ◾ Adds preferred location for Product Goal to 3 Scrum Commitments

### DIFF
--- a/rules/the-3-commitments-in-scrum/rule.md
+++ b/rules/the-3-commitments-in-scrum/rule.md
@@ -32,6 +32,10 @@ The Product Goal is the long-term objective for the Scrum Team. They must fulfil
 :::
 **Excerpt from [The Scrum Guide](https://scrumguides.org/scrum-guide.html)**
 
+::: info
+**Tip:** Make it easy to find your Product Goal by documenting it in the README of your project.
+:::
+
 ### Sprint Goal
 
 This is the commitment at the Sprint Backlog level. It is negotiated between the Product Owner and the Team, and defines the “why” of the Sprint, and how it will help the product eventually reach the Product Goal.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Requested by @adamcogan and @piers-sinclair at meeting "Roadmap Rodeo - Review of Product Communication Rule and PO Training Material" conducted 10am Monday 22 April 2024

> 2. What was changed?

- An information box was added to the Product Goal section stating that the Product Goal should be recorded in the README

> 3. Did you do pair or mob programming (list names)?

❌ No
