### PR TITLE
XS ◾ Remove third goal option

### DIFF
--- a/rules/sprint-review-retro-email/rule.md
+++ b/rules/sprint-review-retro-email/rule.md
@@ -59,8 +59,8 @@ Here are the Sprint Goals and their status at a glance:
 
 Sprint Goals (in priority order):
 
-* {{ ✅/❌/🚧 }} {{ DONE? }} - {{ GOAL }}
-* {{ ✅/❌/🚧 }} {{ DONE? }} - {{ GOAL }}
+* {{ ✅/❌ }} {{ DONE? }} - {{ GOAL }}
+* {{ ✅/❌ }} {{ DONE? }} - {{ GOAL }}
 
 Please see below for a more detailed breakdown of the Sprint:
 


### PR DESCRIPTION
cc: @uly1 @PennyWalker 

Upon decision removing the third option for sprint goals in sprint summary emails