### PR TITLE
XS ◾ Update PR review and merge responsibilities

### DIFF
--- a/rules/merge-debt/rule.md
+++ b/rules/merge-debt/rule.md
@@ -39,15 +39,19 @@ Merge debt can be avoided by:
   
 ## Internal contributors
 
-If you are in a team (i.e. an internal contributor) it is the PR author's responsibility to get a PR reviewed and action feedback ASAP.  
+If you are in a team (i.e. an internal contributor) it is the PR author's responsibility to get the PR **reviewed** and **merged** ASAP.  
 
 ::: greybox
 **Tip:** For internal contributors, it's a good idea to have a call with the PR reviewers.
 :::
 
+::: info
+**Note:** If are a PR author and you don't have merge permissions, add a comment to the description, so Repo maintainers can action.
+:::
+
 ## Outside contributors
 
-If you are **not** part of the team (i.e. an outside contributor), reviewing the PR is the responsibility of the Repo maintainers. Actioning the feedback is still the responsibility of the PR author.  
+If you are **not** part of the team (i.e. an outside contributor), reviewing and merging the PR is the responsibility of the Repo maintainers. Actioning the feedback is still the responsibility of the PR author.  
 
 ::: greybox
 **Tip:** For outside contributors, it's a good idea to chase the reviewers by reaching out with a comment on GitHub, or through the repo's community (e.g. Discord channels).


### PR DESCRIPTION
Clarified responsibilities for PR authors and reviewers based on contributor type.

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Conversation with @wicksipedia and @isaaclombardssw 

> 2. What was changed?

Making clear it's PR author's responsibility to merge, or leave a comment if they don't have permissions