### PR TITLE
XS ◾ Fix markdown code block syntax in rule.md

### DIFF
--- a/rules/rule/rule.md
+++ b/rules/rule/rule.md
@@ -44,7 +44,7 @@ See a few examples of SSW Rules that follow the structure of good and bad exampl
 
 ### 1. Headings, paragraphs, and blockquotes
 
-```markdown
+```md
 ## This is a heading 2 
 
 ### This is a heading 3


### PR DESCRIPTION
Updated markdown code block syntax from 'markdown' to 'md'.

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Saw & conquered the issue

> 2. What was changed?

markdown -> md
