### PR TITLE
S ◾ removed greater sign on "x-to-y"  + bad example + line break on Note for "indent" rule 

### DIFF
--- a/rules/change-from-x-to-y/rule.md
+++ b/rules/change-from-x-to-y/rule.md
@@ -82,7 +82,7 @@ On CodeAuditor web page ssw.com.au/ssw/codeauditor
 
 From:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\> Scan all your projects for coding <span style="background-color:#ff0000;color:#fff;font-weight:bolder;">bugs and</span> errors:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Scan all your projects for coding <span style="background-color:#ff0000;color:#fff;font-weight:bolder;">bugs and</span> errors:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; - Enforce industry best practices.
 
@@ -90,7 +90,7 @@ From:
 
 To:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\> Scan all your projects for coding errors
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Scan all your projects for coding errors
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; - <mark>Guarantee</mark> industry best practices
 

--- a/rules/indent/rule.md
+++ b/rules/indent/rule.md
@@ -27,9 +27,10 @@ Written communication can easily cause misunderstandings. Help the reader unders
 
 * Using “&gt;” and indentation when quoting the text from others, like the original email you are replying to.\
   **Note:** “&gt;” is not needed when quoting from a web page
-* Your text should be always kept to the left
+* Make the question/task followed by the respective answer in a logical order
 * [Add numbers to tasks](/number-tasks-questions) if the sender forgot.\
   Mention you changed the history. E.g. “(added numbers to tasks in the history, so we can clearly refer to them)”
+* Your text should be always kept to the left
 
 <!--endintro-->
 
@@ -67,6 +68,27 @@ Figure: Bad example - There's too much information with no reasonable order
 
 ### Hi Adam
 
+"Please change from X to Y"\
+Done - northwind365.com\
+"The program flow logic worries me a bit"\
+Sorry, this wasn't a final decision - I just put it there for testing purposes
+
+:::
+:::
+::: bad
+Figure: Bad example - Order is OK, but it's using quotes to reference others' text + no indentation + missing numbers on questions/tasks
+:::
+
+::: email-template
+
+| | |
+| -------- | --- |
+| To: | Adam |
+| Subject: | RE: Change on Northwind app |
+::: email-content
+
+### Hi Adam
+
 &nbsp;&nbsp;&nbsp; > 1. Please change from X to Y\
 Done - northwind365.com\
 &nbsp;&nbsp;&nbsp; > 2. The program flow logic worries me a bit\
@@ -74,8 +96,8 @@ Sorry, this wasn't a final decision - I just put it there for testing purposes
 
 :::
 :::
-::: bad
-Figure: Bad example - Even with order, without spacing the text becomes cramped and hard to read
+::: ok
+Figure: OK example - Even with ">", indentation and numbers, without spacing the text becomes cramped and hard to read
 :::
 
 ::: email-template

--- a/rules/indent/rule.md
+++ b/rules/indent/rule.md
@@ -25,9 +25,9 @@ guid: 1899c3db-ac1b-468e-a8e7-f2cdc5e0748a
 
 Written communication can easily cause misunderstandings. Help the reader understand your message better by:
 
-* Using “&gt;” and indentation when quoting the text from others, like the original email you are replying to
+* Using “&gt;” and indentation when quoting the text from others, like the original email you are replying to.\
   **Note:** “&gt;” is not needed when quoting from a web page
-* Your text should be kept to the left
+* Your text should be always kept to the left
 * [Add numbers to tasks](/number-tasks-questions) if the sender forgot.\
   Mention you changed the history. E.g. “(added numbers to tasks in the history, so we can clearly refer to them)”
 


### PR DESCRIPTION
cc @mishmanners 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

@adamcogan 's email : **Re: Rule - Change indentation and add >**

> 2. What was changed?

line break for better readability + removed `>` from X to Y 