### PR TITLE
🗑️ Removed whitespace after backslash

### DIFF
--- a/rules/scrum-master-do-you-schedule-the-3-meetings/rule.md
+++ b/rules/scrum-master-do-you-schedule-the-3-meetings/rule.md
@@ -73,13 +73,13 @@ This is a calendar appointment to hold the following 3 Scrum meetings:
 
 **Sprint Review Meeting**
 
-We will go through the user stories that have been completed and demonstrate them.\  
+We will go through the user stories that have been completed and demonstrate them.\
 See rule [What happens at a Sprint Review Meeting?](/do-you-know-what-happens-at-a-sprint-review-meeting)
 
 **Sprint Retrospective Meeting**
 
 Sprint closed and new Sprint starts.  
-We ask for feedback of the previous Sprint so that we can ‘Inspect and Adapt’.\  
+We ask for feedback of the previous Sprint so that we can ‘Inspect and Adapt’.\
 See rule [What happens at a Sprint Retrospective Meeting?](/do-you-know-what-happens-at-a-sprint-retrospective-meeting)
 
 **Sprint Planning Meeting**


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The whitespace after backslash are causing backslash to be displayed in the view

https://www.ssw.com.au/rules/scrum-master-do-you-schedule-the-3-meetings/
![image](https://github.com/user-attachments/assets/cdf0c607-66b3-4bef-9c41-3aa3c21d8a8f)
**Figure: The backslashes are displayed in the view**

> 2. What was changed?

✏️ Removed whitespaces after backslash

> 3. Did you do pair or mob programming (list names)?

✏️ No

<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
