### PR TITLE
XS✔ ◾ Update branching in git rule to link to branch naming rule

### DIFF
--- a/rules/do-you-know-when-to-branch-in-git/rule.md
+++ b/rules/do-you-know-when-to-branch-in-git/rule.md
@@ -19,6 +19,7 @@ authors:
     url: https://ssw.com.au/people/gabriel-george
 related:
   - do-you-use-the-best-deployment-tool
+  - branch-naming
 redirects: []
 ---
 
@@ -70,11 +71,11 @@ Figure: Bad example - Branch name is not descriptive
 :::
 
 ```console
-git branch create-basic-web-application
+git branch feature/1234-create-basic-web-application
 ```
 
 ::: good
-Figure: Good example - Branch name describes the intent of the change
+Figure: Good example - Branch name describes the intent of the change and follows a [branch naming convention](/branch-naming)
 :::
 
 **It is critical that this branch always comes off master, not another feature branch. Master is the only branch that is mandated to be in a deployable state, so any other option is unsafe.**

--- a/rules/do-you-know-when-to-branch-in-git/rule.md
+++ b/rules/do-you-know-when-to-branch-in-git/rule.md
@@ -29,7 +29,7 @@ Using this strategy, **master** is always production-ready and deployable.
 
 <!--endintro-->
 
-![](finishing-a-feature-with-world-class-flow.jpg)
+![Finishing a Feature with World Class Flow](finishing-a-feature-with-world-class-flow.jpg)
 
 ::: greybox
 **Note:** This rule applies to git. For branching advice in TFVC, see [when to branch](/do-you-know-when-to-branch).


### PR DESCRIPTION
Added links the the branch naming convention rule

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Creation of new rule

> 2. What was changed?

Updated the [do-you-know-when-to-branch-in-git](https://www.ssw.com.au/rules/do-you-know-when-to-branch-in-git/) to align with the new branch naming rule https://www.ssw.com.au/rules/branch-naming/ and added links to the new rule

> 3. Did you do pair or mob programming (list names)?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
