### PR TITLE
XS ◾ fix: italic formatting in AI Automation Bias

### DIFF
--- a/rules/avoid-automation-bias/rule.md
+++ b/rules/avoid-automation-bias/rule.md
@@ -142,13 +142,13 @@ Bad example - AI provides a summary, with not much context. People may take it a
 ::: greybox
 _"I am writing a university essay on treatments for diabetes._
 
-_The essay question is {{ XXX }},
+_The essay question is {{ XXX }},_
 
-_I have these sources {{ XXX }},
+_I have these sources {{ XXX }},_
 
-_My thoughts are {{ XXX }},
+_My thoughts are {{ XXX }},_
 
-_and I want to make sure I cover {{ THESE POINTS }}.
+_and I want to make sure I cover {{ THESE POINTS }}._
 
 _Can you help me draft an outline?"_
 :::


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ There were some italic formatting options 
<img width="884" height="558" alt="Screenshot 2025-12-05 at 9 30 35 am" src="https://github.com/user-attachments/assets/2de0488f-67df-4b9f-8cf0-8b428a9d1e53" />


> 2. What was changed?

✏️ Just added ending `_` to complete the formatting

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ N/A
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
