### PR TITLE
XS✔ ◾ Do you use AI pair programming? - specify Copilot (product name) instead of the website url

### DIFF
--- a/rules/ai-pair-programming/rule.md
+++ b/rules/ai-pair-programming/rule.md
@@ -40,7 +40,7 @@ There is a lot to love with AI pair programming ❤️, here is just a taste of 
 * Query APIs
 * Do unit tests
 
-### Github Copilot - Help with reading and understanding code
+### GitHub Copilot - Help with reading and understanding code
 
 * Generate Pull Request summaries
 * Explore and learn about a codebase

--- a/rules/ai-pair-programming/rule.md
+++ b/rules/ai-pair-programming/rule.md
@@ -40,7 +40,7 @@ There is a lot to love with AI pair programming ❤️, here is just a taste of 
 * Query APIs
 * Do unit tests
 
-### Github.com - Help with reading and understanding code
+### Github Copilot - Help with reading and understanding code
 
 * Generate Pull Request summaries
 * Explore and learn about a codebase


### PR DESCRIPTION
I noticed a couple of issues on the rule talked about the GitHub Copilot:
- GitHub was incorrectly capitalised
- Website was referenced when Copilot was offering the feature