### PR TITLE
XS✔ ◾ Moves 'Call SysAdmins' rule to better category

### DIFF
--- a/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.md
+++ b/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.md
@@ -78,6 +78,7 @@ index:
 - build-inter-office-interaction
 - efficiency-do-you-always-try-to-work-in-pairs
 - gather-team-opinions
+- call-your-system-administrators-before-raising-a-ticket
 - hand-over-responsibilities
 ---
  

--- a/categories/infrastructure-and-networking/rules-to-better-system-administrators.md
+++ b/categories/infrastructure-and-networking/rules-to-better-system-administrators.md
@@ -31,7 +31,6 @@ index:
 - label-your-assets
 - print-server
 - automate-patch-management
-- call-your-system-administrators-before-raising-a-ticket
 - educate-your-developer
 - ups-send-email
 - entra-group-access-reviews


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

@tiagov8 suggested the change in email "SSW Rules - Calling SysAdmins in the wrong category?"

> 2. What was changed?

The rule "Do you call your System Administrators before raising a ticket?" was moved from category "Rules to Better System Administrators" to "Rules to Better Software Consultants - Working in a Team".

It had appeared to be out of place given that it was for people other than System Administrators.

> 3. Did you do pair or mob programming (list names)?

❌ No.
