### PR TITLE
removing 'archivedreason' field

### DIFF
--- a/rules/what-happens-at-a-sprint-review-meeting/rule.md
+++ b/rules/what-happens-at-a-sprint-review-meeting/rule.md
@@ -15,7 +15,6 @@ related:
 redirects:
   - do-you-know-what-happens-at-a-sprint-review-meeting
 created: 2010-05-06T02:07:33.000Z
-archivedreason: null
 guid: 863b6968-c082-4413-b90d-d68e0211adc5
 ---
 This is the meeting where the Product Owner accepts or rejects the Product Backlog Items (PBIs) done in the Sprint.


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ it failed the frontmatter check

> 2. What was changed?

✏️ removed archivedreason field

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️no
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
