### PR TITLE
Update Rule “important-documents-to-get-started-on-unit-testing/rule”

### DIFF
--- a/rules/important-documents-to-get-started-on-unit-testing/rule.md
+++ b/rules/important-documents-to-get-started-on-unit-testing/rule.md
@@ -1,7 +1,9 @@
 ---
-seoDescription: Discover essential resources to get started with unit testing and learn how to write high-quality software with these expert-approved sources.
 type: rule
 title: Do you know good sources of information to get started with Unit Testing?
+seoDescription: Discover essential resources to get started with unit testing
+  and learn how to write high-quality software with these expert-approved
+  sources.
 uri: important-documents-to-get-started-on-unit-testing
 authors:
   - title: Adam Cogan
@@ -13,16 +15,14 @@ created: 2020-03-11T16:55:47.000Z
 archivedreason: null
 guid: 93dfc4c7-0db5-4d93-8083-cbe7f6c5e648
 ---
-
 Check out these sources to get an understanding of the role of unit testing in delivering high-quality software:
 
 <!--endintro-->
 
-- Read the [Wikipedia Unit test](https://www.ssw.com.au/SSW/Redirect/WikipediaUnitTest.htm) page and learn how to write unit tests on fragile code.
-- Read Tim Ottinger & Jeff Langr's [**FIRST** principles of unit tests](http://agileinaflash.blogspot.com/2009/02/first.html) (**F**ast, **I**solated, **R**epeatable, **S**elf-validating, **T**imely) to learn about some common properties of good unit tests.
-- Read Bas Dijkstra's [Why I think unit testing is the basis of any solid automation strategy](https://www.ontestautomation.com/why-i-think-unit-testing-is-the-basis-of-any-solid-automation-strategy/) article to understand how a good foundation of unit tests helps you with your automation strategy.
-- Read Martin Fowler's [UnitTest](https://martinfowler.com/bliki/UnitTest.html) to learn about some different opinions as to what constitutes a "unit".
-- Read the short article [100 Percent Unit Test Coverage Is Not Enough](https://www.stickyminds.com/article/100-percent-unit-test-coverage-not-enough) by John Ruberto as a cautionary tale about focusing on test coverage over test quality.
-
-- Read the [Wikipedia Test-driven development](https://www.ssw.com.au/SSW/Redirect/WikipediaTest-drivenDevelopment.htm) page (optional)
-- Read the [SSW Rule - Test Please](/conduct-a-test-please-internally-and-then-with-the-client) - we never release un-tested code to a client!
+* Read the [Wikipedia Unit test](http://en.wikipedia.org/wiki/Unit_testing) page and learn how to write unit tests on fragile code.
+* Read Tim Ottinger & Jeff Langr's [**FIRST** principles of unit tests](http://agileinaflash.blogspot.com/2009/02/first.html) (**F**ast, **I**solated, **R**epeatable, **S**elf-validating, **T**imely) to learn about some common properties of good unit tests.
+* Read Bas Dijkstra's [Why I think unit testing is the basis of any solid automation strategy](https://www.ontestautomation.com/why-i-think-unit-testing-is-the-basis-of-any-solid-automation-strategy/) article to understand how a good foundation of unit tests helps you with your automation strategy.
+* Read Martin Fowler's [UnitTest](https://martinfowler.com/bliki/UnitTest.html) to learn about some different opinions as to what constitutes a "unit".
+* Read the short article [100 Percent Unit Test Coverage Is Not Enough](https://www.stickyminds.com/article/100-percent-unit-test-coverage-not-enough) by John Ruberto as a cautionary tale about focusing on test coverage over test quality.
+* Read the [Wikipedia Test-driven development](http://en.wikipedia.org/wiki/Test-driven_development) page (optional)
+* Read the [SSW Rule - Test Please](/conduct-a-test-please-internally-and-then-with-the-client) - we never release un-tested code to a client!


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Reading this for a SugarLearning item and realized the links were broken because he redirects weren't migrated. I've updated the links to be the destinations of the redirects.

> 2. What was changed?

✏️

Changed the links 

**from**:

Read the \[Wikipedia Test-driven development\]\(~~https://www.ssw.com.au/SSW/Redirect/WikipediaTest-drivenDevelopment.htm~~ \) page (optional)

Read the \[Wikipedia Unit test\]\(~~https://www.ssw.com.au/SSW/Redirect/WikipediaUnitTest.htm~~ \)

**to**

Read the \[Wikipedia Unit test\]\(<mark>http://en.wikipedia.org/wiki/Unit_testing</mark>\)

Read the \[Wikipedia Test-driven development\]\(<mark>http://en.wikipedia.org/wiki/Test-driven_development</mark>\) page (optional)

> 3. Did you do pair or mob programming (list names)?

✏️ N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
