### PR TITLE
XS ◾ AI Internationalisation - Create React App is not modern

### DIFF
--- a/rules/i18n-with-ai/rule.md
+++ b/rules/i18n-with-ai/rule.md
@@ -61,7 +61,7 @@ Here are the most frequent pitfalls developers encounter when scaling globally:
 
 ✅ **Tip:** Use UTF-8 end-to-end (database, API, frontend).  
 
-**Note:** Modern UI frameworks (React, Angular, Blazor, and Vue) include UTF-8 charset in their HTML templates by default. You should still verify whether it's included in your `index.html` file and configured correctly on the server.  
+**Note:** Modern UI frameworks (e.g. React, Angular, Blazor, Vue) include UTF-8 charset in their HTML templates by default. You should still verify whether it's included in your `index.html` file and configured correctly on the server.  
   
 ### UI - Dates & numbers formatting
 


### PR DESCRIPTION
This pull request updates the guidance about UTF-8 charset defaults in modern web frameworks to use more accurate terminology and examples.

Documentation update:

* Updated the note to refer to "modern UI frameworks" (e.g. React, Angular, Blazor, Vue) instead of specific build tools, providing broader and more accurate coverage of frameworks that include UTF-8 charset by default.