### PR TITLE
XS ◾ 📈 Project portals - Updates 'as of' date for GitHub projects

### DIFF
--- a/rules/use-a-project-portal-for-your-team-and-client/rule.md
+++ b/rules/use-a-project-portal-for-your-team-and-client/rule.md
@@ -24,7 +24,7 @@ When a new developer joins a project, there is often a sea of information that t
 Make it easy for the new developer by putting all this information in a central location like the Visual Studio dashboard.
 
 ::: info
-**Note:** As of October 2021, this feature is missing in GitHub Projects.
+**Note:** As of July 2025, this feature is missing in GitHub Projects.
 :::
 
 ![](plaindashboard.png)

--- a/rules/use-a-project-portal-for-your-team-and-client/rule.md
+++ b/rules/use-a-project-portal-for-your-team-and-client/rule.md
@@ -45,9 +45,9 @@ The dashboard should contain:
 4. The current Sprint backlog
 5. Show the current build status
 6. Show links to:
-   - Staging environment
-   - Production environment
-   - Any other external service used by the project e.g. Octopus Deploy, Application Insights, RayGun, Elmah, Slack
+   * Staging environment
+   * Production environment
+   * Any other external service used by the project e.g. Octopus Deploy, Application Insights, RayGun, Elmah, Slack
 
 Your solution should also contain the standard [\_Instructions.docx](/do-you-make-instructions-at-the-beginning-of-a-project-and-improve-them-gradually) file for additional details on getting the project up and running in Visual Studio.
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

During a review of the SugarLearning Dashboard, the question was raised as to whether GitHub projects still didn't support a Project Portal page like that which exists in Azure DevOps.

> 2. What was changed?

After confirming that this is still the case, I've updated the 'as of' date for the missing feature to the current date to help keep the article up-to-date.

