### PR TITLE
Fix typos in health check references across multiple documents

### DIFF
--- a/categories/software-engineering/rules-to-better-unit-tests.md
+++ b/categories/software-engineering/rules-to-better-unit-tests.md
@@ -19,7 +19,7 @@ index:
 - isolate-your-logic-and-remove-dependencies-on-instances-of-objects
 - microsoft-recommended-frameworks-for-automated-ui-driven-functional-testing
 - have-tests-for-performance
-- infrastructure-healthchecks
+- infrastructure-health-checks
 - isolate-your-logic-from-your-io-to-increase-the-testability
 - when-adding-a-unit-test-for-an-edge-case-the-naming-convention-should-be-the-issue-id
 - test-your-javascript

--- a/categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.md
+++ b/categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.md
@@ -9,7 +9,7 @@ index:
 - analyze-website-performance
 - analyze-your-website-stats
 - do-you-check-your-website-is-multi-browser-compatible
-- have-a-healthcheck-page-to-make-sure-your-website-is-healthy
+- have-a-health-check-page-to-make-sure-your-website-is-healthy
 - have-auto-generated-maintenance-pages
 - have-an-uptime-report-for-your-website
 - how-to-find-broken-links

--- a/rules/infrastructure-health-checks/rule.md
+++ b/rules/infrastructure-health-checks/rule.md
@@ -11,7 +11,7 @@ authors:
   - title: Luke Cook
     url: https://ssw.com.au/people/luke-cook
 related:
-  - have-a-healthcheck-page-to-make-sure-your-website-is-healthy
+  - have-a-health-check-page-to-make-sure-your-website-is-healthy
 redirects:
   - do-you-have-a-healthcheck-was-zsvalidate-page-to-test-your-website-dependencies
   - do-you-have-a-healthcheck-(was-zsvalidate)
@@ -21,7 +21,7 @@ created: 2020-03-12T20:57:37.000Z
 archivedreason: null
 guid: 015fcac3-c2c2-4d25-a6cd-1317eed69fc6
 ---
-Most developers include [health checks for their own applications](/have-a-healthcheck-page-to-make-sure-your-website-is-healthy/), but modern solutions are often highly dependent on external cloud infrastructure. When critical services go down, your app could become unresponsive or fail entirely. Ensuring your infrastructure is healthy is just as important as your app.
+Most developers include [health checks for their own applications](/have-a-health-check-page-to-make-sure-your-website-is-healthy/), but modern solutions are often highly dependent on external cloud infrastructure. When critical services go down, your app could become unresponsive or fail entirely. Ensuring your infrastructure is healthy is just as important as your app.
 
 <!--endintro-->
 


### PR DESCRIPTION
This pull request focuses on standardizing the spelling of "health check" across multiple files for consistency and clarity. The changes primarily involve updating references to align with the corrected spelling.

### Standardization of "health check" spelling:

* [`categories/software-engineering/rules-to-better-unit-tests.md`](diffhunk://#diff-0ec798d142c79b9fd0809b86a1918c3facb6c3b3770facf7701271210edd77b4L22-R22): Corrected "infrastructure-healthchecks" to "infrastructure-health-checks" for consistency.
* [`categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.md`](diffhunk://#diff-97a3e7f0f28d809cb360c0eb7ae30ffa40a2ac3841eca3aee0d1becbf61c820cL12-R12): Updated "have-a-healthcheck-page-to-make-sure-your-website-is-healthy" to "have-a-health-check-page-to-make-sure-your-website-is-healthy."
* [`rules/infrastructure-health-checks/rule.md`](diffhunk://#diff-50758d3c49e3ce090ea53ef6e810a6672913fcd431f9fb7023993462c9cc54adL14-R14): Adjusted related link references and inline text to use "health check" instead of "healthcheck" for consistency. [[1]](diffhunk://#diff-50758d3c49e3ce090ea53ef6e810a6672913fcd431f9fb7023993462c9cc54adL14-R14) [[2]](diffhunk://#diff-50758d3c49e3ce090ea53ef6e810a6672913fcd431f9fb7023993462c9cc54adL24-R24)