### PR TITLE
Update avoid-reviewing-performance-without-metrics Rule to add a list of other nice tools

### DIFF
--- a/rules/avoid-reviewing-performance-without-metrics/rule.md
+++ b/rules/avoid-reviewing-performance-without-metrics/rule.md
@@ -68,6 +68,25 @@ Depending on your tech stack, there are various tools available to measure perfo
 
 ![Figure: Google Chrome has a handy Performance tab in the DevTools](chrome-perf-tools.png)
 
-### Samples
+Here are other performance tools worth considering:
+
+### Frontend Performance:
+- **Page Speed Insights** - Google's web performance analyzer
+- **React Developer Tools** - Component-specific profiling for React apps
+
+### API Performance:
+- **Insomnia** - REST client with performance timing
+- **BenchmarkDotNet** - .NET microbenchmarking framework
+- **Fiddler** - HTTP debugging proxy with performance metrics
+- **Visual Studio Performance Profiler** - Integrated .NET profiling
+- **Bombardier** - HTTP load testing tool
+
+### Telemetry & Monitoring:
+- **Azure App Insights** - Microsoft's application performance monitoring
+- **OpenTelemetry** - Vendor-neutral observability framework
+- **Sentry.io** - Error tracking with performance monitoring
+- **AWS CloudWatch** - Amazon's monitoring and observability service
+
+## Samples
 
 For sample code on how to measure performance, please refer to [Do you have tests for Performance?](/have-tests-for-performance/) on [Rules To Better Unit Tests](/rules-to-better-unit-tests/).


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

This week's CTF

> 2. What was changed?

Added a list of of nice performance tool to the rule

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

Nope