### PR TITLE
XS✔ ◾ 3 steps to PBI - Add separate step for PR

### DIFF
--- a/rules/3-steps-to-a-pbi/rule.md
+++ b/rules/3-steps-to-a-pbi/rule.md
@@ -21,6 +21,7 @@ related:
   - rules-to-better-product-owners
   - acceptance-criteria
   - reply-done-plus-added-a-unit-test
+  - write-a-good-pull-request
   - record-a-quick-and-dirty-done-video
   - definition-of-done
   - done-do-you-know-when-to-send-a-done-email-in-scrum

--- a/rules/3-steps-to-a-pbi/rule.md
+++ b/rules/3-steps-to-a-pbi/rule.md
@@ -13,6 +13,8 @@ authors:
     url: https://ssw.com.au/people/matt-wicks
   - title: Piers Sinclair
     url: https://ssw.com.au/people/piers-sinclair
+  - title: Brady Stroud
+    url: https://ssw.com.au/people/brady-stroud
 related:
   - turn-emails-into-pbis
   - have-a-definition-of-ready
@@ -57,11 +59,12 @@ This step depends on the complexity and nature of the task, especially if the PB
 
 1. On the Sprint board, move your PBI into "In Progress"
 2. Create a new branch and code, code, code... (remember to [Red, Green, Refactor](/reply-done-plus-added-a-unit-test))
-3. Open a Pull Request and get another engineer in your team to do an ["over the shoulder"](/over-the-shoulder) check of the code
-4. Record a [Done Video](/record-a-quick-and-dirty-done-video) so you get your ducks in a row for the explanation to the Product Owner
-5. Show the Product Owner so they give you earlier feedback
-6. Make changes based on feedback (and then get more feedback)
-7. Check your [Definition of Done](/definition-of-done) and complete the Pull Request!
+3. Open a Pull Request with [lots of context](/write-a-good-pull-request)
+4. Get another engineer in your team to do an ["over the shoulder"](/over-the-shoulder) check of the code
+5. Record a [Done Video](/record-a-quick-and-dirty-done-video) so you get your ducks in a row for the explanation to the Product Owner
+6. Show the Product Owner so they give you earlier feedback
+7. Make changes based on feedback (and then get more feedback)
+8. Check your [Definition of Done](/definition-of-done) and complete the Pull Request!
 
 ### 3. Done
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I wanted to link to the PR, rule so I made PR a separate step.

> 2. What was changed?

✏️

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
