### PR TITLE
Cross reference weekly-client-love and upsell

### DIFF
--- a/rules/upsell/rule.md
+++ b/rules/upsell/rule.md
@@ -78,3 +78,7 @@ Figure: Good example - of upselling
 From the above video, you can see that the software consultants at SSW completed a Microsoft Form with the question: Your advice: Pretend you are talking to a junior dev about this concept of upselling. What do you say to them? Here were some stand out answers:
 
 ![Figure: Good ways to upsell](Screen Shot 2020-09-10 at 10.16.58 AM.png)
+
+::: greybox
+**Tip:** [Show your "Client Love" regularly](/weekly-client-love) so that your client are more willing to buy your upsellings.
+:::

--- a/rules/weekly-client-love/rule.md
+++ b/rules/weekly-client-love/rule.md
@@ -70,7 +70,7 @@ The tasks don't have to cost anything. Free tasks are more thoughtful and show t
 
 Some of these are also relevant to previous clients. Great consultants try to maintain a friendly relationship with previous clients by touching base. This will keep you in the back of the clients mind, and they will think of you next time they need some work done.
 
-Try not to urge to [upsell your products or services](/upsell) before you have gained your client's trust. The "Client Love" should focus on improving interpersonal relationship and should be non-work related.
+Try not to [upsell your products or services](/upsell) before you have gained your client's trust. The "Client Love" should focus on improving interpersonal relationship and should be non-work related.
 
 ::: greybox
 **Extra reading:** For some, the above comes naturally. For everyone else, read the book [How to Win Friends and Influence People](https://www.amazon.au/How-Win-Friends-Influence-People/dp/0671027034) written by Dale Carnegie. It is an easy read, the principles are easy to implement and will enhance all the relationships in your life.

--- a/rules/weekly-client-love/rule.md
+++ b/rules/weekly-client-love/rule.md
@@ -70,6 +70,8 @@ The tasks don't have to cost anything. Free tasks are more thoughtful and show t
 
 Some of these are also relevant to previous clients. Great consultants try to maintain a friendly relationship with previous clients by touching base. This will keep you in the back of the clients mind, and they will think of you next time they need some work done.
 
+Try not to urge to [upsell your products or services](/upsell) before you have gained your client's trust. The "Client Love" should focus on improving interpersonal relationship and should be non-work related.
+
 ::: greybox
 **Extra reading:** For some, the above comes naturally. For everyone else, read the book [How to Win Friends and Influence People](https://www.amazon.au/How-Win-Friends-Influence-People/dp/0671027034) written by Dale Carnegie. It is an easy read, the principles are easy to implement and will enhance all the relationships in your life.
 :::


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email - "Update rules - Cross link the Client Love rule and the Upselling rule"

As per my conversation with Adam, the ["show client love" rule](https://ssw.com.au/rules/weekly-client-love)  from the last CTF (Apr 26th) has received some misunderstandings with the existence of the ["upselling" rule](https://www.ssw.com.au/rules/upsell). We have different practises to follow for the 2 rules and we want to make it explicit.
1. Update the rules to clarify the difference
2. Cross reference by adding links to each other

> 2. What was changed?

✏️ The weekly-client-love rule and the upsell rule have been updated to add cross references

> 3. Did you do pair or mob programming (list names)?

✏️
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
