### PR TITLE
S ◾ generate api clients rule - added Orval

### DIFF
--- a/rules/generate-api-clients/rule.md
+++ b/rules/generate-api-clients/rule.md
@@ -32,6 +32,7 @@ Generating API clients from OpenAPI specifications provides several key benefits
 * **Consistency** - Standardized approach across your codebase
 
 ### Best practices
+
 * **Automate generation** - Include client generation in your build pipeline
 * **Separate generated code** - Keep generated clients in separate projects/folders
 * **Don't modify generated code** - Use partial classes or wrapper services for customizations
@@ -48,15 +49,16 @@ Kiota is Microsoft's next-generation API client generator designed for modern cl
 **How it works:** Generates fluent clients from OpenAPI specifications with focus on Microsoft Graph APIs and modern patterns.
 
 ✅ **Pros**
+
 * Modern async/await patterns
 * Supports complex API scenarios - you can filter to the endpoints you care about
 * Growing ecosystem and active development
 * Extendable - easy to add handlers to the client
 
 ❌ **Cons**
+
 * Smaller community compared to alternatives
 * Newer tool with fewer examples
-
 
 ### Orval ⭐ (Recommended for TypeScript/React projects)
 
@@ -67,6 +69,7 @@ Orval is a TypeScript-first OpenAPI generator, popular for Next.js and React pro
 **How it works:** Reads your OpenAPI specification and generates TypeScript clients with optional React Query hooks, mocks, and strongly typed DTOs.
 
 ✅ **Pros**
+
 * Generates modern fetch-based clients compatible with Next.js and Edge runtimes
 * Optional React Query hooks out of the box
 * Type-safe DTOs and request/response validation
@@ -75,6 +78,7 @@ Orval is a TypeScript-first OpenAPI generator, popular for Next.js and React pro
 * Clients are easily extensible e.g. add interceptors for bearer tokens, custom headers, or logging with minimal effort
 
 ❌ **Cons**
+
 * Focused on TypeScript/React – less useful for .NET-only stacks
 * Requires configuration file for advanced setups
 
@@ -87,12 +91,14 @@ NSwag generates strongly-typed C# and TypeScript clients from OpenAPI specificat
 **How it works:** Reads your OpenAPI/Swagger specification and generates complete client classes with methods, models, and error handling.
 
 ✅ **Pros**
+
 * Generates C# and TypeScript clients
 * Full-featured with extensive customization options
 * Handles complex scenarios (inheritance, polymorphism)
 * Strong tooling support (CLI, MSBuild, Visual Studio)
 
 ❌ **Cons**
+
 * Needs configuration
 * Can generate complex code for simple APIs
 * Large generated files for big APIs
@@ -106,12 +112,14 @@ Refit generates HTTP client implementations from interface definitions using att
 **How it works:** You define interfaces with HTTP attributes, and Refit generates the implementation at runtime.
 
 ✅ **Pros**
+
 * Simple attribute-based API definitions
 * Lightweight and easy to learn
 * Great integration with .NET dependency injection
 * No code generation step required
 
 ❌ **Cons**
+
 * REST HTTP only (no GraphQL, gRPC, etc.)
 * Manual model definition required
 * Runtime generation (no compile-time validation of endpoints)
@@ -121,11 +129,13 @@ Refit generates HTTP client implementations from interface definitions using att
 Hand-writing HTTP client code for each API endpoint without any code generation.
 
 ✅ **Pros**
+
 * Full control over implementation
 * No external dependencies
 * Simple
 
 ❌ **Cons**
+
 * Time consuming and repetitive
 * Error prone (typos, wrong URLs, etc.)
 * No automatic updates when API changes

--- a/rules/generate-api-clients/rule.md
+++ b/rules/generate-api-clients/rule.md
@@ -8,6 +8,8 @@ authors:
     url: https://www.ssw.com.au/people/brady-stroud
   - title: Daniel Mackay
     url: https://www.ssw.com.au/people/daniel-mackay
+  - title: Matt Wicks
+    url: https://www.ssw.com.au/people/matt-wicks
 related:
   - the-best-way-to-generate-your-entities-from-swagger
   - generate-interfaces-for-your-dtos
@@ -54,6 +56,27 @@ Kiota is Microsoft's next-generation API client generator designed for modern cl
 ❌ **Cons**
 * Smaller community compared to alternatives
 * Newer tool with fewer examples
+
+
+### Orval ⭐ (Recommended for TypeScript/React projects)
+
+<https://orval.dev>
+
+Orval is a TypeScript-first OpenAPI generator, popular for Next.js and React projects. It integrates cleanly with TanStack Query (React Query), making API consumption highly ergonomic.
+
+**How it works:** Reads your OpenAPI specification and generates TypeScript clients with optional React Query hooks, mocks, and strongly typed DTOs.
+
+✅ **Pros**
+* Generates modern fetch-based clients compatible with Next.js and Edge runtimes
+* Optional React Query hooks out of the box
+* Type-safe DTOs and request/response validation
+* Can also generate API mocks for frontend testing
+* Generated code is clean, readable, and follows familiar HTTP conventions
+* Clients are easily extensible e.g. add interceptors for bearer tokens, custom headers, or logging with minimal effort
+
+❌ **Cons**
+* Focused on TypeScript/React – less useful for .NET-only stacks
+* Requires configuration file for advanced setups
 
 ### NSwag
 


### PR DESCRIPTION
Added a new section describing Orval, a TypeScript-first OpenAPI generator recommended for Next.js and React projects