### PR TITLE
XS ◾ 🐛 Sprint forecast should not include Done PBIs

### DIFF
--- a/rules/sprint-forecast/rule.md
+++ b/rules/sprint-forecast/rule.md
@@ -27,7 +27,6 @@ This is simply an agreement between the Development Team and the PO for one Spri
 <!--endintro-->
 
 > “The implementation team agrees to do its best to deliver an agreed on set of features (scope) to a defined quality standard by the end of the Sprint. (Ideally they deliver what they promised, or even a bit more). The Product Owner agrees not to change his instructions before the end of the Sprint.”
-> **Agile Project management**
 
 Each Sprint in a Scrum project can be considered a mini-project that has **time** (Sprint Length), **scope** (Sprint Backlog), **quality** (Definition of Done) and **cost** (Team Size \* Sprint Length). Only the scope can vary and this is measured every Sprint.
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

📧 RE: SSW EagleEye - Sprint 78 Forecast

> 2. What was changed?

- Updated the status of the PBIs in the example for Sprint Forecast email

