### PR TITLE
Update Rule “how-to-hand-over-tasks-to-others/rule”

### DIFF
--- a/rules/how-to-hand-over-tasks-to-others/rule.md
+++ b/rules/how-to-hand-over-tasks-to-others/rule.md
@@ -13,6 +13,7 @@ authors:
     url: https://www.ssw.com.au/people/camilla-rosa-silva
 related:
   - do-you-know-how-to-handover-a-project
+  - how-to-hand-over-tasks-to-others
 redirects:
   - do-you-know-how-to-hand-over-tasks-aka-emails-to-others
   - do-you-know-how-to-hand-over-tasks-(aka-emails)-to-others


### PR DESCRIPTION
I was referencing this rule, and noticed it should be linked back & forth with **hand-over-responsibilities**