### PR TITLE
rule/security email account - add security.txt reference

### DIFF
--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -9,12 +9,12 @@ uri: security-email-account
 authors:
   - title: Matt Wicks
     url: https://ssw.com.au/people/matt-wicks
-guid: 58523891-7aa2-4f5c-ae34-376d002f0a14
-created: 2025-03-25T00:01:20.896Z
 related: []
 redirects: []
+created: 2025-03-25T00:01:20.896Z
+guid: 58523891-7aa2-4f5c-ae34-376d002f0a14
 ---
-When hackers or security researchers find a vulnerability in your system, they need a way to tell you. If you don’t have a <security@yourcompany.com> email, they might give up or go public.
+When hackers or security researchers find a vulnerability in your system, they need a way to tell you. If you don’t have a security@yourcompany.com email, they might give up or go public.
 
 Your `security@` inbox is your first line of defense.
 
@@ -34,12 +34,13 @@ Make sure it’s:
 * Responded to quickly (aim for <48h)
 * Part of your incident response process
 
+
 ::: bad  
 Bad example: No security@ exists. The researcher tweets the exploit. The company finds out via media. Damage is done.
 :::
 
 ::: good  
-Good example: A security researcher finds a critical bug and emails security@. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
+Good example: A security researcher finds a critical bug and emails security @company.com. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
 :::
 
 ::: info

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -46,3 +46,7 @@ Good example: A security researcher finds a critical bug and emails security@. T
 ::: info
 Be aware of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) – people who send low-risk reports and demand money. You can politely thank them or ignore if it’s not a real issue.
 :::
+
+::: info
+Want ethical hackers to help you? Add a [security.txt](https://securitytxt.org) file with your security contact information. Check out how we setup ours - https://github.com/SSWConsulting/securitytxt
+:::

--- a/rules/security-email-account/rule.md
+++ b/rules/security-email-account/rule.md
@@ -40,7 +40,7 @@ Bad example: No security@ exists. The researcher tweets the exploit. The company
 :::
 
 ::: good  
-Good example: A security researcher finds a critical bug and emails security @company.com. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
+Good example: A security researcher finds a critical bug and emails security@. The team replies in 1 day, verifies the issue, patches it in a week, and thanks the reporter.
 :::
 
 ::: info


### PR DESCRIPTION
This pull request includes updates to the `rules/security-email-account/rule.md` file to improve clarity and provide additional guidance on security practices.

Key changes include:

Content updates:

* Reordered the `created` and `guid` fields for better consistency.
* Added a new section under "Good example" to encourage the use of a `security.txt` file for ethical hackers to contact the organization.

Formatting improvements:

* Added a newline for better readability between sections.