### PR TITLE
XS ◾ fix: my broken image link

### DIFF
--- a/rules/content-check-before-public-facing-video/rule.md
+++ b/rules/content-check-before-public-facing-video/rule.md
@@ -4,7 +4,7 @@ type: rule
 title: Do you ask for a content check before posting a public video?
 uri: content-check-before-public-facing-video
 authors:
-  - title: Hark Singh
+  - title: Harkirat Singh
     url: https://ssw.com.au/people/harkirat-singh
 related: 
   - checked-by-xxx


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ My profile image link was broken on Rule's page. Inspect elements shows `404: Hark-Singh-Profile.jpg` not found.
After reading [Wiki](https://github.com/SSWConsulting/SSW.Rules.Content/wiki/How-to-Add-an-Acknowledgment) as suggested by @TobyChurches I found this:
<img width="925" height="355" alt="Screenshot 2025-11-06 at 3 27 11 pm" src="https://github.com/user-attachments/assets/2fb0e7f1-3842-44f7-82d3-2efa305ff86d" />
**Figure: Do not use Nicknames**

> 2. What was changed?

✏️ Changed my name from Hark Singh to Harkirat Singh, which will fetch the right `Harkirat-Singh-Profile.jpg`

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ N/A
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
