### PR TITLE
XS ◾ Github issue templates - mention issue forms

### DIFF
--- a/rules/github-issue-templates/rule.md
+++ b/rules/github-issue-templates/rule.md
@@ -61,5 +61,3 @@ You can take this a step further by creating Issue Forms - these are awesome for
 Check it out on GitHub's doc on [GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
 
 ![Figure: Issue Forms make reporting bugs easy](https://github.com/user-attachments/assets/c0c198b4-7069-4519-90f7-4f2083ec2efb)
-
-

--- a/rules/github-issue-templates/rule.md
+++ b/rules/github-issue-templates/rule.md
@@ -56,5 +56,5 @@ For instructions on setting this up, check out:
 ::: info
 You can take this a step further by creating Issue Forms - these are awesome for non-technical people who aren't comfortable with Markdown.
 Check it out on GitHub's docs:  
-https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+<https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms>
 :::

--- a/rules/github-issue-templates/rule.md
+++ b/rules/github-issue-templates/rule.md
@@ -52,3 +52,9 @@ For instructions on setting this up, check out:
 * [SSW Github repo Template](https://github.com/SSWConsulting/SSW.GitHub.Template)
 
 :::
+
+::: info
+You can take this a step further by creating Issue Forms - these are awesome for non-technical people who aren't comfortable with Markdown.
+Check it out on GitHub's docs:  
+https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+:::

--- a/rules/github-issue-templates/rule.md
+++ b/rules/github-issue-templates/rule.md
@@ -58,6 +58,7 @@ For instructions on setting this up, check out:
 ## GitHub Issue Forms
 
 You can take this a step further by creating Issue Forms - these are awesome for non-technical people who aren't comfortable with Markdown.
-Check it out on GitHub's doc on [GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
+
+Check it out on [GitHub Issue Forms docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
 
 ![Figure: Issue Forms make reporting bugs easy](https://github.com/user-attachments/assets/c0c198b4-7069-4519-90f7-4f2083ec2efb)

--- a/rules/github-issue-templates/rule.md
+++ b/rules/github-issue-templates/rule.md
@@ -26,6 +26,8 @@ guid: ba8f3441-139a-4638-9fc8-144408902104
 
 GitHub Issues offer a great way of raising Issues within projects. However, it can be difficult to distinguish whether the Issue is a **bug**, **feature request** or just a **question**. GitHub Issue Templates should be used to help standardize Issues and ensure they have enough information for a developer to start work.
 
+The templates also make it easy for people to write good quality issues, increasing the chance of getting good feedback and suggestions from users.
+
 Let's take a look at how implementing Issue Templates can improve repository backlogs...
 
 <!--endintro-->
@@ -53,8 +55,11 @@ For instructions on setting this up, check out:
 
 :::
 
-::: info
+## GitHub Issue Forms
+
 You can take this a step further by creating Issue Forms - these are awesome for non-technical people who aren't comfortable with Markdown.
-Check it out on GitHub's docs:  
-<https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms>
-:::
+Check it out on GitHub's doc on [GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
+
+![Figure: Issue Forms make reporting bugs easy](https://github.com/user-attachments/assets/c0c198b4-7069-4519-90f7-4f2083ec2efb)
+
+


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed this was missing

> 2. What was changed?

Added a mention of issue forms

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

No
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
