### PR TITLE
XS ◾ Fix link in GitHub Discussions rule

### DIFF
--- a/rules/use-github-discussions/rule.md
+++ b/rules/use-github-discussions/rule.md
@@ -74,7 +74,7 @@ GitHub Discussions can be converted to GitHub Issues with a single click!
 ::: info
 **Using votes to prioritize community needs on GitHub**
 
-Voting up is available in GitHub Discussions, and they provide a great way to prioritize what the community wants most. By encouraging users to upvote feature requests, bug reports, or important discussions, maintainers can better understand which topics have the highest demand. Learn more about [why reacting to GitHub Issues and Discussions matters](react-to-github).
+Voting up is available in GitHub Discussions, and they provide a great way to prioritize what the community wants most. By encouraging users to upvote feature requests, bug reports, or important discussions, maintainers can better understand which topics have the highest demand. Learn more about [why reacting to GitHub Issues and Discussions matters](/react-to-github).
 :::
 
 #### ✨ Stage 2 - GitHub Issues


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

@adamcogan 's email **404 ❌ Do you use GitHub Discussions? | SSW.Rules**

> 2. What was changed?

added missing `/` to internal link
