### PR TITLE
XS ◾ underpromise overdeliver - fix Sprint casing

### DIFF
--- a/rules/underpromise-overdeliver/rule.md
+++ b/rules/underpromise-overdeliver/rule.md
@@ -16,7 +16,7 @@ created: 2025-05-26T10:30:00.000Z
 guid: b07a2a47-7887-4b27-9626-48f4175a251d
 ---
 
-We’ve all experienced that awkward silence in a sprint review when the boss joins the call, expecting features to be done... and they’re not. Maybe the requirements weren’t clear, maybe a "quick fix" exploded into days of debugging. Whatever the cause, the result is the same: another commitment missed, and another dent in trust.
+We’ve all experienced that awkward silence in a Sprint Review when the boss joins the call, expecting features to be done... and they’re not. Maybe the requirements weren’t clear, maybe a "quick fix" exploded into days of debugging. Whatever the cause, the result is the same: another commitment missed, and another dent in trust.
 
 <!--endintro-->
 
@@ -62,7 +62,7 @@ If you’re ahead of schedule, tell the client. If you're falling behind, say so
 
 ### 3. Prioritize consistency over perfection  
 
-You don't have to wow every sprint. What clients value more is **predictability**. Be the team they can count on.
+You don't have to wow every Sprint. What clients value more is **predictability**. Be the team they can count on.
 
 > “It’s not about hitting every target perfectly. It’s about reliably delivering over time.”
 >


### PR DESCRIPTION
This pull request includes minor updates to the `rules/underpromise-overdeliver/rule.md` file to standardize terminology. The changes ensure consistent capitalization of "Sprint" throughout the document.

Standardization updates:

* [`rules/underpromise-overdeliver/rule.md`](diffhunk://#diff-57dea7c748f130094cc3bc36bc6422979eebee10f857585262c69addf33b7595L19-R19): Changed "sprint" to "Sprint" in the introduction to align with standardized terminology.
* [`rules/underpromise-overdeliver/rule.md`](diffhunk://#diff-57dea7c748f130094cc3bc36bc6422979eebee10f857585262c69addf33b7595L65-R65): Updated "sprint" to "Sprint" in the section emphasizing consistency over perfection.