### PR TITLE
XS ◾ Data - fixing wrong rule name in rule to better email category

### DIFF
--- a/categories/communication/rules-to-better-email.mdx
+++ b/categories/communication/rules-to-better-email.mdx
@@ -83,7 +83,7 @@ index:
 - rule: public/uploads/rules/screenshots-avoid-walls-of-text/rule.mdx
 - rule: public/uploads/rules/screenshots-add-branding/rule.mdx
 - rule: public/uploads/rules/bounces-do-you-know-what-to-do-with-bounced-email/rule.mdx
-- rule: public/uploads/rules/bounces-do-you-know-how-to-correct-a-bounce/rule.mdx
+- rule: public/uploads/rules/correct-a-wrong-email-bounce/rule.mdx
 - rule: public/uploads/rules/fix-small-web-errors/rule.mdx
 - rule: public/uploads/rules/use-the-best-email-templates/rule.mdx
 - rule: public/uploads/rules/add-a-bot-signature-on-automated-emails/rule.mdx


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

PBI: https://github.com/SSWConsulting/SSW.Rules/issues/1898

> 2. What was changed?

Fixed wrong rule name in rule to better email category file.

Also did it in production: https://github.com/SSWConsulting/SSW.Rules.Content/pull/10684

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

No.
