### PR TITLE
XS ◾ Remove Skype & TeamViewer reference

### DIFF
--- a/rules/meeting-do-you-know-what-to-prepare-for-each-meeting/rule.md
+++ b/rules/meeting-do-you-know-what-to-prepare-for-each-meeting/rule.md
@@ -27,7 +27,7 @@ This is time boxed to 15 mins. All members of the team should be well prepared 
 - Be ready to answer the 3 main questions: - What did you do yesterday? e.g. "Yesterday I did xxx" - What are you doing today? e.g. "Today I will do yyy" - Do you foresee any impediments or roadblocks? e.g. "I might hit a roadblock today because of xxx"
 
 - Remember to say "Let's park that conversation for after the Daily Scrum". Major discussions are not to be conducted during the time boxed Scrum meeting.
-- Being online on Skype (especially for team members in different locations).
+- Being on the video call (especially for team members in different locations).
 
 ### Sprint Review Meetings
 
@@ -36,7 +36,7 @@ All members of the team must be well prepared by:
 - Deploying the latest iteration of the product
 - Being available **30 minutes** before the meeting
 - Setting up and testing the projector with a computer before the meeting starts
-- Making sure remote members are connected via Skype and/or TeamViewer before the meeting starts
+- Making sure remote members are connected via video call before the meeting starts
 - Nominating in advance another member of the team to take notes from the presentation
 - Deciding, in advance, the order in which PBIs should be presented; priority, Sprint backlog order, logical order and minimizing presenter and presentation medium switching should be taken into account.
 - Controlling the time spent on the PBI presentation

--- a/rules/meeting-do-you-know-what-to-prepare-for-each-meeting/rule.md
+++ b/rules/meeting-do-you-know-what-to-prepare-for-each-meeting/rule.md
@@ -21,45 +21,45 @@ In Scrum, meetings are time boxed. Team members should be well prepared in order
 
 This is time boxed to 15 mins. All members of the team should be well prepared by:
 
-- Being ready on time
-- (If your team is estimating tasks) Having their "Remaining hours" up-to-date – read
+* Being ready on time
+* (If your team is estimating tasks) Having their "Remaining hours" up-to-date – read
   [Do you update your tasks before the daily Scrum meeting?](/meeting-do-you-update-your-tasks-before-the-daily-scrum)
-- Be ready to answer the 3 main questions: - What did you do yesterday? e.g. "Yesterday I did xxx" - What are you doing today? e.g. "Today I will do yyy" - Do you foresee any impediments or roadblocks? e.g. "I might hit a roadblock today because of xxx"
+* Be ready to answer the 3 main questions: - What did you do yesterday? e.g. "Yesterday I did xxx" - What are you doing today? e.g. "Today I will do yyy" - Do you foresee any impediments or roadblocks? e.g. "I might hit a roadblock today because of xxx"
 
-- Remember to say "Let's park that conversation for after the Daily Scrum". Major discussions are not to be conducted during the time boxed Scrum meeting.
-- Being on the video call (especially for team members in different locations).
+* Remember to say "Let's park that conversation for after the Daily Scrum". Major discussions are not to be conducted during the time boxed Scrum meeting.
+* Being on the video call (especially for team members in different locations).
 
 ### Sprint Review Meetings
 
 All members of the team must be well prepared by:
 
-- Deploying the latest iteration of the product
-- Being available **30 minutes** before the meeting
-- Setting up and testing the projector with a computer before the meeting starts
-- Making sure remote members are connected via video call before the meeting starts
-- Nominating in advance another member of the team to take notes from the presentation
-- Deciding, in advance, the order in which PBIs should be presented; priority, Sprint backlog order, logical order and minimizing presenter and presentation medium switching should be taken into account.
-- Controlling the time spent on the PBI presentation
+* Deploying the latest iteration of the product
+* Being available **30 minutes** before the meeting
+* Setting up and testing the projector with a computer before the meeting starts
+* Making sure remote members are connected via video call before the meeting starts
+* Nominating in advance another member of the team to take notes from the presentation
+* Deciding, in advance, the order in which PBIs should be presented; priority, Sprint backlog order, logical order and minimizing presenter and presentation medium switching should be taken into account.
+* Controlling the time spent on the PBI presentation
 
-  - Practice the demo beforehand if needed to ensure a succinct delivery. This can be in the form of a pre-prepared video if desired
-  - Inform the Product Owner what the main goal of the PBI is and tell if the team believe it was done or not
-  - If the Product Owner previously saw what was done, ideally the member should just mention that and ask if the PBI is accepted
-  - If the member needs to show something, show a couple of examples and ask if the Product Owner wants to see something else
+  * Practice the demo beforehand if needed to ensure a succinct delivery. This can be in the form of a pre-prepared video if desired
+  * Inform the Product Owner what the main goal of the PBI is and tell if the team believe it was done or not
+  * If the Product Owner previously saw what was done, ideally the member should just mention that and ask if the PBI is accepted
+  * If the member needs to show something, show a couple of examples and ask if the Product Owner wants to see something else
 
 ### Sprint Retrospective Meetings
 
 All members of the team must be well prepared by:
 
-- Having all your tasks from the last Sprint closed
-- Having your Sprint feedback ready in advance, so members don’t need to think about it during the meeting, saving time
-- Being clear and pointing out issues that need further discussions
+* Having all your tasks from the last Sprint closed
+* Having your Sprint feedback ready in advance, so members don’t need to think about it during the meeting, saving time
+* Being clear and pointing out issues that need further discussions
 
 ### Sprint Planning Meetings
 
 All members of the team must be well prepared by:
 
-- Having all bugs and PBIs up-to-date on the backlog
-- Having all PBIs on the backlog “groomed” in order of priority (according to the Product Owner)
-- Understanding all PBIs and the Product Owner’s priorities
-- Being responsible on estimates
-- Volunteering to work on PBIs and tasks, even if they are not related to your best skills – read [Do you encourage multi-skilled teams?](/the-team-do-you-encourage-multi-skilled-teams-by-leaving-your-comfort-zone)
+* Having all bugs and PBIs up-to-date on the backlog
+* Having all PBIs on the backlog “groomed” in order of priority (according to the Product Owner)
+* Understanding all PBIs and the Product Owner’s priorities
+* Being responsible on estimates
+* Volunteering to work on PBIs and tasks, even if they are not related to your best skills – read [Do you encourage multi-skilled teams?](/the-team-do-you-encourage-multi-skilled-teams-by-leaving-your-comfort-zone)


### PR DESCRIPTION


<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Completing this SugarLearning module: https://my.sugarlearning.com/SSW/items/8182/projects-scrum-at-ssw

> 2. What was changed?

✏️ Make it generic and applicable to everyone.

Skype has now been depreciated.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
