### PR TITLE
XS ◾ MCP Server - point to AI consulting page

### DIFF
--- a/rules/mcp-server/rule.md
+++ b/rules/mcp-server/rule.md
@@ -96,4 +96,4 @@ As AI continues to transform business operations, having an MCP server will incr
 
 #### Need help connecting your proprietary services?
 
-📩 [Reach out to SSW](https://www.ssw.com.au/contact-us) – we'll help you build a robust, scalable MCP server.
+📩 [Reach out to SSW](https://www.ssw.com.au/consulting/artificial-intelligence) – we'll help you build a robust, scalable MCP server.

--- a/rules/use-mcp-to-standardize-llm-connections/rule.md
+++ b/rules/use-mcp-to-standardize-llm-connections/rule.md
@@ -97,11 +97,9 @@ Betting against MCP is like betting against standards that make life easier.
 
 Whether you're building the agent side or the server:
 
-
 * 🛠️ **[Server Quick Start](https://modelcontextprotocol.io/quickstart/server)** - Perfect for devs making reusable tools
 * 🧠 **[Client Quick Start](https://modelcontextprotocol.io/quickstart/client)** - If you're building apps that want to call those tools
 * 📚 Browse [example servers](https://modelcontextprotocol.io/examples) and [client list](https://modelcontextprotocol.io/clients) to see the growing ecosystem
-
 
 ### Try it yourself
 

--- a/rules/use-mcp-to-standardize-llm-connections/rule.md
+++ b/rules/use-mcp-to-standardize-llm-connections/rule.md
@@ -135,4 +135,4 @@ More servers can be found on [MCP Server Directory](https://www.pulsemcp.com/ser
 
 #### Need help connecting your proprietary services?  
 
-📩 [Reach out to SSW](https://www.ssw.com.au/contact-us) – we'll help you build a robust, scalable MCP server.
+📩 [Reach out to SSW](https://www.ssw.com.au/consulting/artificial-intelligence) – we'll help you build a robust, scalable MCP server.


### PR DESCRIPTION
This pull request updates links in two rule files to point to a consulting page for artificial intelligence services. Old link was 404'ing

Link updates:

* [`rules/mcp-server/rule.md`](diffhunk://#diff-e5a4518eb4302e1a847d7792e316d0d1edf53a6a004f6cb850779c784f80c9e5L99-R99): Updated the SSW contact link to direct users to the "Artificial Intelligence" consulting page.
* [`rules/use-mcp-to-standardize-llm-connections/rule.md`](diffhunk://#diff-6a936c1f76492ce26fcf6768204e7bafc87963364b0841bb41ac9a6395e98060L138-R138): Similarly updated the SSW contact link to the "Artificial Intelligence" consulting page.