### PR TITLE
XS ◾ Archived duplicated GitHub notifications rule

### DIFF
--- a/rules/do-you-know-how-to-setup-github-notifications/rule.md
+++ b/rules/do-you-know-how-to-setup-github-notifications/rule.md
@@ -19,12 +19,12 @@ GitHub notifications can be frustrating if they are not setup for your personal 
 1. From [GitHub](https://www.github.com) **Profile Dropdown | Settings | Notifications**
    ![Figure: First navigate to your notifications](https://user-images.githubusercontent.com/79821522/113793099-d8973000-978a-11eb-9ca4-3991ba25e7fd.png)
 
-2. Customise the settings as you see fit 
+2. Customise the settings as you see fit
    ![Figure: The recommended notification setup for non-technical users](https://user-images.githubusercontent.com/79821522/113793107-ddf47a80-978a-11eb-91ea-f8bbce616a21.png)
 
 From the default remove:
 
-- Automatic watching x2
-- Dependabot alerts x5
-- GitHub Actions x1
-- Email notification preferences | Pull Request pushes x1
+* Automatic watching x2
+* Dependabot alerts x5
+* GitHub Actions x1
+* Email notification preferences | Pull Request pushes x1


### PR DESCRIPTION
cc @adamcogan @JeanThirion 

Updated the archived reason for the GitHub notifications rule.

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Checking @Calinator444 's video: **Re: Missing Embed on SSW.Dory Homepage**

> 2. What was changed?

archived