### PR TITLE
XS✔ ◾ Aspire Rule - Extend good and bad examples

### DIFF
--- a/rules/aspire/rule.md
+++ b/rules/aspire/rule.md
@@ -57,35 +57,35 @@ Leverage predefined templates and tooling to:
 
 1. Manually set up a Redis container (e.g., using Docker Compose).
 
-```yaml
-version: '3.9'
+  ```yaml
+  version: '3.9'
 
-services:
-  redis:
-    image: redis:latest
-    container_name: redis-cache
-    ports:
-      - "6379:6379"
-    environment:
-      REDIS_PASSWORD: examplepassword # Optional, for enabling authentication
-    command: ["redis-server", "--requirepass", "examplepassword"] # Optional, for setting up a password
-    volumes:
-      - redis_data:/data # Persist data locally
+  services:
+    redis:
+      image: redis:latest
+      container_name: redis-cache
+      ports:
+        - "6379:6379"
+      environment:
+        REDIS_PASSWORD: examplepassword # Optional, for enabling authentication
+      command: ["redis-server", "--requirepass", "examplepassword"] # Optional, for setting up a password
+      volumes:
+        - redis_data:/data # Persist data locally
 
-volumes:
-  redis_data:
-    driver: local
-```
+  volumes:
+    redis_data:
+      driver: local
+  ```
 
 2. Write custom code to handle connection strings and inject them into your application (this needs to be manually kept in sync with all your environments)
 
-```csharp
-var redisConnection = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING") ?? "localhost:6379";
-services.AddStackExchangeRedisCache(options =>
-{
-    options.Configuration = redisConnection;
-    options.InstanceName = "SampleInstance";
-});
+  ```csharp
+  var redisConnection = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING") ?? "localhost:6379";
+  services.AddStackExchangeRedisCache(options =>
+  {
+      options.Configuration = redisConnection;
+      options.InstanceName = "SampleInstance";
+  });
 ```
 
 ::: bad  
@@ -98,19 +98,25 @@ Aspire handles Redis setup and connection string injection for you:
 
 1. Configure your Aspire application and pass a reference to Redis Cache
 
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-var cache = builder.AddRedis("cache");
-builder.AddProject<Projects.MyApp>("app")
-       .WithReference(cache)
-       .WaitFor(cache);
-```
+  ```csharp
+  var builder = DistributedApplication.CreateBuilder(args);
+  var cache = builder.AddRedis("cache");
+  builder.AddProject<Projects.MyApp>("app")
+        .WithReference(cache)
+        .WaitFor(cache);
+  ```
 
 2. Add the client integration for Redis
 
-```cs
-builder.AddRedisClient("cache");
-```
+  ```cs
+  public static class DependencyInjection
+  {
+      public static void AddInfrastructure(this IHostApplicationBuilder builder)
+      {
+          builder.AddRedisClient("my-redis-connection-string");
+      }
+  }
+  ```
 
 ::: good
 **Figure: Good Example - Simple Redis setup with .NET Aspire 🚀**


### PR DESCRIPTION
This pull request includes several changes to the `rules/aspire/rule.md` file to improve the documentation for setting up Redis Cache in a .NET Core app using Aspire. The most important changes include adding a new author, updating example sections to use Docker Compose, and simplifying the Redis setup process with Aspire.

Documentation updates:

* Added Daniel Mackay as a new author in the `authors` section.
* Updated the "old way" example to include Docker Compose configuration for setting up a Redis container.

Simplifying Redis setup with Aspire:

* Added instructions to configure the Aspire application and pass a reference to Redis Cache.
* Added instructions to integrate the Redis client with Aspire.