### PR TITLE
Update Rule “architecture-diagram/rule”

### DIFF
--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -189,7 +189,7 @@ Another popular tool is [Eraser](app.eraser.io) which provide many industry stan
 
 **Miro (by Adobe)**
 
-[Miro](https://miro.com/) is an online tool designed primarily for whiteboard-style collaboration. It is very easy to use and optimised for this purpose. As a diagramming tool, it is lacking in features compared to draw.io, but it can be used to create simple diagrams.
+[Miro](https://miro.com/) is an online tool designed primarily for whiteboard-style collaboration. It is very easy to use and optimised for this purpose.
 
 **Note:** The paid version of Miro gives you Azure Architecture Diagram templates - see [miro.com/templates/azure-architecture-diagram/](https://miro.com/templates/azure-architecture-diagram/)
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -168,6 +168,8 @@ Make sure to tick *Include a copy of my diagram* is selected. This will let you 
 
 To make it easy to tell that you can open the file in draw.io, ensure that the file extension is `.drawio.png`. 
 
+Read more in the docs - https://www.drawio.com/doc/faq/export-to-png
+
 ### Tip #11: Where to store Diagrams?
 
 Standardizing where your organisation stores architecture diagrams ensures a consistent experience among developers. Therefore store your architecture diagrams in the repo **docs**\ folder. Additionally, the \README.md (in the root) should have a link and an embedded image of the high-level architecture diagram (from the **docs**\\* folder).

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -182,6 +182,11 @@ Standardizing where your organisation stores architecture diagrams ensures a con
 
 ### Alternatives to draw.io
 
+
+**Eraser**
+
+Another popular tool is [Eraser](app.eraser.io) which provide many industry standard icons, features, and tools that are used for architecture diagrams and software design blueprints.
+
 **Miro (by Adobe)**
 
 [Miro](https://miro.com/) is an online tool designed primarily for whiteboard-style collaboration. It is very easy to use and optimised for this purpose. As a diagramming tool, it is lacking in features compared to draw.io, but it can be used to create simple diagrams.

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -120,7 +120,7 @@ Putting something on a whiteboard is "low risk" for the participants as its real
 ![Figure: Better example - SSW Rewards - the same sketch but captured with Office Lens. How much clearer and more vibrant is this!](reward-hand-drawn-sketch-office-lens.jpg)
 :::
 
-### Tip #7: ...and Finish up with Draw.io
+### Tip #7: ...and finish up with draw.io
 
 The best tool for creating these diagrams is [draw.io](https://draw.io/). All the examples on this page were created with this tool.
 
@@ -144,7 +144,7 @@ There are multiple extensions available that let you do this, the best one is [V
 ![Figure: Good example - Auctions (a Blazor + .NET + Cosmos DB project) - architecture diagram created within VS Code and checked into the repo in the same commit as the relevant code changes. Blazor UI layer encapsulated in thematic color](architecture-2.png)
 :::
 
-### Tip #8: Polish up Draw.io
+### Tip #8: Polish up draw.io
 
 Maintain standards to keep your diagrams consistent:
 
@@ -170,7 +170,7 @@ To make it easy to tell that you can open the file in draw.io, ensure that the f
 
 Read more in the docs - https://www.drawio.com/doc/faq/export-to-png
 
-### Tip #11: Where to store Diagrams?
+### Tip #11: Where to store diagrams?
 
 Standardizing where your organisation stores architecture diagrams ensures a consistent experience among developers. Therefore store your architecture diagrams in the repo **docs**\ folder. Additionally, the \README.md (in the root) should have a link and an embedded image of the high-level architecture diagram (from the **docs**\\* folder).
 

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -5,10 +5,8 @@ uri: architecture-diagram
 authors:
   - title: Adam Cogan
     url: https://ssw.com.au/people/adam-cogan
-  - title: Matt Goldman
-    url: https://ssw.com.au/people/matt-goldman
-  - title: Piers Sinclair
-    url: https://ssw.com.au/people/piers-sinclair
+  - title: Matt Wicks
+    url: https://ssw.com.au/people/matt-wicks
 related:
   - awesome-documentation
   - azure-resources-diagram

--- a/rules/architecture-diagram/rule.md
+++ b/rules/architecture-diagram/rule.md
@@ -122,22 +122,22 @@ Putting something on a whiteboard is "low risk" for the participants as its real
 ![Figure: Better example - SSW Rewards - the same sketch but captured with Office Lens. How much clearer and more vibrant is this!](reward-hand-drawn-sketch-office-lens.jpg)
 :::
 
-### Tip #7: ...and Finish up with Diagrams.net
+### Tip #7: ...and Finish up with Draw.io
 
-The best tool for creating these diagrams is [diagrams.net](https://diagrams.net/) (previously draw.io). All the examples on this page were created with this tool.
+The best tool for creating these diagrams is [draw.io](https://draw.io/). All the examples on this page were created with this tool.
 
 It is definitely the most popular diagram tool at SSW:
 
-![Figure: When SSW developers were surveyed, diagrams.net was the clear winner (see green) for building architecture diagrams](FaveTool.png)
+![Figure: When SSW developers were surveyed, draw.io was the clear winner (see green) for building architecture diagrams](FaveTool.png)
 
 ::: good img-medium
-![Figure: Better example - TimePro (an Angular &plus; .NET project with Hangfire) - you can create diagrams quickly and easily with diagrams.net that still look very professional. This one is in the style of a technical document](TimePRO-Architecture-Diagram-v2.png)
+![Figure: Better example - TimePro (an Angular &plus; .NET project with Hangfire) - you can create diagrams quickly and easily with draw.io that still look very professional. This one is in the style of a technical document](TimePRO-Architecture-Diagram-v2.png)
 :::
 
-Diagrams.net is free, can be used in the browser, or can be downloaded as a desktop app. But the best way to use diagrams.net is to integrate it directly into VS Code.
+Draw.io is free, can be used in the browser, or can be downloaded as a desktop app. But the best way to use draw.io is to integrate it directly into VS Code.
 
 ::: good img-medium
-![Figure: Great example - Auctions (a Blazor + .NET + Cosmos DB project) - diagrams.net integrated directly into VS Code](thumbnail_image003.jpg)
+![Figure: Great example - Auctions (a Blazor + .NET + Cosmos DB project) - draw.io integrated directly into VS Code](thumbnail_image003.jpg)
 :::
 
 There are multiple extensions available that let you do this, the best one is [VS Code | Extensions | Draw.io Integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio). This makes it easy to create and edit the architecture diagram right alongside the code, and check-in with the relevant commits.
@@ -146,7 +146,7 @@ There are multiple extensions available that let you do this, the best one is [V
 ![Figure: Good example - Auctions (a Blazor + .NET + Cosmos DB project) - architecture diagram created within VS Code and checked into the repo in the same commit as the relevant code changes. Blazor UI layer encapsulated in thematic color](architecture-2.png)
 :::
 
-### Tip #8: Polish up Diagrams.net
+### Tip #8: Polish up Draw.io
 
 Maintain standards to keep your diagrams consistent:
 
@@ -162,21 +162,29 @@ Maintain standards to keep your diagrams consistent:
 ![Figure: Good example - SSW People (a Static Site - Gatsby and React with Dynamics 365 and SharePoint Online) - you can just as easily create colorful, engaging diagrams suitable for all of your project stakeholders](SSW.People-Architecture-Diagram.png)
 :::
 
-### Tip #9: Where to store Diagrams?
+### Tip #10: Exporting diagrams
+
+To export your diagram, go to *File* | *Export as* | *PNG*
+
+Make sure to tick *Include a copy of my diagram* is selected. This will let you open your diagram and edit it again when you import the PNG file into draw.io.
+
+To make it easy to tell that you can open the file in draw.io, ensure that the file extension is `.drawio.png`. 
+
+### Tip #11: Where to store Diagrams?
 
 Standardizing where your organisation stores architecture diagrams ensures a consistent experience among developers. Therefore store your architecture diagrams in the repo **docs**\ folder. Additionally, the \README.md (in the root) should have a link and an embedded image of the high-level architecture diagram (from the **docs**\\* folder).
 
 **Note:** If you have a Wiki, for visibility add an architecture diagram page and embed the images from the **docs**\\* folder.
 
-### Tip #10: Use Azure Architecture Center
+### Tip #12: Use Azure Architecture Center
 
 [Azure Architecture Center](https://docs.microsoft.com/en-us/azure/architecture/) is the best tool to help you figure out the pieces you need for an architecure diagram - see [SSW.Rules | Do you use Azure Architecture Center](/azure-architecture-center)
 
-### Alternatives to Diagrams.net
+### Alternatives to draw.io
 
 **Miro (by Adobe)**
 
-[Miro](https://miro.com/) is an online tool designed primarily for whiteboard-style collaboration. It is very easy to use and optimised for this purpose. As a diagramming tool, it is lacking in features compared to Diagrams.net, but it can be used to create simple diagrams.
+[Miro](https://miro.com/) is an online tool designed primarily for whiteboard-style collaboration. It is very easy to use and optimised for this purpose. As a diagramming tool, it is lacking in features compared to draw.io, but it can be used to create simple diagrams.
 
 **Note:** The paid version of Miro gives you Azure Architecture Diagram templates - see [miro.com/templates/azure-architecture-diagram/](https://miro.com/templates/azure-architecture-diagram/)
 


### PR DESCRIPTION
This pull request includes changes to the `rules/architecture-diagram/rule.md` file to update references from `diagrams.net` to `draw.io`. The most important changes include updating the tool's name in various tips and image captions, adding a new tip for exporting diagrams, and updating the alternatives section.

Updates to tool references:

* Updated references from `diagrams.net` to `draw.io` in tips and image captions to reflect the current tool's name. [[1]](diffhunk://#diff-1cba977d665767e4e8a654218634b654607b2a1b7b1a162468c1682460a90c91L125-R140) [[2]](diffhunk://#diff-1cba977d665767e4e8a654218634b654607b2a1b7b1a162468c1682460a90c91L149-R149)

New tips:

* Added a new tip `#10` for exporting diagrams with instructions to include a copy of the diagram and use the `.drawio.png` file extension.
