### PR TITLE
🦺 Validation - Removed 'created' field from frontmatter validation check

### DIFF
--- a/scripts/frontmatter-validator/schema/rule-schema.json
+++ b/scripts/frontmatter-validator/schema/rule-schema.json
@@ -19,10 +19,6 @@
       "type": "string",
       "format": "uuid"
     },
-    "created": {
-      "type": "string",
-      "format": "date-time"
-    },
     "authors": {
       "type": "array",
       "items": {
@@ -53,7 +49,7 @@
       }
     }
   },
-  "required": ["type", "title", "guid", "uri", "created", "authors"],
+  "required": ["type", "title", "guid", "uri", "authors"],
   "additionalProperties": true,
   "errorMessage": {
     "properties": {
@@ -62,7 +58,6 @@
       "archivedreason": "'archivedreason' must be deleted or left empty.",
       "guid": "'guid' must be a valid GUID.",
       "uri": "'uri' must not be empty.",
-      "created": "'created' must not be empty.",
       "authors": "'authors' must be valid content."
     }
   }


### PR DESCRIPTION
### Description
Based on my investigation this field is not being used in the main code base. We have a separate JSON file containing the list of changes across all of the rules.
