### PR TITLE
XS ◾ Fixed email template markdown

### DIFF
--- a/rules/add-days-to-dates/rule.md
+++ b/rules/add-days-to-dates/rule.md
@@ -33,11 +33,11 @@ To ensure complete clarity, you should always include the **day of the week** al
 | Subject: | Penny - Working from the Sydney office for 3 days |  
 ::: email-content
 
-### Hi Sydney team
+### Hi Sydney team,
 
-As per my conversation with Uly, I will be visiting your office for 3 days (**16th Sep** to **18th Sep**) to run the Angular Workshop.
+I'll be visiting your office for 3 days (**16th Sep** to **18th Sep**) to run the Angular Workshop.
 
-Looking forward to seeing you all!
+Looking forward to seeing you all!   
 Penny
 
 :::  
@@ -55,14 +55,15 @@ Figure: Bad example - The team know what dates you're coming, but it's not clear
 | Subject: | Penny - Working from the Sydney office for 3 days |  
 ::: email-content
 
-### Hi Sydney team
+### Hi Sydney team,
 
-As per my conversation with Uly, I will be visiting your office for 3 days (**Mon 16th Sep** to **Wed 18th Sep**) to run the Angular Workshop.
+I'll be visiting your office for 3 days (**Mon 16th Sep** to **Wed 18th Sep**) to run the Angular Workshop.
 
-Looking forward to seeing you all!
+Looking forward to seeing you all!   
 Penny
 
-:::  
+:::
+:::
 ::: good  
 Figure: Good example - Having the day of the week next to the date makes it easy for the team to know exactly when you're visting
 :::

--- a/rules/add-days-to-dates/rule.md
+++ b/rules/add-days-to-dates/rule.md
@@ -33,11 +33,11 @@ To ensure complete clarity, you should always include the **day of the week** al
 | Subject: | Penny - Working from the Sydney office for 3 days |  
 ::: email-content
 
-### Hi Sydney team,
+### Hi Sydney team
 
 I'll be visiting your office for 3 days (**16th Sep** to **18th Sep**) to run the Angular Workshop.
 
-Looking forward to seeing you all!   
+Looking forward to seeing you all!
 Penny
 
 :::  
@@ -55,11 +55,11 @@ Figure: Bad example - The team know what dates you're coming, but it's not clear
 | Subject: | Penny - Working from the Sydney office for 3 days |  
 ::: email-content
 
-### Hi Sydney team,
+### Hi Sydney team
 
 I'll be visiting your office for 3 days (**Mon 16th Sep** to **Wed 18th Sep**) to run the Angular Workshop.
 
-Looking forward to seeing you all!   
+Looking forward to seeing you all!
 Penny
 
 :::


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Broken email template
<img width="1000" alt="Screenshot 2025-01-20 at 7 47 44 PM" src="https://github.com/user-attachments/assets/78a3dcfc-04ad-4917-913b-cc24af4f75ad" />


> 2. What was changed?

Fixed markdown and reduced content for better reading

