### PR TITLE
XS ◾ making lists standard on prompt engineering rule

### DIFF
--- a/rules/fundamentals-of-prompt-engineering/rule.md
+++ b/rules/fundamentals-of-prompt-engineering/rule.md
@@ -19,11 +19,11 @@ In ChatGPT prompt engineering, various elements play a critical role in shaping 
 
 Let's define each of them and provide an example that illustrates their use.
 
-* **[Role:](/give-chatgpt-a-role)**  The role defines the specific function or identity that the ChatGPT model is expected to assume during the conversation. It helps set the tone and expertise level expected from the model's responses.
-* **Result:** The result refers to the desired outcome or specific information the user seeks to obtain from the interaction with ChatGPT. This guides the model in providing relevant and useful responses.
-* **[Intent:](/define-intent-in-prompts)** Intent represents the user's goal or the purpose behind the interaction with the ChatGPT model. It helps the model understand the user's needs and respond accordingly.
-* **[Context](/tell-chatgpt-to-ask-questions):** Context refers to any background information or situational details that are relevant to the conversation. Context helps the model understand the broader scenario and provide appropriate responses that fit the situation.
-* **Constraint:** A constraint is a condition or limitation placed on the model's response. It ensures that the output adheres to specific requirements or avoids certain topics, styles, or content.
+* **[Role](/give-chatgpt-a-role)** - The role defines the specific function or identity that the ChatGPT model is expected to assume during the conversation. It helps set the tone and expertise level expected from the model's responses
+* **Result** - The result refers to the desired outcome or specific information the user seeks to obtain from the interaction with ChatGPT. This guides the model in providing relevant and useful responses
+* **[Intent](/define-intent-in-prompts)** - Intent represents the user's goal or the purpose behind the interaction with the ChatGPT model. It helps the model understand the user's needs and respond accordingly
+* **[Context](/tell-chatgpt-to-ask-questions)** - Context refers to any background information or situational details that are relevant to the conversation. Context helps the model understand the broader scenario and provide appropriate responses that fit the situation
+* **Constraint** - A constraint is a condition or limitation placed on the model's response. It ensures that the output adheres to specific requirements or avoids certain topics, styles, or content
 
 Suppose you're seeking advice on improving coding practices, specifically focusing on C#. Here's how each part can be framed:
 


### PR DESCRIPTION
Updated definitions and formatting for prompt engineering rules.

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Found myself

> 2. What was changed?

From colons to dashes, no full stops
