### PR TITLE
XS✔ ◾ Link Product Roadmap with Product Goal

### DIFF
--- a/rules/roadmap/rule.md
+++ b/rules/roadmap/rule.md
@@ -18,7 +18,7 @@ guid: 3e1cb281-662b-4420-a016-713f27d69acf
 
 A Product Backlog is a great way to see the fairly small broken up Product Backlog Items (PBIs) that make up your team's "to do" list, but it can be a bit too **zoomed in** and makes it easy to stray from the [Product Goal](/the-3-commitments-in-scrum/).
 
-To get a better **zoomed out** view, you should have a product roadmap. 
+To get a better **zoomed out** view, you should have a product roadmap.
 
 <!--endintro-->
 
@@ -47,9 +47,9 @@ Having this zoomed out view helps the team to stay focused on the overall goal o
 
 ### Building the product roadmap
 
-It's important to think about the scope of the product when building the product roadmap so that the milestones are an achievable grouping of tasks. Consider the size of your team: 
+It's important to think about the scope of the product when building the product roadmap so that the milestones are an achievable grouping of tasks. Consider the size of your team:
 
-* For small teams that shift to different products a lot, you might want to make the milestones a bit more granular and short term. 
+* For small teams that shift to different products a lot, you might want to make the milestones a bit more granular and short term.
 * For larger product oriented teams, it is more important to have a general overview of what is going to happen across a longer timeframe.
 
 By factoring in the size of the team, it keeps everyone accountable while remaining realistic.
@@ -67,7 +67,7 @@ There are heaps of tools out there you can use to make a product roadmap includi
 
 These tools have a lot of functionality and use differing complicated terminology like Features, Epics or MMFs (Minimum Marketable Features). So, they can be an intimidating first step into product roadmaps.
 
-At their core, product roadmaps are simply a list of critical milestones to tick off as they are completed. So, as a stepping stone, you can store them in your project wiki. 
+At their core, product roadmaps are simply a list of critical milestones to tick off as they are completed. So, as a stepping stone, you can store them in your project wiki.
 
 The project wiki makes the concept much easier to understand and implement. Once the team is comfortable with the idea, move on to more complex tools.
 

--- a/rules/roadmap/rule.md
+++ b/rules/roadmap/rule.md
@@ -16,7 +16,7 @@ archivedreason: null
 guid: 3e1cb281-662b-4420-a016-713f27d69acf
 ---
 
-A Product Backlog is a great way to see the fairly small broken up Product Backlog Items (PBIs) that make up your team's "to do" list, but it can be a bit too **zoomed in** and makes it easy to stray from the [Product Goal](https://www.ssw.com.au/rules/the-3-commitments-in-scrum/).
+A Product Backlog is a great way to see the fairly small broken up Product Backlog Items (PBIs) that make up your team's "to do" list, but it can be a bit too **zoomed in** and makes it easy to stray from the [Product Goal](/the-3-commitments-in-scrum/).
 
 To get a better **zoomed out** view, you should have a product roadmap. 
 

--- a/rules/roadmap/rule.md
+++ b/rules/roadmap/rule.md
@@ -16,7 +16,7 @@ archivedreason: null
 guid: 3e1cb281-662b-4420-a016-713f27d69acf
 ---
 
-A Product Backlog is a great way to see the fairly small broken up Product Backlog Items (PBIs) that make up your team's "to do" list, but it can be a bit too **zoomed in** and makes it easy to stray from the product goals.
+A Product Backlog is a great way to see the fairly small broken up Product Backlog Items (PBIs) that make up your team's "to do" list, but it can be a bit too **zoomed in** and makes it easy to stray from the [Product Goal](https://www.ssw.com.au/rules/the-3-commitments-in-scrum/).
 
 To get a better **zoomed out** view, you should have a product roadmap. 
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed the use of vague "product goals", where it can be made more specific by linking directly to 1 of the 3 Scrum Commitments - that is, the Product Goal

> 2. What was changed?

- "product goals" was changed to "Product Goal" with a link to ["Do you know the 3 commitments in Scrum (Product Goal, Sprint Goal, and Definition of Done)?"](https://www.ssw.com.au/rules/the-3-commitments-in-scrum/)

> 3. Did you do pair or mob programming (list names)?

❌ No
