### PR TITLE
Removing reference to LinkedIn creator mode

### DIFF
--- a/categories/marketing-and-video/rules-to-better-social-media-personal.md
+++ b/categories/marketing-and-video/rules-to-better-social-media-personal.md
@@ -18,7 +18,6 @@ index:
 - linkedin-connect-your-microsoft-account
 - linkedin-connect-with-people
 - linkedin-maintain-connections
-- linkedin-creator-mode
 - do-you-know-what-to-tweet
 - do-you-know-that-every-comment-gets-a-tweet
 - x-hashtag-vs-mention

--- a/rules/linkedin-profile/rule.md
+++ b/rules/linkedin-profile/rule.md
@@ -39,12 +39,11 @@ Do the following on your profile page:
 9. Add your top skills in the 'About' section (Aim for 5)
 10. [Add your job experience](/linkedin-job-experience)
 11. Under your company, add [relevant links](https://www.youtube.com/watch?v=3rPpCchYUfc) to showcase your experience in a specific job
-12. [Use hashtags](/linkedin-creator-mode) to make yourself searchable
-13. Add a link to your company's profile in your description
+12. Add a link to your company's profile in your description
 
     E.g. `https://www.ssw.com.au/people/{{ YOUR-NAME }}`
 
-14. **Account Managers** - Include a button to book as per [the best way to let clients book a meeting with you](/meeting-bookings)
+13. **Account Managers** - Include a button to book as per [the best way to let clients book a meeting with you](/meeting-bookings)
 
 ::: good
 ![Figure: Good example - A clean and professional profile give clients the right idea - that you will be great to work with](good-linkedin.jpg)


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ email: RE: LinkedIn Creator Rule

> 2. What was changed?

✏️ removed linkedin creator step because it's an obsolete featrue

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️no
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
