### PR TITLE
include the presneter's name for the sprint summary

### DIFF
--- a/rules/what-happens-at-a-sprint-review-meeting/rule.md
+++ b/rules/what-happens-at-a-sprint-review-meeting/rule.md
@@ -59,8 +59,8 @@ If there are additional stakeholders, make sure they get called in for the summa
 **When you ping stakeholders, include a message like this**:
 
 * I'm recording the current meeting so I can get the Copilot stats later.
-* I'll call you and the stakeholders in 30 mins.  
-* The stakeholders are: {{ Stakeholders Name }}  
+* I'll call you and the stakeholders in 30 mins, {{ PRESENTER_NAME }} will run the Sprint Summary.
+* The stakeholders are: {{ STAKEHOLDER NAMES }}  
 * Let me know if you want anyone else added.
 :::
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Adam requested the update

> 2. What was changed?

include the presenter's name in the summary heads-up message send to stakeholders

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
no
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
