### PR TITLE
L ◾ Add rule for using unique DTOs per use case in Clean Architecture

### DIFF
--- a/categories/software-engineering/index.md
+++ b/categories/software-engineering/index.md
@@ -84,5 +84,4 @@ index:
   - rules-to-better-exchange-server
   - rules-to-better-windows-forms-applications-clickonce
   - rules-do-you-use-loggermessage-in-net
-  - do-you-optimize-tinacms-project
 ---

--- a/categories/software-engineering/rules-to-better-architecture-and-code-review.md
+++ b/categories/software-engineering/rules-to-better-architecture-and-code-review.md
@@ -19,6 +19,7 @@ index:
   - do-you-know-how-to-laser-in-on-the-smelliest-code
   - do-you-know-the-common-design-principles-part-1
   - do-you-know-the-common-design-principles-part-2-example
+  - unique-dtos-per-endpoint
   - common-design-patterns
   - dependency-injection
   - code-against-interfaces
@@ -59,7 +60,6 @@ index:
   - architectural-decision-records
   - use-prefixes-to-improve-code-review-communication
   - use-mass-transit
-  - software-architecture-decision-tree
   - multi-tenancy-models
 ---
 

--- a/categories/software-engineering/rules-to-better-architecture-and-code-review.md
+++ b/categories/software-engineering/rules-to-better-architecture-and-code-review.md
@@ -5,6 +5,7 @@ guid: a09ec7f5-4035-48ad-afb2-08ac9c620dc6
 uri: rules-to-better-architecture-and-code-review
 index:
   - do-you-evaluate-the-processes
+  - software-architecture-decision-tree
   - developer-experience
   - do-you-review-the-solution-and-project-names
   - do-you-conduct-an-architecture-review-after-every-sprint

--- a/categories/software-engineering/rules-to-better-clean-architecture.md
+++ b/categories/software-engineering/rules-to-better-clean-architecture.md
@@ -11,6 +11,7 @@ index:
 - keep-business-logic-out-of-the-presentation-layer
 - how-to-improve-the-discoverability-of-your-mediatr-requests
 - the-difference-between-data-transfer-objects-and-view-models
+- unique-dtos-per-endpoint
 - the-best-approach-to-validate-your-client-requests
 - when-to-use-value-objects
 - do-you-use-strongly-typed-ids

--- a/rules/unique-dtos-per-endpoint/rule.md
+++ b/rules/unique-dtos-per-endpoint/rule.md
@@ -1,4 +1,5 @@
 ---
+seoDescription: Learn why creating unique DTOs for each API endpoint improves performance, reduces coupling, and leads to better maintainability in Clean Architecture.
 type: rule
 title: Do you use unique DTOs per use case?
 guid: 19a53ef8-5b5c-4e44-baef-1433d4a77e48

--- a/rules/unique-dtos-per-endpoint/rule.md
+++ b/rules/unique-dtos-per-endpoint/rule.md
@@ -18,17 +18,17 @@ In Clean Architecture, it is normally better to have a unique Data Transfer Obje
 
 While sharing DTOs across multiple endpoints might seem like a way to save some code, it often leads to several problems:
 
-*   **Unnecessary Data Transfer:** Endpoints sending more data than what is actually needed, this can lead to performance issues.
-*   **Increased Coupling:** When multiple endpoints share the same DTO, a change required by one endpoint can inadvertently affect others.
-*   **Developer Confusion:** Developers will find it hard to understand which properties are relevant for a specific endpoint, leading to potential misuse or misunderstanding of the data structure.
+* **Unnecessary Data Transfer:** Endpoints sending more data than what is actually needed, this can lead to performance issues.
+* **Increased Coupling:** When multiple endpoints share the same DTO, a change required by one endpoint can inadvertently affect others.
+* **Developer Confusion:** Developers will find it hard to understand which properties are relevant for a specific endpoint, leading to potential misuse or misunderstanding of the data structure.
 
 <!--endintro-->
 
 By creating unique DTOs tailored to each endpoint's specific requirements, you ensure that:
 
-*   Endpoints only deal with the data they need.
-*   Performance is optimized by avoiding the transfer of superfluous data.
-*   Endpoints are decoupled, making them easier to develop, test, and maintain independently.
+* Endpoints only deal with the data they need.
+* Performance is optimized by avoiding the transfer of superfluous data.
+* Endpoints are decoupled, making them easier to develop, test, and maintain independently.
 
 ```csharp
 namespace Northwind.Trading.Application.Contracts.Models;
@@ -58,10 +58,10 @@ public class OrderItemModel
     public List<OrderItemViewModel> OrderItems { get; set; } = [];
 }
 ```
+
 ::: bad
 Figure: Bad example - `OrderViewModel` is used for multiple purposes (e.g., `GetOrderList`, `GetOrderDetails`, `CreateOrder`) and has accumulated many properties, making it hard to read and maintain.
 :::
-
 
 ```csharp
 namespace Northwind.Trading.Application.Contracts.OrderQueries.Models;
@@ -75,6 +75,7 @@ public class GetOrderListItemDto
     public OrderStatus Status { get; set; }
 }
 ```
+
 ::: good
 Figure: Good example - A simple `OrderSummaryDto` designed specifically for an endpoint that lists orders.
 :::

--- a/rules/unique-dtos-per-endpoint/rule.md
+++ b/rules/unique-dtos-per-endpoint/rule.md
@@ -1,0 +1,80 @@
+---
+type: rule
+title: Do you use unique DTOs per use case?
+guid: 19a53ef8-5b5c-4e44-baef-1433d4a77e48
+uri: unique-dtos-per-endpoint
+authors:
+  - title: Brady Stroud
+    url: https://ssw.com.au/people/brady-stroud
+related:
+  - serialize-view-models-not-domain-entities
+  - the-difference-between-data-transfer-objects-and-view-models
+redirects: []
+created: 2025-05-15T00:00:00.000Z
+archivedreason: null
+---
+
+In Clean Architecture, it is normally better to have a unique Data Transfer Object (DTO) for each endpoint or use case.
+
+While sharing DTOs across multiple endpoints might seem like a way to save some code, it often leads to several problems:
+
+*   **Unnecessary Data Transfer:** Endpoints sending more data than what is actually needed, this can lead to performance issues.
+*   **Increased Coupling:** When multiple endpoints share the same DTO, a change required by one endpoint can inadvertently affect others.
+*   **Developer Confusion:** Developers will find it hard to understand which properties are relevant for a specific endpoint, leading to potential misuse or misunderstanding of the data structure.
+
+<!--endintro-->
+
+By creating unique DTOs tailored to each endpoint's specific requirements, you ensure that:
+
+*   Endpoints only deal with the data they need.
+*   Performance is optimized by avoiding the transfer of superfluous data.
+*   Endpoints are decoupled, making them easier to develop, test, and maintain independently.
+
+```csharp
+namespace Northwind.Trading.Application.Contracts.Models;
+
+public class OrderItemModel
+{
+    public int OrderId { get; set; } 
+    public string CustomerId { get; set; }
+    public DateTime OrderDate { get; set; }
+    public decimal TotalAmount { get; set; }
+    public OrderStatus Status { get; set; }
+
+    /// <summary>
+    /// Used for GetOrderListEndpoint. Ignore when updating
+    /// </summary>
+    public string? ShipFromCountry { get; set; }
+
+    /// <summary>
+    /// Used only for GetOrdersEndpoint. 
+    /// </summary>
+    public DateTimeOffset ModifiedDateUtc { get; set; }
+
+    /// <summary>
+    /// Detailed list of order items. Only for GetOrderDetails.
+    /// Not used for GetOrderList
+    /// </summary>
+    public List<OrderItemViewModel> OrderItems { get; set; } = [];
+}
+```
+::: bad
+Figure: Bad example - `OrderViewModel` is used for multiple purposes (e.g., `GetOrderList`, `GetOrderDetails`, `CreateOrder`) and has accumulated many properties, making it hard to read and maintain.
+:::
+
+
+```csharp
+namespace Northwind.Trading.Application.Contracts.OrderQueries.Models;
+
+public class GetOrderListItemDto
+{
+    public int OrderId { get; set; }
+    public string CustomerId { get; set; }
+    public DateTime OrderDate { get; set; }
+    public decimal TotalAmount { get; set; }
+    public OrderStatus Status { get; set; }
+}
+```
+::: good
+Figure: Good example - A simple `OrderSummaryDto` designed specifically for an endpoint that lists orders.
+:::


### PR DESCRIPTION
In this PR:

- Add a new rule explaining why it's better to use unique DTOs per endpoint or use case
- Add examples of good and bad practices
- Show how shared DTOs lead to confusion, poor performance, and maintainability issues
- Demonstrate how specific DTOs for each endpoint improve clarity and maintainability