### PR TITLE
Removed duplicate entry from rules-to-successful-projects.md

### DIFF
--- a/categories/company-operations/rules-to-successful-projects.md
+++ b/categories/company-operations/rules-to-successful-projects.md
@@ -68,7 +68,6 @@ index:
 - does-your-scrum-master-aka-project-manager-maintain-a-strict-project-schedule
 - management-do-you-have-a-release-update-debrief-meeting-on-a-weekly-basis
 - management-do-you-know-who-has-authority
-- conduct-a-test-please
 - have-an-induction-program
 - do-you-identify-development-test-and-production-crm-web-servers-by-colors
 - record-a-quick-and-dirty-done-video


### PR DESCRIPTION
conduct-a-test-please was duplicated twice, leading to rules 50 and 55 being the same rule. Have removed the later version of the duplicate

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️Induction for small content changes to SSW Rules

> 2. What was changed?

✏️Removed duplicate for Rules to Successful Projects

> 3. Did you do pair or mob programming (list names)?

✏️ I worked with @ncn-ssw 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
