### PR TITLE
XS ◾ fixed some formatting for Do you leave explanatory notes for non-standard code?

### DIFF
--- a/rules/leave-explanatory-notes-for-non-standard-code/rule.md
+++ b/rules/leave-explanatory-notes-for-non-standard-code/rule.md
@@ -15,7 +15,7 @@ archivedreason: null
 guid: B60B8EC3-A44F-43C9-94F0-13E8ABCB9533
 ---
 
-Sometimes, you need to write code that deviates from the standard pattern. It might be a workaround for a library bug, an optimization for a critical performance path, or a temporary solution pending a larger refactor. Without context, a future developer—or even you, months later—might see this "weird" code and refactor it back to the standard pattern, unknowingly reintroducing a bug.
+Sometimes, you need to write code that deviates from the standard pattern. It might be a workaround for a library bug, an optimization for a critical performance path, or a temporary solution pending a larger refactor. Without context, a future developer, or even you, months later, might see this "weird" code and refactor it back to the standard pattern, unknowingly reintroducing a bug.
 
 To prevent this, it's crucial to leave a clear, permanent note directly in the code. This ensures the "why" behind the decision is never lost.
 
@@ -34,7 +34,7 @@ var db = sqlServer
 ```
 :::
 ::: bad
-Figure: Bad Example - This format is ambiguous. Is it a permanent note or a temporary reminder for the author to fix later?
+Bad Example - This format is ambiguous. Is it a permanent note or a temporary reminder for the author to fix later?
 :::
 
 ### The Problem with External Documentation
@@ -42,12 +42,12 @@ Figure: Bad Example - This format is ambiguous. Is it a permanent note or a temp
 Another common approach is to document these decisions in a wiki, like Confluence. While great for detailed documentation, it has a major flaw.
 
 ::: greybox
-**Confluence Page: "Fund File Sync Job Architecture"**
+**Wiki Page: "Local Development & Testing Setup"**
 
-... The fund file synchronization is handled in a separate Azure Function (SyncJob) due to performance considerations. The main HubX API will not process these files directly...
+...To ensure idempotent and reliable local test runs, the database for the 'clean-architecture' project must be dropped and recreated on each execution when running in `DEBUG` mode. This prevents data contamination between test sessions...
 :::
 ::: bad
-Figure: Bad Example - Documentation is disconnected from the code. A developer won't see this unless they know to look for it, making it easy to miss.
+Bad Example - Documentation is disconnected from the code. A developer won't see this unless they know to look for it, making it easy to miss.
 :::
 
 ## The Solution: A Standardized NOTE Format
@@ -56,13 +56,12 @@ To solve this, use a standardized, prefixed format for these permanent notes. Th
 
 The format is:
 
-**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`**
-**`// {{ OPTIONAL: see URL }}`**
+**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`** 
+**`// {{ OPTIONAL: see URL }}`** 
 
 This approach provides the best of both worlds: the explanation is right next to the code, but it can also link out to more detailed documentation if needed.
 
 ::: greybox
-
 ```csharp
 // NOTE: [10 Sep 2025] GB - We need to drop database each run in DEBUG mode for local testing
 // see [https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421](https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421)
@@ -70,10 +69,9 @@ var db = sqlServer
     .AddDatabase("clean-architecture")
     .WithDropDatabaseCommand();
 ```
-
 :::
 ::: good
-Figure: Good Example - The `NOTE:` prefix makes the intent clear. The comment is permanent, explains the deviation, and provides a link for more context.
+Good Example - The `NOTE:` prefix makes the intent clear. The comment is permanent, explains the deviation, and provides a link for more context.
 :::
 
 This standardized format ensures:

--- a/rules/leave-explanatory-notes-for-non-standard-code/rule.md
+++ b/rules/leave-explanatory-notes-for-non-standard-code/rule.md
@@ -26,12 +26,14 @@ To prevent this, it's crucial to leave a clear, permanent note directly in the c
 Developer comments are often temporary. We use them as personal reminders to fix something before a pull request is merged. These are often unstructured and can be confusing if left in the codebase permanently.
 
 ::: greybox
+
 ```csharp
 // GB: We need to drop database each run in DEBUG mode for local testing
 var db = sqlServer
     .AddDatabase("clean-architecture")
     .WithDropDatabaseCommand();
 ```
+
 :::
 ::: bad
 Bad Example - This format is ambiguous. Is it a permanent note or a temporary reminder for the author to fix later?
@@ -56,12 +58,13 @@ To solve this, use a standardized, prefixed format for these permanent notes. Th
 
 The format is:
 
-**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`** 
-**`// {{ OPTIONAL: see URL }}`** 
+**`// NOTE: [{{ DATE }}] {{ INITIALS }} - {{ REASON }}`**
+**`// {{ OPTIONAL: see URL }}`**
 
 This approach provides the best of both worlds: the explanation is right next to the code, but it can also link out to more detailed documentation if needed.
 
 ::: greybox
+
 ```csharp
 // NOTE: [10 Sep 2025] GB - We need to drop database each run in DEBUG mode for local testing
 // see [https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421](https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/421)
@@ -69,6 +72,7 @@ var db = sqlServer
     .AddDatabase("clean-architecture")
     .WithDropDatabaseCommand();
 ```
+
 :::
 ::: good
 Good Example - The `NOTE:` prefix makes the intent clear. The comment is permanent, explains the deviation, and provides a link for more context.


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ I noticed when reviewing the content that it needed format updates

> 2. What was changed?

✏️

This pull request updates the documentation in `rules/leave-explanatory-notes-for-non-standard-code/rule.md` to improve clarity and consistency in explaining non-standard code practices. The changes focus on making examples more relevant and refining the guidance around explanatory notes in code.

Documentation improvements:

* Updated the ambiguous "bad example" section to clarify its intent and removed unnecessary figure captions for better readability.
* Replaced the external documentation example with a more relevant wiki page scenario, making the advice more applicable to local development and testing setups.

Formatting and clarity:

* Refined wording for better flow and readability in the introduction, making it easier for developers to understand the importance of explanatory notes.
* Improved the presentation of the "good example" by removing redundant figure captions and clarifying the benefits of the standardized NOTE format.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️no
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
