### PR TITLE
Update Rule “meeting-do-you-update-your-tasks-before-the-daily-scrum/rule”

### DIFF
--- a/rules/meeting-do-you-update-your-tasks-before-the-daily-scrum/rule.md
+++ b/rules/meeting-do-you-update-your-tasks-before-the-daily-scrum/rule.md
@@ -1,7 +1,9 @@
 ---
-seoDescription: All team members must update their tasks with status and remaining hours before attending the daily Scrum meeting to ensure an accurate burn-down rate.
 type: rule
 title: Meeting - Do you update your tasks before the Daily Scrum?
+seoDescription: All team members must update their tasks with status and
+  remaining hours before attending the daily Scrum meeting to ensure an accurate
+  burn-down rate.
 uri: meeting-do-you-update-your-tasks-before-the-daily-scrum
 authors:
   - title: Adam Cogan
@@ -14,7 +16,6 @@ created: 2010-04-07T05:21:16.000Z
 archivedreason: null
 guid: 7ba991bc-384e-48ad-919e-09cb5b67472c
 ---
-
 All team members must update their tasks with status, (and remaining hours if you are estimating tasks) prior to the daily Scrum meeting.
 
 <!--endintro-->
@@ -23,7 +24,7 @@ All team members must update their tasks with status, (and remaining hours if yo
 
 **Note:** If you are updating the details of a PBI then follow the rule [Do you know when you use @ mentions in a PBI?](/when-you-use-mentions-in-a-pbi)
 
----
+- - -
 
 ::: greybox
 Learn more about the meetings in Scrum:
@@ -31,12 +32,12 @@ Learn more about the meetings in Scrum:
 * [Sprint Planning Meeting](/what-happens-at-a-sprint-planning-meeting "Sprint Planning Meeting")
 * [Sprint Review Meeting](/what-happens-at-a-sprint-review-meeting "Sprint Review Meeting")
 * [Sprint Retrospective Meeting](/what-happens-at-a-sprint-retrospective-meeting "Sprint Retrospective Meeting")
-* [Scrum Meeting (Daily standup)](/methodology-daily-scrums)
+* [Daily Scrum (Stand-up)](/methodology-daily-scrums)
 
 **Tip:** It can be helpful to finish the **Sprint Planning meeting** with the first **Daily Scrum** of that Sprint.
 :::
 
----
+- - -
 
 ### Scrum at Microsoft Videos
 


### PR DESCRIPTION

As per our conversation with @UlyssesMaclaren, the wording should change 
FROM
![image](https://github.com/user-attachments/assets/7cdedb68-1f04-4f86-909a-12a3f0d12bf1)
TO
![image](https://github.com/user-attachments/assets/47b9f773-962c-4b5f-91c2-983cc02fe26d)
