### PR TITLE
Update Rule “chatgpt-security-risks/rule”

### DIFF
--- a/rules/chatgpt-security-risks/rule.md
+++ b/rules/chatgpt-security-risks/rule.md
@@ -1,7 +1,9 @@
 ---
-seoDescription: ChatGPT security risks include data breaches and unauthorized access to confidential information, while best practices involve not sharing sensitive info and monitoring data retention policies.
 type: rule
 title: Do you know the potential security risks of using ChatGPT?
+seoDescription: ChatGPT security risks include data breaches and unauthorized
+  access to confidential information, while best practices involve not sharing
+  sensitive info and monitoring data retention policies.
 uri: chatgpt-security-risks
 authors:
   - title: Ulysses Maclaren
@@ -9,14 +11,13 @@ authors:
 created: 2023-05-16T14:47:50.644Z
 guid: 9eddfea2-3870-4814-8097-ddbf68afaa36
 ---
-
 ChatGPT is an AI language model developed by OpenAI that is considered generally safe due to the implementation of various security measures, data handling practices, and privacy policies. However, users should be aware of potential risks and follow best practices when using the platform.
 
 ::: good
 ![Figure: Good Example - You want to use your tools safely!](safe-dev.jpg)
 :::
 
-Open AI is a third-party platform and you should not make assumptions about how they process or retain data. They will also likely be able to change their policies from time to time so even if something is stated today it might be different tomorrow.
+OpenAI is a third-party platform and you should not make assumptions about how they process or retain data. They will also likely be able to change their policies from time to time so even if something is stated today it might be different tomorrow.
 
 You should never submit any confidential information into ChatGPT. Specifically, you should never submit any information which identifies or could potentially be used to identify an individual (E.g. name, address, date of birth, phone number etc.)
 
@@ -31,7 +32,6 @@ Key points:
   * External security audits
   * Bug bounty program
   * Incident response plans
-
 * Responsible data handling practices by OpenAI:
 
   * Transparency about data collection purposes
@@ -39,11 +39,10 @@ Key points:
   * Controlled data sharing with third parties
   * Compliance with regional data protection regulations
   * Respecting user rights and control over their data
-
 * ChatGPT is not confidential:
 
-  * All conversations are used as training data by default, but this can be turnedd off in the paid versions
-  * Users should avoid sharing sensitive information in the free version
+  * All conversations are used as training data by default, but this can be turned off
+  * Users should avoid sharing sensitive information
 
 ![Figure: Toggle Your Name | Settings | Data controls | Improve the model for everyone to stop the model training on your data](trainingondata.png)
 
@@ -52,14 +51,12 @@ Key points:
   * Data breaches
   * Unauthorized access to confidential information
   * Biased or inaccurate information generation
-
 * Best practices for using ChatGPT:
 
-  * Do not share or submit sensitive or confidential information on Chat GPT, ever
+  * Do not share or submit sensitive or confidential information on ChatGPT, ever
   * Review privacy policies of platforms using ChatGPT
   * Use anonymous or pseudonymous accounts
   * Monitor data retention policies
-
 * Current regulations:
 
   * No specific regulations for AI systems like ChatGPT


### PR DESCRIPTION
> 1. What triggered this change?

ChatGPT's "Improve the model for everyone setting" can now be turned off by all users

> 2. What was changed?

- Removed explicit mention of free and paid users in turning off your conversation being used as training data by default and sharing sensitive information
- Fixed minor spelling mistakes

> 3. Did you do pair or mob programming (list names)?

N/A