### PR TITLE
XS ◾ Improved readability and syntax on "include-links-in-emails" rule

### DIFF
--- a/rules/include-links-in-emails/rule.md
+++ b/rules/include-links-in-emails/rule.md
@@ -23,12 +23,12 @@ guid: ed0fa76a-418b-4b59-9e3b-2544c08b910e
 
 Always include the relevant URL to your emails, like when you want to request or just made a change to a webpage or document. This way people can easily check the details of the tasks. This is especially important for ["Done" emails](/reply-done-and-delete-the-email).
 
-If you are using a task tracking system like **Azure DevOps**, **GitHub**, or Jira, also include the link to the PBI/Issue/task.
+If you are using a task tracking system like **Azure DevOps**, **GitHub**, or Jira, also include the link to the PBI/Issue/task/PR for extra information.
 
 <!--endintro-->
 
 ::: info
-**Tip:** It is [important to give context and reasoning](/do-you-add-context-reasoning-to-your-emails) to your emails too.
+**Tip:** It's [important to give context and reasoning](/do-you-add-context-reasoning-to-your-emails) to your emails.
 :::
 
 ::: greybox
@@ -47,13 +47,15 @@ Figure: Good example - Easy to check what was done
 :::
 
 ::: greybox
-Done - northwind&#46;com/about-us/ as requested on ssw2&#46;visualstudio&#46;com/Northwind/\_workitems/edit/00001
+Done - northwind&#46;com/about-us/ 
+
+As requested on ssw2&#46;visualstudio&#46;com/Northwind/\_workitems/edit/00001
 :::
 ::: good
 Figure: Good example - Easy to check what was done + includes the context of the task within the Sprint
 :::
 
-### Ensure changes are live
+## Ensure changes are live
 
 Before declaring a task 'done' with a link, ensure that your changes are live and accessible for verification.
 
@@ -61,7 +63,7 @@ Before declaring a task 'done' with a link, ensure that your changes are live an
 **Note:** It is the PR author's responsibility to [avoid merge debt](/merge-debt) by getting the PR reviewed ASAP.
 :::
 
-#### Scenario: PR waiting for approval
+### Scenario: PR waiting for approval
 
 ::: greybox
 Done - ssw&#46;com&#46;au/rules/dones-is-your-inbox-a-task-list-only
@@ -80,6 +82,7 @@ Figure: Bad example - Using the PR link instead of the final page link
 
 ::: greybox
 (PR waiting for approval - github&#46;com/SSWConsulting/SSW.Rules.Content/pull/0001)  
+
 Done - Changes will be on ssw&#46;com&#46;au/rules/dones-is-your-inbox-a-task-list-only
 
 :::
@@ -87,7 +90,7 @@ Done - Changes will be on ssw&#46;com&#46;au/rules/dones-is-your-inbox-a-task-l
 Figure: OK example - Changes are not live yet, but people are aware and have the links
 :::
 
-#### Scenario: PR is approved and merged
+### Scenario: PR is approved and merged
 
 ::: greybox
 Done - ssw&#46;com&#46;au/rules/dones-is-your-inbox-a-task-list-only
@@ -96,14 +99,14 @@ Done - ssw&#46;com&#46;au/rules/dones-is-your-inbox-a-task-list-only
 Figure: Good example - Final link is included and changes are live to be checked
 :::
 
-### Ensure others have permissions
+## Ensure others have permissions
 
 It is a common problem where someone CC'd will not have permissions to see a file and the sender knows this. You should still add the link but inform the recipient.
 
-#### Scenario: Recipient doesn't have permissions
+### Scenario: Recipient doesn't have permissions
 
 ::: greybox
-Done - onedrive.live.com/file-name.xls
+Done - onedrive&#46;live.com/file-name.xls
 :::
 ::: bad
 Figure: Bad example - Link is included but recipient won't be able to open it, potentially generating more emails
@@ -111,7 +114,8 @@ Figure: Bad example - Link is included but recipient won't be able to open it, p
 
 ::: greybox
 (link for reference - you don't have permissions)  
-Done - onedrive.live.com/file-name.xls
+
+Done - onedrive&#46;live.com/file-name.xls
 :::
 ::: good
 Figure: Good example - Link is included and people are aware of permission issues

--- a/rules/include-links-in-emails/rule.md
+++ b/rules/include-links-in-emails/rule.md
@@ -47,7 +47,7 @@ Figure: Good example - Easy to check what was done
 :::
 
 ::: greybox
-Done - northwind&#46;com/about-us/ 
+Done - northwind&#46;com/about-us/
 
 As requested on ssw2&#46;visualstudio&#46;com/Northwind/\_workitems/edit/00001
 :::

--- a/rules/include-links-in-emails/rule.md
+++ b/rules/include-links-in-emails/rule.md
@@ -10,6 +10,8 @@ authors:
     url: https://ssw.com.au/people/cameron-shaw
   - title: Ulysses Maclaren
     url: https://ssw.com.au/people/ulysses-maclaren
+  - title: Tiago Araujo
+    url: https://ssw.com.au/people/tiago-araujo
 related:
   - add-context-reasoning-to-emails
   - dones-do-you-include-useful-details-in-your-done-email


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Sent this link to @adamcogan and @mishmanners 

> 2. What was changed?

Improved examples readabillity with line breaks 
More small improvements
