### PR TITLE
XS ◾ remove highlight from "meeting chat" so users aren't confused

### DIFF
--- a/rules/teams-meetings-vs-group-chats/rule.md
+++ b/rules/teams-meetings-vs-group-chats/rule.md
@@ -22,7 +22,7 @@ If others need to be part of the discussion or you want to continue the conversa
 
 <!--endintro-->
 
-Use **group chats** instead of **meeting chats** when you want to:
+Use **group chats** - instead of meeting chats - when you want to:
 
 * Allow anyone you choose to see the chat (including the full message history), regardless of meeting attendance
 * Make [reaction polls](/easy-questions/#ask-for-reactions-for-multiple-options), where you may want to gather extra opinions or continue the discussion later


### PR DESCRIPTION
https://www.ssw.com.au/rules/teams-meetings-vs-group-chats/ 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

found myself

> 2. What was changed?

removing highlight from "meeting chat" so users aren't confused

<img width="665" alt="Screenshot 2025-04-10 at 2 59 39 PM" src="https://github.com/user-attachments/assets/7f2a7cf9-d8bb-42bf-b3de-1bd9f01a1781" />

