### PR TITLE
XS✔ ◾ backlog refinement meeting - change prescription for number of PBIs to refine

### DIFF
--- a/rules/backlog-refinement-meeting/rule.md
+++ b/rules/backlog-refinement-meeting/rule.md
@@ -65,11 +65,11 @@ Product Backlog: {{ LINK TO PRODUCT BACKLOG }}
 2. Refine and estimate the top PBIs that are not marked as "Ready" or in the "Not Ready" state
     * You should aim to have enough ready PBIs to cover work for the next 2-3 Sprints
     * Call in the Product Owner if any feature requires requirements clarification
-4. Check if any PBIs need to be added
+3. Check if any PBIs need to be added
     * Consider any [Tech Debt](/technical-debt) identified in the [architecture review](/do-you-conduct-an-architecture-review-after-every-sprint)
     * Consider if [PBIs need to be broken down](/create-pbis-under-2-days)
     * Consider if a [Spike](/encourage-spikes-when-a-story-is-inestimable) is required
-5. Check if any PBIs need to be deleted
+4. Check if any PBIs need to be deleted
     * Call in the Product Owner to double check
 
 :::

--- a/rules/backlog-refinement-meeting/rule.md
+++ b/rules/backlog-refinement-meeting/rule.md
@@ -62,9 +62,10 @@ Product Backlog: {{ LINK TO PRODUCT BACKLOG }}
 #### Agenda
 
 1. Skip all PBIs that are already marked as "Ready"
-2. Refine and estimate the top 5 PBIs that are not marked as "Ready" or in the "Not Ready" state
+2. Refine and estimate the top PBIs that are not marked as "Ready" or in the "Not Ready" state
+    * You should aim to have enough ready PBIs to cover work for the next 2-3 Sprints
     * Call in the Product Owner if any feature requires requirements clarification
-3. Check if any PBIs need to be added
+4. Check if any PBIs need to be added
     * Consider any [Tech Debt](/technical-debt) identified in the [architecture review](/do-you-conduct-an-architecture-review-after-every-sprint)
     * Consider if [PBIs need to be broken down](/create-pbis-under-2-days)
     * Consider if a [Spike](/encourage-spikes-when-a-story-is-inestimable) is required


### PR DESCRIPTION
I think specifying the top 5 PBIs isn't a good target - better to have 2-3 Sprint worth of work ready in case the meeting can't be held every week