### PR TITLE
Add new SSW Rule – Designers helping devs with inspect tool

### DIFF
--- a/ui-tweaks-in-code
+++ b/ui-tweaks-in-code
@@ -1,0 +1,32 @@
+---
+
+  type: rule
+archivedreason:
+title: Do you use DevTools to communicate UI tweaks to developers?
+seoDescription: A brief summary of rule's content. It appears below the title in search engine results and should be both concise and include relevant keywords
+guid: 87bd4e47-869e-440f-a22c-2d7f51d33490
+uri: https://www.ssw.com.au/rules/ui-tweaks-in-code
+created: 09/12/2025
+authors:
+- title: Alex Blum (Required)
+  url: <Hyperlink when clicked> (Optional) 
+  img: <Profile Image to show> (Optional)
+- title: Tiago Araujo (Required)
+  url: <Hyperlink when clicked> (Optional) 
+  img: <Profile Image to show> (Optional)
+- title: Adam Cogan (Required)
+  url: <Hyperlink when clicked> (Optional) 
+  img: <Profile Image to show> (Optional)
+related:
+- do-you-use-chrome-devtools-device-mode-to-design-and-test-your-mobile-views
+- css-changes
+- keep-developers-away-from-design-work
+- hand-over-mockups-to-developers
+
+---
+
+Markdown for the blurb. Outline the problem that the rule is solving.
+
+<!--endintro-->
+
+Markdown with the rest of the content (not shown in the blurb).


### PR DESCRIPTION
Do you use DevTools to explain UI tweaks to developers?

<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Email from @adamcogan

See PBI: [Product Backlog Item 121362](https://dev.azure.com/ssw/SSW.Design/_workitems/edit/121362): 🧑‍💻 Add new SSW Rule – Designers helping devs (inspect tool)


> 2. What was changed?

Added a new SSW Rule: Do you use DevTools to explain UI tweaks to developers?

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✅ Done – with @tiagov8

<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
