### PR TITLE
Updated rules to include links to PBIs in todos

### DIFF
--- a/categories/software-engineering/rules-to-better-code-commenting.md
+++ b/categories/software-engineering/rules-to-better-code-commenting.md
@@ -7,11 +7,10 @@ index:
 - code-commenting
 - what-to-do-with-comments-and-debug-print-statements
 - comment-when-your-code-is-updated
-- create-task-list-comments-for-your-code
+- todo-tasks
 - add-a-comment-when-you-use-thread-sleep
 - what-to-do-with-a-work-around
 - comment-each-property-and-method
-- todo-tasks
 ---
 
 

--- a/rules/create-task-list-comments-for-your-code/rule.md
+++ b/rules/create-task-list-comments-for-your-code/rule.md
@@ -1,7 +1,7 @@
 ---
 seoDescription: Create task list comments for your code to manage features, corrections, and reminders with ease.
 type: rule
-archivedreason: Consolidated with todo-tasks pplus outdated legacy link
+archivedreason: Consolidated with todo-tasks - https://www.ssw.com.au/rules/todo-tasks
 title: Comments - Do you create Task List Comments for your code?
 guid: 7fd9ea97-c399-41b7-821b-b5d4005ca13c
 uri: create-task-list-comments-for-your-code
@@ -24,14 +24,14 @@ Task List comments can be used to indicate a variety of work to be done at the l
 
 <!--endintro-->
 
-As with other Task List entries, you can double-click any comment entry to display the file indicated in the Code Editor and jump to the line of code marked. More details for [Task List comments](https://www.ssw.com.au/SSW/Redirect/MSDN2/TaskListcomments.htm).
+As with other Task List entries, you can double-click any comment entry to display the file indicated in the Code Editor and jump to the line of code marked. 
 
 ::: bad
 ![Figure: Bad example - the comment doesn't show in Task List window](pic1.png)
 :::
 
 ::: good
-![Figure: Good example - Marked TODO in the comment, so you can see it in Task List window and double-click to jump to  ](pic2.png)
+![Figure: Good example - Marked TODO in the comment, so you can see it in Task List window and double-click to jump to](pic2.png)
 :::
 
 ::: good

--- a/rules/create-task-list-comments-for-your-code/rule.md
+++ b/rules/create-task-list-comments-for-your-code/rule.md
@@ -1,7 +1,7 @@
 ---
 seoDescription: Create task list comments for your code to manage features, corrections, and reminders with ease.
 type: rule
-archivedreason:
+archivedreason: Consolidated with todo-tasks pplus outdated legacy link
 title: Comments - Do you create Task List Comments for your code?
 guid: 7fd9ea97-c399-41b7-821b-b5d4005ca13c
 uri: create-task-list-comments-for-your-code

--- a/rules/todo-tasks/rule.md
+++ b/rules/todo-tasks/rule.md
@@ -8,20 +8,74 @@ authors:
     url: https://www.ssw.com.au/people/adam-cogan
   - title: Matt Wicks
     url: https://www.ssw.com.au/people/matt-wicks
+  - title: Matt Goldman
+    url: https://www.ssw.com.au/people/matt-goldman
 related:
   - do-you-make-todo-items-in-red
 created: 2021-08-09T23:00:41.371Z
 guid: 1f5d6f06-e69f-4306-9601-df6640bd5caa
 ---
 
-When you have an idea for content or notice some content is missing and cannot be written straight away, it is important to document it. It should be done by adding the words "TODO:" followed by what you want to be added there.
+It's common to add a `TODO` comment to some code you're working on, either because there's more work to be done here or because you've spotted a problem that will need to be fixed later. But how do you ensure these are tracked and followed up?
 
 <!--endintro-->
 
-### GitHub
+We add a `TODO` comment to our code when we have either identified or introduced [technical debt](/technical-debt) as a way of showing other developers that there's work to be done here. It could be finishing the implementation of a feature, or it could be fixing a bug which (hypothetically) is limited in scope and therefore deprioritized. That's all well and good if another developer happens to be looking at that code and sees the comment, but if nobody looks at the code, then the problem could potentially never be fixed.
 
-For GitHub projects, [creating an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) using "TODO" as prefix is the preferred way.
+```cs
+public class UserService(ApplicationDbContext context) : IUserService
+{
+    public async Task<UserDto> GetUserByEmailAsync(string emailAddress, CancellationToken cancellationToken = default)
+    {
+        var dbUser = await context.Users
+          .AsNoTracking()
+          .FirstOrDefaultAsync(u => u.Email == emailAddress, cancellationToken);
 
-### VS Code Extension
+        // TODO: handle null user if not found
+        return new UserDto
+        {
+            Id          = dbUser.Id,
+            Name        = dbUser.Name,
+            Email       = dbUser.Email,
+            TenantId    = dbUser.TenantId.ToString()
+        }
+    }
+}
+```
+::: bad
+Bad Example - there is problematic code here, and while the comment is useful as it immediately alerts developers to the problem, but it is not tracked anywhere
 
-In VS Code, we recommend using the extension [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree). You can find TODOs and highlight them in open files.
+:::
+
+
+Just like with any other technical debt, it's critical to ensure that it is captured on the backlog. When you add a `TODO` in your code, it should _always_ be accompanied by a link to the PBI.
+
+
+```cs
+public class UserService(ApplicationDbContext context) : IUserService
+{
+    public async Task<UserDto> GetUserByEmailAsync(string emailAddress, CancellationToken cancellationToken = default)
+    {
+        var dbUser = await context.Users
+          .AsNoTracking()
+          .FirstOrDefaultAsync(u => u.Email == emailAddress, cancellationToken);
+
+        // TODO: handle null user if not found. See: https://github.com/SSWConsulting/SSWSockDarner/issues/324
+        return new UserDto
+        {
+            Id          = dbUser.Id,
+            Name        = dbUser.Name,
+            Email       = dbUser.Email,
+            TenantId    = dbUser.TenantId.ToString()
+        }
+    }
+}
+```
+::: good
+Good Example - the `TODO` is tracked on the backlog, so the developers and the Product Owner have visibility of the problem and can plan and prioritise accordingly.
+
+:::
+
+::: info
+💡 **Tip:** If you are reviewing a Pull Request and you spot a `TODO` without a link to a PBI, you should either create the PBI and update the code (Good Samaritan) or request the change before approving and merging the code.
+:::

--- a/rules/todo-tasks/rule.md
+++ b/rules/todo-tasks/rule.md
@@ -10,6 +10,8 @@ authors:
     url: https://www.ssw.com.au/people/matt-wicks
   - title: Matt Goldman
     url: https://www.ssw.com.au/people/matt-goldman
+  - title: Daniel Mackay
+    url: https://www.ssw.com.au/people/daniel-mackay
 related:
   - do-you-make-todo-items-in-red
 created: 2021-08-09T23:00:41.371Z

--- a/rules/todo-tasks/rule.md
+++ b/rules/todo-tasks/rule.md
@@ -43,13 +43,10 @@ public class UserService(ApplicationDbContext context) : IUserService
 }
 ```
 ::: bad
-Bad Example - there is problematic code here, and while the comment is useful as it immediately alerts developers to the problem, but it is not tracked anywhere
-
+Bad example - There is problematic code here, and while the comment is useful as it immediately alerts developers to the problem, but it is not tracked anywhere
 :::
 
-
 Just like with any other technical debt, it's critical to ensure that it is captured on the backlog. When you add a `TODO` in your code, it should _always_ be accompanied by a link to the PBI.
-
 
 ```cs
 public class UserService(ApplicationDbContext context) : IUserService
@@ -72,10 +69,9 @@ public class UserService(ApplicationDbContext context) : IUserService
 }
 ```
 ::: good
-Good Example - the `TODO` is tracked on the backlog, so the developers and the Product Owner have visibility of the problem and can plan and prioritise accordingly.
-
+Good example - The `TODO` is tracked on the backlog, so the developers and the Product Owner have visibility of the problem and can plan and prioritise accordingly
 :::
 
 ::: info
-💡 **Tip:** If you are reviewing a Pull Request and you spot a `TODO` without a link to a PBI, you should either create the PBI and update the code (Good Samaritan) or request the change before approving and merging the code.
+**Tip:** If you are reviewing a Pull Request and you spot a `TODO` without a link to a PBI, you should either create the PBI and update the code (Good Samaritan) or request the change before approving and merging the code.
 :::


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Conversation with @danielmackay 

> 2. What was changed?

✏️ The rules around `TODOs` were updated - an old rule was archived and another rule was updated to indicate that they should be linked to the backlog.

> 3. Did you do pair or mob programming (list names)?

✏️N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
