### PR TITLE
Fix - Do you record a summary of your Sprint Meeting?

### DIFF
--- a/rules/summary-recording-sprint-reviews/rule.md
+++ b/rules/summary-recording-sprint-reviews/rule.md
@@ -72,11 +72,11 @@ You should also include a description about the contents for ease of navigation.
 ::: greybox
 Join us for {{ TEAM NAME }}'s Sprint {{ OLD NUMBER }} Review + Retro and Sprint {{ NEW NUMBER }} Planning
 
-{{ MIN }}:{{ SEC }} Intro
-{{ MIN }}:{{ SEC }} Sprint Review
-{{ MIN }}:{{ SEC }} Sprint Retro
-{{ MIN }}:{{ SEC }} Sprint Planning
-{{ MIN }}:{{ SEC }} Outro
+{{ MIN }}:{{ SEC }} Intro  
+{{ MIN }}:{{ SEC }} Sprint Review  
+{{ MIN }}:{{ SEC }} Sprint Retro  
+{{ MIN }}:{{ SEC }} Sprint Planning  
+{{ MIN }}:{{ SEC }} Outro  
 
 🔗 Link: {{ PRODUCT WEBSITE URL }}
 :::


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ noticed error on the layout of below box, each part should be displayed in the new line

https://www.ssw.com.au/rules/summary-recording-sprint-reviews
![image](https://github.com/user-attachments/assets/c89f64fc-ee7d-4fae-8a99-2b030aee96b5)
**Figure: Each part of the video description need to be displayed in new line**

> 2. What was changed?

✏️ added space

> 3. Did you do pair or mob programming (list names)?

✏️ no
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
