### PR TITLE
Correct formatting of info box on Sprint Forecast email

### DIFF
--- a/rules/sprint-forecast/rule.md
+++ b/rules/sprint-forecast/rule.md
@@ -83,4 +83,4 @@ Figure: Good example - Copy this as email template and send to Product Owner
    E.g. `https://dev.azure.com/ssw/Northwind/_sprints/backlog/Northwind%20Team/Northwind/Sprint%201`
 2. Remove the unnecessary columns so it looks clean
 3. Select all items, copy, then paste into the Sprint Forecast email
-   :::
+:::


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed that the formatting of the info box was incorrect.

> 2. What was changed?

The closing ":::" was moved to the start of the line.

> 3. Did you do pair or mob programming (list names)?

❌ No.