### PR TITLE
Remove break to change "inVisual Studio" to "in Visual Studio"

### DIFF
--- a/rules/how-to-use-gamification/rule.md
+++ b/rules/how-to-use-gamification/rule.md
@@ -21,8 +21,7 @@ redirects:
 
 It originated with Frequent Flyer programs and has crossed over into the software world with the success of Foursquare.
 
-This concept is being utilized even in
-Visual Studio.
+This concept is being utilized even in Visual Studio.
 
 ::: good  
 ![Figure: Good Example – Microsoft Rewards gives points when you search on Bing.com and buy things from the Microsoft Store online and in Windows 10](microsoft-rewards.jpg)  


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Was doing the SugarLearning module: https://my.sugarlearning.com/SSW/items/8322/do-you-know-how-to-jazz-up-your-page

> 2. What was changed?

✏️ Add a space instead of a line break

![image](https://github.com/user-attachments/assets/9eee0994-bcde-4adf-80a9-03dc3ea3fdbf)
**Figure: The break made it so the text reads "inVisual Studio"**

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
