### PR TITLE
exit `git log` instructions

### DIFF
--- a/rules/important-git-commands/rule.md
+++ b/rules/important-git-commands/rule.md
@@ -159,6 +159,8 @@ You can customize the output of git log with many options. Here are some of the 
 | `git log --pretty=oneline`      | Shows each commit on one line (more detailed than `--oneline`)               |
 | `git log --abbrev-commit`       | Shows only a short SHA-1 for each commit                                     |
 
+> To exit the `git log`, press `q`
+
 ### 8. git reset
 
 Resets your staging area or moves HEAD to a different commit.


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Missing instructions on how to exit the `git log` command

> 2. What was changed?

✏️ Added this:
> To exit the `git log`, press `q`

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
