### PR TITLE
XS ◾ use MCP rule

### DIFF
--- a/rules/use-mcp-to-standardize-llm-connections/rule.md
+++ b/rules/use-mcp-to-standardize-llm-connections/rule.md
@@ -94,9 +94,9 @@ Betting against MCP is like betting against standards that make life easier.
 
 Whether you're building the agent side or the server:
 
-* 🛠️ **[Server Quick Start](https://modelcontextprotocol.info/docs/quickstart/quickstart/)**: Perfect for devs making reusable tools.
-* 🧠 **[Client Quick Start](https://modelcontextprotocol.info/docs/quickstart/client/)**: If you're building apps that want to call those tools.
-* 📚 Browse [example servers](https://modelcontext.org/servers) and [client list](https://modelcontext.org/clients) to see the growing ecosystem.
+* 🛠️ **[Server Quick Start](https://modelcontextprotocol.io/quickstart/server)**: Perfect for devs making reusable tools.
+* 🧠 **[Client Quick Start](https://modelcontextprotocol.io/quickstart/client)**: If you're building apps that want to call those tools.
+* 📚 Browse [example servers](https://modelcontextprotocol.io/examples) and [client list](https://modelcontextprotocol.io/clients) to see the growing ecosystem.
 
 #### Try it yourself
 


### PR DESCRIPTION
Fixed broken links for MCP quickstart

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

The links to the quickstart information were broken

> 2. What was changed?

Fixed the links to point to modelcontextprotocol.io relevant pages

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
No
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
