### PR TITLE
Move URL blog post to the top

### DIFF
--- a/rules/discord-communities/rule.md
+++ b/rules/discord-communities/rule.md
@@ -13,7 +13,7 @@ authors:
     url: https://www.ssw.com.au/people/matt-wicks/
 guid: 5bd712ca-2495-44cf-87c6-fe0b33e44063
 ---
-The tech community thrives on collaboration, communication, and shared learning. Discord has become one of the top platforms for developers, engineers, and open source contributors to connect. Whether you're working in support, marketing, or engineering, joining a tech-focused Discord server can help you stay informed and involved.
+The tech community thrives on collaboration, communication, and shared learning. Discord has become one of the top platforms for developers, engineers, and open source contributors to connect. Whether you're working in support, marketing, or engineering, joining a tech-focused Discord server can help you stay informed and involved. Check out the [blog post on ten of the top community Discord servers to join](https://dev.to/mishmanners/best-community-tech-discord-servers-to-join-4gie) and find your next favorite server.
 
 ## Why Use Discord for Tech Community Engagement?
 
@@ -65,7 +65,3 @@ If you're working on a project, particularly in support, engineering, or marketi
 * Use public threads and channels instead of private messages for transparency
 * Stay respectful and always follow the community’s code of conduct
 * Offer help when you can. By sharing your knowledge, you'll boosts your own learning and helps others
-
-## Bonus: Find Top Tech Discord Servers
-
-Want to explore new communities? Check out the [blog post on ten of the top community Discord servers to join](https://dev.to/mishmanners/best-community-tech-discord-servers-to-join-4gie) and find your next favorite server.

--- a/rules/discord-communities/rule.md
+++ b/rules/discord-communities/rule.md
@@ -40,7 +40,7 @@ Here's how you can join Discord:
 
 4. (optional) Install Discord on your phone via the [App Store](https://apps.apple.com/us/app/discord-talk-play-hang-out/id985746746) or [Google Play](https://play.google.com/store/apps/details?id=com.discord&hl=en_US)
 
-5. Find your community. Look for Discord invite links on websites, GitHub repos, newsletters, or social media. You will need an invite link to join a server. Some servers will allow a friend to send you an invite, and others you will need an invite directly from the server owner
+5. Find your community and join a few servers. Look for Discord invite links on websites, GitHub repos, newsletters, or social media. You will need an invite link to join a server. Some servers will allow a friend to send you an invite, and others you will need an invite directly from the server owner
 
 ::: good example :::
 


### PR DESCRIPTION
This pull request includes updates to the `rules/discord-communities/rule.md` file to improve the content and provide additional resources for users. The most important changes include adding a link to a blog post about top tech Discord servers and removing a redundant section about finding top tech Discord servers.

Content improvements:

* Added a link to a blog post on top community Discord servers to join, enhancing the section on the benefits of joining tech-focused Discord servers.
* Removed a redundant section that also provided a link to the blog post on top community Discord servers, streamlining the content.

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email with @sethdaily 

