### PR TITLE
Change "Chaining your prompts" to "Prompt chaining"

### DIFF
--- a/rules/chained-prompting/rule.md
+++ b/rules/chained-prompting/rule.md
@@ -1,7 +1,7 @@
 ---
 seoDescription: Guide conversations through a series of questions or tasks using chained prompting, yielding comprehensive and interconnected responses.
 type: rule
-title: Do you use chained prompting?
+title: Do you use prompt chaining?
 uri: chained-prompting
 authors:
   - title: Ulysses Maclaren
@@ -10,13 +10,13 @@ created: 2023-04-12T14:32:05.794Z
 guid: 37000b4b-fe77-4be7-a41b-12ca9aadc97b
 ---
 
-Utilizing chained prompting can help you guide ChatGPT through a series of questions or tasks, resulting in more comprehensive and interconnected responses. You do this by replying to ChatGPT's output each time to bring it closer and closer to your desired result.
+Utilizing prompt chaining can help you guide ChatGPT through a series of questions or tasks, resulting in more comprehensive and interconnected responses. You do this by replying to ChatGPT's output each time to bring it closer and closer to your desired result.
 
 By creating a sequence of related prompts, you can explore a topic in-depth or complete a multi-step task more effectively.
 
 <!--endintro-->
 
-Here are some tips for using chained prompting:
+Here are some tips for using prompt chaining:
 
 * Break down your topic or task into a series of smaller, related prompts
 * Maintain a logical flow between prompts so each subsequent prompt builds on the previous one
@@ -25,31 +25,35 @@ Here are some tips for using chained prompting:
 Example chained prompts (think of it like having a conversation):
 
 ::: greybox
-User: "ChatGPT, suggest 3 time management tips that can help improve productivity."
+**User:** "ChatGPT, suggest 3 time management tips that can help improve productivity."
 
-ChatGPT:
+**ChatGPT:**
   \[Output]\
   \[Output]\
   \[Output]
 
-User: "Now, provide a brief explanation for each time management tip, explaining how it can improve productivity."
+**User:** "Now, provide a brief explanation for each time management tip, explaining how it can improve productivity."
 
-ChatGPT: \[Output]
+**ChatGPT:** \[Output]
 
-User: "Finally, write a short introductory paragraph for a blog post about these time management tips for improving productivity."
+**User:** "Finally, write a short introductory paragraph for a blog post about these time management tips for improving productivity."
 
-ChatGPT: \[Output]
+**ChatGPT:** \[Output]
 :::
-**Figure: Chained prompting for writing a blog post about time management tips**
+::: good
+Figure: Prompt chaining for writing a blog post about time management tips**
+:::
 
 You can also a chained prompt for refining responses or getting more details. If the initial answer isn't sufficient, ask ChatGPT to expand upon or clarify its response, such as:
 
 ::: greybox
 
-"Could you provide more information about that solution?", or
+"Could you provide more information about that solution?" 
+
+or
 
 "Can you explain that in simpler terms?"
 
 :::
 
-By using chained prompting, you 'coach' ChatGPT to provide more comprehensive and interconnected responses that address your topic or task in a thorough and structured manner.
+By using prompt chaining, you 'coach' ChatGPT to provide more comprehensive and interconnected responses that address your topic or task in a thorough and structured manner.

--- a/rules/chatgpt-cheat-sheet/rule.md
+++ b/rules/chatgpt-cheat-sheet/rule.md
@@ -1,7 +1,8 @@
 ---
-seoDescription: Master ChatGPT with our cheat sheet, exploring roles, dos, don’ts, and effective prompting techniques for better AI interactions.
 type: rule
 title: Do you have a ChatGPT cheat sheet?
+seoDescription: Master ChatGPT with our cheat sheet, exploring roles, dos,
+  don’ts, and effective prompting techniques for better AI interactions.
 uri: chatgpt-cheat-sheet
 authors:
   - title: Adam Cogan
@@ -122,8 +123,8 @@ For more on this prompt structure, see: [Do you know the fundamentals of Prompt 
 
 ![Figure: Results from the 5 in 1 example prompt](5in1-prompt.png)
 
-## Chain your prompts
+## Prompt Chaining
 
-Chain prompting is the technique of guiding GTP's responses by asking a series of related questions or prompts, building upon the previous answers to obtain more coherent and relevant information.
+Prompt chaining is the technique of guiding GTP's responses by asking a series of related questions or prompts, building upon the previous answers to obtain more coherent and relevant information.
 
-For an example on this, see: [Do you use chained prompting?](/chained-prompting)
+For an example on this, see: [Do you use prompt chaining?](/chained-prompting)


### PR DESCRIPTION
As per my conversation with Uly, this rule “Rules to better Chatgpt prompt engineering”, item 2, there is a section about “Chain prompting”. When looking up chain prompting or “Chaining your prompts” I did not get accurate results. I only got the proper results when looking up “Prompt chaining”.

https://github.com/SSWConsulting/SSW.Rules.Content/pull/10129