### PR TITLE
💄Small change to add priority number is IM messages

### DIFF
--- a/rules/cross-approvals/rule.md
+++ b/rules/cross-approvals/rule.md
@@ -89,6 +89,11 @@ Once the list is compiled, assign each person a priority. That determines the or
 **Tip:** Set the "original approver" as the lowest priority to minimize their involvement.
 :::
 
+::: greybox
+**Tip:** When pinging the approvers in priority order, make sure to include the priority number as part of the message.  
+**Example:** Calling you to review a code change - Code Master (2/5)
+:::
+
 ::: bad
 ![Figure: Bad example - Adam approves the completion of everyone's induction](induction-bad.png)
 :::


### PR DESCRIPTION
Made a small addition to the second step to instruct users to add priority numbers as part of their messages to masters. Suggested by Adam to signify when you are the "last line of defense" for a query.

>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Adam

> 2. What was changed?

✏️ Made a small addition to the second step to instruct users to add priority numbers as part of their messages to masters.
Suggested by Adam to signify when you are the "last line of defense" for a query.

> 3. Did you do pair or mob programming (list names)?

✏️ Nope
