### PR TITLE
XS ◾ Deleting "how-to-respond-to-criticism" related uri in "separate-urge-from-behavior" rule.

### DIFF
--- a/rules/separate-urge-from-behavior/rule.md
+++ b/rules/separate-urge-from-behavior/rule.md
@@ -13,7 +13,6 @@ authors:
     url: https://ssw.com.au/people/brady-stroud
 related: 
   - accepting-unsolicited-feedback
-  - how-to-respond-to-criticism
 redirects: []
 ---
 


### PR DESCRIPTION
…("how-to-respond-to-criticism")

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Working on [this PBI](https://github.com/SSWConsulting/SSW.Rules/issues/2139), I found that a related PBI ("how-to-respond-to-criticism") hasn't any related file, so I deleted that reference.
Related PR - https://github.com/SSWConsulting/SSW.Rules.Content/pull/11326

> 2. What was changed?

Simple uri deletion in related section for "separate-urge-from-behavior" rule.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

N/A
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
