### PR TITLE
Create Rule “security-email-account/rule”

### DIFF
--- a/categories/infrastructure-and-networking/rules-to-better-security.md
+++ b/categories/infrastructure-and-networking/rules-to-better-security.md
@@ -17,6 +17,7 @@ index:
 - open-policy-personal-data-breaches
 - do-you-use-built-in-authentication-from-ms
 - use-automatic-key-management-with-duende-identityserver
+- security-email-account
 - do-you-disable-insecure-protocols
 - password-manager
 - secure-password-share

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -1,0 +1,46 @@
+---
+type: rule
+tips: ""
+title: Do you have a security@ email account?
+seoDescription: Learn why every company should have a security@ email address to
+  handle vulnerability reports, prevent public exploits, and build trust with
+  ethical hackers. Includes best practices, response tips, and a warning about
+  common bug bounty scams.
+uri: security-email-account
+authors:
+  - title: Matt Wicks
+    url: https://ssw.com.au/people/matt-wicks
+guid: 58523891-7aa2-4f5c-ae34-376d002f0a14
+---
+When hackers or security researchers find a vulnerability in your system, they need a way to tell you. If you don’t have a security@yourcompany.com email, they might give up or go public.
+
+Your `security@` inbox is your first line of defense.
+
+<!--endintro-->
+
+It helps with:
+
+* Responsible disclosure from ethical hackers
+* Bug bounty submissions
+* Early warnings before public leaks
+
+You don’t need a full bug bounty program to start. Just set up the email, publish it (e.g. in your [security.txt](https://securitytxt.org)), and monitor it.
+
+Make sure it’s:
+
+* Monitored by trusted staff (not just one person)
+* Responded to quickly (aim for <48h)
+* Part of your incident response process
+
+
+::: bad  
+No security@ exists. The researcher tweets the exploit. The company finds out via media. Damage is done.
+:::
+
+::: good  
+A security researcher finds a critical bug and emails security @company.com. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
+:::
+
+::: warn
+Be aware of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) – people who send low-risk reports and demand money. You can politely thank them or ignore if it’s not a real issue.
+:::

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -10,6 +10,9 @@ authors:
   - title: Matt Wicks
     url: https://ssw.com.au/people/matt-wicks
 guid: 58523891-7aa2-4f5c-ae34-376d002f0a14
+created: 2025-03-25T00:01:20.896Z
+related: []
+redirects: []
 ---
 When hackers or security researchers find a vulnerability in your system, they need a way to tell you. If you don’t have a security@yourcompany.com email, they might give up or go public.
 

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -41,6 +41,6 @@ No security@ exists. The researcher tweets the exploit. The company finds out vi
 A security researcher finds a critical bug and emails security @company.com. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
 :::
 
-::: warn
+::: info
 Be aware of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) – people who send low-risk reports and demand money. You can politely thank them or ignore if it’s not a real issue.
 :::

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -1,6 +1,5 @@
 ---
 type: rule
-tips: ""
 title: Do you have a security@ email account?
 seoDescription: Learn why every company should have a security@ email address to
   handle vulnerability reports, prevent public exploits, and build trust with


### PR DESCRIPTION
This pull request introduces a new security rule and updates the index to include it. The most important changes involve adding a new rule about having a security email account and updating the index to reflect this addition.

### New Rule Addition:

* [`rules/security-email-account/rule.md`](diffhunk://#diff-386dbf15e3aeab3f1ac0c19e42464463f832de2dcb25d394195bc7ab496a97b3R1-R46): Added a new rule titled "Do you have a security@ email account?" which provides guidelines on setting up and managing a security email account to handle vulnerability reports and build trust with ethical hackers.

### Index Update:

* [`categories/infrastructure-and-networking/rules-to-better-security.md`](diffhunk://#diff-7bab27bd060f5ba6866372fc13d383fe3ac9dfff6041d3bd01e0be4a5af86ad3R20): Updated the index to include the new rule `security-email-account`.