### PR TITLE
Added hyperlink tip to Checked By rule

### DIFF
--- a/rules/checked-by-xxx/rule.md
+++ b/rules/checked-by-xxx/rule.md
@@ -54,6 +54,10 @@ Doing this will ensure:
 - You don’t forget anything important
 - The receiver knows who else agrees with the content
 
+::: tip
+Not everyone knows about this rule - make the "checked by" line a hyperlink to this rule to avoid confusion
+:::
+
 ::: email-template
 | | |
 | -------- | --- |
@@ -61,7 +65,7 @@ Doing this will ensure:
 | Cc: | Ulysses |
 ::: email-content
 
-(Checked by Uly)
+[(Checked by Uly)](https://www.ssw.com.au/rules/checked-by-xxx/)
 
 ### Hi Bob
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The Checked By rule is great, but it can be problematic for external recipients who don't know about it. It can come across as though the person sending the email is not "qualified" to send emails without being babysat. This change suggests making the Checked By line a hyperlink to the rule to help avoid confusion.

> 2. What was changed?

✏️ Tip added to the rule suggesting to make the "Checked by" line a hyperlink to the rule.

> 3. Did you do pair or mob programming (list names)?

✏️ Discussed the proposed change with @adamcogan and @danielmackay. Also with @camillars re adding a tracking link but this will go elsewhere.
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
