### PR TITLE
Update Rule “hand-over-responsibilities/rule”

### DIFF
--- a/rules/hand-over-responsibilities/rule.md
+++ b/rules/hand-over-responsibilities/rule.md
@@ -9,6 +9,7 @@ authors:
     url: https://ssw.com.au/people/brady-stroud
 related:
   - hand-over-projects
+  - how-to-hand-over-tasks-to-others
 redirects: []
 created: 2024-03-07T06:22:03.000Z
 archivedreason: null


### PR DESCRIPTION
I was referencing this rule, and noticed it should be linked back & forth with **how-to-hand-over-tasks-to-others**