### PR TITLE
Add caption to the image - was missing

### DIFF
--- a/rules/use-clean-designs-when-creating-forms/rule.md
+++ b/rules/use-clean-designs-when-creating-forms/rule.md
@@ -35,7 +35,7 @@ A fairly standard Access 97 application that needs some love (Before a makeover)
 :::
 
 ::: bad  
-![](accessui_candidateedit4_before.gif)  
+![Figure: The form is backward, with the employee's details at the top. It's not clear what needs to be changed, and the form is missing the current key information](accessui_candidateedit4_before.gif)  
 :::
 
 ::: bad  


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Was reading SugarLearning module: https://my.sugarlearning.com/SSW/items/8322/do-you-know-how-to-jazz-up-your-page

Linked to https://www.ssw.com.au/rules/rules-to-better-access-ui/

Rule 4 had the fourth image missing a caption:
![image](https://github.com/user-attachments/assets/4ed770a2-4ec8-4a20-9d06-37e0edd1b17c)
**Figure: Example showing missing caption**

> 2. What was changed?

✏️ Added caption

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
