### PR TITLE
XS ◾ Fix link for reacting and voting on GitHub

### DIFF
--- a/rules/use-github-discussions/rule.md
+++ b/rules/use-github-discussions/rule.md
@@ -74,7 +74,7 @@ GitHub Discussions can be converted to GitHub Issues with a single click!
 ::: info
 **Using votes to prioritize community needs on GitHub**
 
-Voting up is available in GitHub Discussions, and they provide a great way to prioritize what the community wants most. By encouraging users to upvote feature requests, bug reports, or important discussions, maintainers can better understand which topics have the highest demand. Learn more about [why reacting to GitHub Issues and Discussions matters](/react-to-github).
+Voting up is available in GitHub Discussions, and they provide a great way to prioritize what the community wants most. By encouraging users to upvote feature requests, bug reports, or important discussions, maintainers can better understand which topics have the highest demand. Learn more about [why reacting to GitHub Issues and Discussions matters](/react-and-vote-on-github).
 :::
 
 #### ✨ Stage 2 - GitHub Issues


### PR DESCRIPTION
Updated the link to reflect the correct page for reacting and voting on GitHub.

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

URI was wrong!

> 2. What was changed?

fixed link