### PR TITLE
Update Rule “sprint-review-retro-email/rule”

### DIFF
--- a/rules/sprint-review-retro-email/rule.md
+++ b/rules/sprint-review-retro-email/rule.md
@@ -59,8 +59,8 @@ Here are the Sprint Goals and their status at a glance:
 
 Sprint Goals (in priority order):
 
-* {{ ✅/❌/🚧 }} {{ GOAL }} – {{ DONE? }}
-* {{ ✅/❌/🚧 }} {{ GOAL }} – {{ DONE? }}
+* {{ ✅/❌/🚧 }} {{ DONE? }} - {{ GOAL }}
+* {{ ✅/❌/🚧 }} {{ DONE? }} - {{ GOAL }}
 
 Please see below for a more detailed breakdown of the Sprint:
 


### PR DESCRIPTION
I do want our language to be friendly and consistent.  We use “✅ Done - xxx”  all the time. It is on hundreds of SSW rules and in all our email, GitHub and teams communications.

The Sprint Review email template should be consistent with this as well.