### PR TITLE
Create rule for leaving explanatory notes for non-standard code

### DIFF
--- a/categories/software-engineering/rules-to-better-code-commenting.md
+++ b/categories/software-engineering/rules-to-better-code-commenting.md
@@ -5,6 +5,7 @@ guid: 1c07cfbf-ffe2-41fc-a115-ccd0d6b26f37
 uri: rules-to-better-code-commenting
 index:
 - code-commenting
+- leave-explanatory-notes-for-non-standard-code
 - what-to-do-with-comments-and-debug-print-statements
 - comment-when-your-code-is-updated
 - todo-tasks

--- a/rules/code-commenting/rule.md
+++ b/rules/code-commenting/rule.md
@@ -13,6 +13,7 @@ related: []
 redirects:
 - comments-do-you-follow-the-general-commenting-rules
 - follow-version-conventions
+- leave-explanatory-notes-for-non-standard-code
 
 ---
 

--- a/rules/code-commenting/rule.md
+++ b/rules/code-commenting/rule.md
@@ -9,11 +9,12 @@ created: 2018-04-23T23:28:08.0000000Z
 authors:
 - title: Adam Cogan
   url: https://ssw.com.au/people/adam-cogan
-related: []
+related:
+- leave-explanatory-notes-for-non-standard-code
 redirects:
 - comments-do-you-follow-the-general-commenting-rules
 - follow-version-conventions
-- leave-explanatory-notes-for-non-standard-code
+
 
 ---
 

--- a/rules/leave-explanatory-notes-for-non-standard-code/rule.md
+++ b/rules/leave-explanatory-notes-for-non-standard-code/rule.md
@@ -1,0 +1,84 @@
+---
+type: rule
+title: Do you leave explanatory notes for non-standard code?
+seoDescription: Learn how to leave clear, permanent comments for non-standard code. This standard ensures future developers understand the reasoning behind specific implementations, preventing accidental bugs.
+uri: leave-explanatory-notes-for-non-standard-code
+authors:
+  - title: Gordon Beeming
+    url: https://ssw.com.au/people/gordon-beeming
+  - title: Daniel Mackay
+    url: https://ssw.com.au/people/daniel-mackay
+related:
+  - code-commenting
+created: 2025-09-09T00:00:00.000Z
+archivedreason: null
+guid: B60B8EC3-A44F-43C9-94F0-13E8ABCB9533
+---
+
+Sometimes, you need to write code that deviates from the standard pattern. It might be a workaround for a library bug, an optimization for a critical performance path, or a temporary solution pending a larger refactor. Without context, a future developer—or even you, months later—might see this "weird" code and refactor it back to the standard pattern, unknowingly reintroducing a bug.
+
+To prevent this, it's crucial to leave a clear, permanent note directly in the code. This ensures the "why" behind the decision is never lost.
+
+<!--endintro-->
+
+### The Problem with Temporary Comments
+
+Developer comments are often temporary. We use them as personal reminders to fix something before a pull request is merged. These are often unstructured and can be confusing if left in the codebase permanently.
+
+::: greybox
+```csharp
+// GB: We need to drop database each run in DEBUG mode for local testing
+var db = sqlServer
+    .AddDatabase("clean-architecture")
+    .WithDropDatabaseCommand();
+```
+:::
+::: bad
+Figure: Bad Example - This format is ambiguous. Is it a permanent note or a temporary reminder for the author to fix later?
+:::
+
+### The Problem with External Documentation
+
+Another common approach is to document these decisions in a wiki, like Confluence. While great for detailed documentation, it has a major flaw.
+
+::: greybox
+**Confluence Page: "Fund File Sync Job Architecture"**
+
+... The fund file synchronization is handled in a separate Azure Function (SyncJob) due to performance considerations. The main HubX API will not process these files directly...
+:::
+::: bad
+Figure: Bad Example - Documentation is disconnected from the code. A developer won't see this unless they know to look for it, making it easy to miss.
+:::
+
+## The Solution: A Standardized NOTE Format
+
+To solve this, use a standardized, prefixed format for these permanent notes. This makes them easy to identify, read, and search for across the entire codebase.
+
+The format is:
+
+**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`**\
+**`// {{ OPTIONAL: see URL }}`**
+
+This approach provides the best of both worlds: the explanation is right next to the code, but it can also link out to more detailed documentation if needed.
+
+::: greybox
+
+```csharp
+// NOTE: [10 Sep 2025] GB - We need to drop database each run in DEBUG mode for local testing
+// see [https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421](https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421)
+var db = sqlServer
+    .AddDatabase("clean-architecture")
+    .WithDropDatabaseCommand();
+```
+
+:::
+::: good
+Figure: Good Example - The `NOTE:` prefix makes the intent clear. The comment is permanent, explains the deviation, and provides a link for more context.
+:::
+
+This standardized format ensures:
+
+✅ **Clarity:** It's immediately obvious that this is a permanent and important note.\
+✅ **Discoverability:** The reason for the non-standard code is impossible to miss.\
+✅ **Consistency:** The format is easy to recognize and search for codebase-wide.\
+✅ **Traceability:** It provides a clear link between the code and the business/technical requirement in the work item or documentation.

--- a/rules/leave-explanatory-notes-for-non-standard-code/rule.md
+++ b/rules/leave-explanatory-notes-for-non-standard-code/rule.md
@@ -56,7 +56,7 @@ To solve this, use a standardized, prefixed format for these permanent notes. Th
 
 The format is:
 
-**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`**\
+**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`**
 **`// {{ OPTIONAL: see URL }}`**
 
 This approach provides the best of both worlds: the explanation is right next to the code, but it can also link out to more detailed documentation if needed.
@@ -78,7 +78,7 @@ Figure: Good Example - The `NOTE:` prefix makes the intent clear. The comment is
 
 This standardized format ensures:
 
-✅ **Clarity:** It's immediately obvious that this is a permanent and important note.\
-✅ **Discoverability:** The reason for the non-standard code is impossible to miss.\
-✅ **Consistency:** The format is easy to recognize and search for codebase-wide.\
-✅ **Traceability:** It provides a clear link between the code and the business/technical requirement in the work item or documentation.
+✅ **Clarity:** It's immediately obvious that this is a permanent and important note.  
+✅ **Discoverability:** The reason for the non-standard code is impossible to miss.  
+✅ **Consistency:** The format is easy to recognize and search for codebase-wide.  
+✅ **Traceability:** It provides a clear link between the code and the business/technical requirement in the work item or documentation.  


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ As per my conversation with @danielmackay, we created an ADR for our current project, and thought this would make for a good general rule for everyone

> 2. What was changed?

✏️

This pull request adds a new rule to the documentation that establishes a standardized approach for leaving explanatory notes in code when deviating from standard patterns. The rule highlights common pitfalls with temporary comments and external documentation, and introduces a clear, consistent format for permanent notes directly in the codebase.

New documentation and standards:

* Added a new rule file `rules/leave-explanatory-notes-for-non-standard-code/rule.md` outlining why explanatory notes are important for non-standard code and how to leave them in a standardized format.
* Provided examples contrasting temporary comments and external documentation with the new standardized `NOTE:` comment format, emphasizing clarity, discoverability, consistency, and traceability.

> 3. Did you do pair or mob programming (list names)?

✏️ no
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
