### PR TITLE
XS ◾ Clean up Sprint Review meeting rule figures

### DIFF
--- a/rules/what-happens-at-a-sprint-review-meeting/rule.md
+++ b/rules/what-happens-at-a-sprint-review-meeting/rule.md
@@ -63,7 +63,7 @@ If there are additional stakeholders, make sure they get called in for the summa
 
 Hey {{ PROJECT NAME }} Stakeholders:
 
-I'm recording the Sprint Review and Sprint Planning so I can get the Copilot stats.   
+I'm recording the Sprint Review and Sprint Planning so I can get the Copilot stats.
 I'll stop the recording to do the Retro to give the recording time to save.
 
 I'll call you and the stakeholders in {{ XX }} mins, {{ PRESENTER NAME }} will run the Sprint Summary.


### PR DESCRIPTION
Removed redundant good example section and image from the Sprint Review meeting rules.

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

call with @adamcogan about https://github.com/SSWConsulting/SSW.Rules.Content/issues/11386

> 2. What was changed?

Removed redundand figure
