### PR TITLE
XS ◾ Add community Discord link again

### DIFF
--- a/rules/discord-communities/rule.md
+++ b/rules/discord-communities/rule.md
@@ -8,18 +8,19 @@ seoDescription: Discover how to join Discord servers, engage in public tech
 uri: discord-communities
 authors:
   - title: Michelle Duke
-    url: https://www.ssw.com.au/people/michelle-duke/
+    url: https://www.ssw.com.au/people/michelle-duke
   - title: Matt Wicks
-    url: https://www.ssw.com.au/people/matt-wicks/
+    url: https://www.ssw.com.au/people/matt-wicks
 guid: 5bd712ca-2495-44cf-87c6-fe0b33e44063
 ---
-The tech community thrives on collaboration, communication, and shared learning. Discord has become one of the top platforms for developers, engineers, and open source contributors to connect. Whether you're working in support, marketing, or engineering, joining a tech-focused Discord server can help you stay informed and involved. Check out the [blog post on ten of the top community Discord servers to join](https://dev.to/mishmanners/best-community-tech-discord-servers-to-join-4gie) and find your next favorite server.
 
-## Why Use Discord for Tech Community Engagement?
+The tech community thrives on collaboration, communication, and shared learning. Discord has become one of the top platforms for developers, engineers, and open source contributors to connect. Whether you're working in support, marketing, or engineering, joining a tech-focused Discord server can help you stay informed and involved. 
+
+## Why use Discord for tech community engagement?
 
 Discord is home to thousands of global tech communities. By joining public servers and engaging in open conversations—especially in public channels or GitHub Discussions—you help foster a collaborative environment where everyone can learn and contribute.
 
-### Benefits
+### ✅ Benefits
 
 * Shared knowledge and transparency
 * Centralized communication for features, bugs, and issues
@@ -36,25 +37,23 @@ Here's how you can join Discord:
 
 3. If you're setting up an account for the first time, set your display name, profile picture, pronouns, avatar, and any other personal preferences. You can do this via Discord | User settings | My Account | Edit User Profile:
 
-![Figure: Profile page where you can change your user preferences](profile.png)
+  ![Figure: Profile page where you can change your user preferences](profile.png)
 
 4. (optional) Install Discord on your phone via the [App Store](https://apps.apple.com/us/app/discord-talk-play-hang-out/id985746746) or [Google Play](https://play.google.com/store/apps/details?id=com.discord&hl=en_US)
 
 5. Find your community and [join a few servers](https://dev.to/mishmanners/best-community-tech-discord-servers-to-join-4gie). Look for Discord invite links on websites, GitHub repos, newsletters, or social media. You will need an invite link to join a server. Some servers will allow a friend to send you an invite, and others you will need an invite directly from the server owner
 
-::: good example :::
-
-As an example, we have Discord servers for [Tina](https://discord.com/invite/zumN63Ybpf) and [YakShaver](https://discord.gg/Jp9dyxKFjR). If you were to join these servers you'll see them  listed under your servers:
-
-![Figure: Discord with the Tina and YakShaver servers added](screenshot-2025-04-02-190625-2-.png)
-
-:::
+  ::: greybox
+  As an example, we have Discord servers for [Tina](https://discord.com/invite/zumN63Ybpf) and [YakShaver](https://discord.gg/Jp9dyxKFjR). If you join these servers, you'll see them listed under your servers:
+  
+  ![Figure: Discord with the Tina and YakShaver servers added](screenshot-2025-04-02-190625-2-.png)
+  :::
 
 6. If you're joining a Discord server for the first time, don't forget to read the rules and announcements before posting in the server. Many Discord communities—like open source communities—have their own rules and guidelines. Just like many open source projects have contribution guidelines, you'll be expected to read the Discord rules and announcements before posting. Failure to do so, could get you banned from a community. Be sure to check channels like #rules, #announcements, or #read-this-first
 
 7. Head to a welcome channel, such as #general, #discussions, or #introductions to say hi and share a bit about yourself
 
-## Tips for Engaging on Discord in Tech Communities
+## Tips for engaging 
 
 By opening conversation in public channels, such as Discord and/or public GitHub Issues, rather than internally opening issues/PBIs, means everyone in the community can benefit and learn together. This also creates a central location for issues/features/bugs, and encourages members of the community to be involved. This is super important for open source projects.
 

--- a/rules/discord-communities/rule.md
+++ b/rules/discord-communities/rule.md
@@ -40,7 +40,7 @@ Here's how you can join Discord:
 
 4. (optional) Install Discord on your phone via the [App Store](https://apps.apple.com/us/app/discord-talk-play-hang-out/id985746746) or [Google Play](https://play.google.com/store/apps/details?id=com.discord&hl=en_US)
 
-5. Find your community and join a few servers. Look for Discord invite links on websites, GitHub repos, newsletters, or social media. You will need an invite link to join a server. Some servers will allow a friend to send you an invite, and others you will need an invite directly from the server owner
+5. Find your community and [join a few servers](https://dev.to/mishmanners/best-community-tech-discord-servers-to-join-4gie). Look for Discord invite links on websites, GitHub repos, newsletters, or social media. You will need an invite link to join a server. Some servers will allow a friend to send you an invite, and others you will need an invite directly from the server owner
 
 ::: good example :::
 


### PR DESCRIPTION
This pull request includes a small change to the `rules/discord-communities/rule.md` file. The change updates the instructions for joining Discord communities by adding a hyperlink to a list of recommended tech Discord servers.

* [`rules/discord-communities/rule.md`](diffhunk://#diff-26b7900284a74a8732fc13bbe36758406a15bf4480b9c555afeb6cdac1d50c9bL43-R43): Added a hyperlink to the text "join a few servers" to direct users to a list of recommended tech Discord servers.

I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️ @sethdaily @wicksipedia 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
