### PR TITLE
Update rules-to-better-email.md - fixing wrong rule name

### DIFF
--- a/categories/communication/rules-to-better-email.md
+++ b/categories/communication/rules-to-better-email.md
@@ -82,7 +82,7 @@ index:
 - screenshots-avoid-walls-of-text
 - screenshots-add-branding
 - bounces-do-you-know-what-to-do-with-bounced-email
-- bounces-do-you-know-how-to-correct-a-bounce
+- correct-a-wrong-email-bounce
 - fix-small-web-errors
 - use-the-best-email-templates
 - add-a-bot-signature-on-automated-emails


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Noticed the issue while working on Rulesv3

> 2. What was changed?

Fixed wrong rule name in rule to better email category file - rule was renamed and the URI changed a few weeks ago

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

No