### PR TITLE
Warn then call - add space for greybox

### DIFF
--- a/rules/warn-then-call/rule.md
+++ b/rules/warn-then-call/rule.md
@@ -57,7 +57,7 @@ e.g. a Sprint Review
 
 If the conversation has history, like a PBI/Issue or email, then it's important to [include the context](/add-context-reasoning-to-emails).
 
-:::greybox
+::: greybox
 Calling in 1 minute. See the PBI/Issue:
 
 **{{ URL }}**


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Failure in rules build pipeline

> 2. What was changed?

✏️ Added a whitespace after the 3 semicolons for one of the grey boxes

> 3. Did you do pair or mob programming (list names)?

✏️ N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
