### PR TITLE
XS✔ ◾ 🧙‍♂️ Remove TDD mention from 3 steps to PBI rule.md

### DIFF
--- a/rules/3-steps-to-a-pbi/rule.md
+++ b/rules/3-steps-to-a-pbi/rule.md
@@ -60,7 +60,7 @@ You have a Sprint Backlog of PBIs (tasks, features, and fixes) which are already
 This step depends on the complexity and nature of the task, especially if the PBI involves intricate coding or extensive testing to meet the defined [Acceptance Criteria](/acceptance-criteria).
 
 1. On the Sprint board, move your PBI into "In Progress"
-2. Create a new branch and code, code, code... (remember to [Red, Green, Refactor](/reply-done-plus-added-a-unit-test))
+2. Create a new branch and code, code, code...
 3. Open a Pull Request with [lots of context](/write-a-good-pull-request)
 4. Get another engineer in your team to do an ["over the shoulder"](/over-the-shoulder) check of the code
 5. Record a [Done Video](/record-a-quick-and-dirty-done-video) so you get your ducks in a row for the explanation to the Product Owner


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ TDD is old fashioned and not a good global prescription. Stop.

> 2. What was changed?

✏️ Remove TDD

> 3. Did you do pair or mob programming (list names)?

✏️ no what.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
