### PR TITLE
XS ◾ Update author URLs for Ulysses Maclaren across multiple rule documents

### DIFF
--- a/public/uploads/rules/agentic-ai/rule.mdx
+++ b/public/uploads/rules/agentic-ai/rule.mdx
@@ -9,7 +9,7 @@ authors:
   - title: Eddie Kranz
     url: 'https://www.ssw.com.au/people/eddie-kranz'
   - title: Ulysses Maclaren
-    url: 'https://www.ssw.com.au/people/uly'
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
   - title: Calum Simpson
     url: 'https://www.ssw.com.au/people/calum-simpson'
   - title: Seth Daily

--- a/public/uploads/rules/annual-employment-retro/rule.mdx
+++ b/public/uploads/rules/annual-employment-retro/rule.mdx
@@ -1,7 +1,7 @@
 ---
 authors:
 - title: Ulysses Maclaren
-  url: https://www.ssw.com.au/people/uly
+  url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-07-11 17:16:46.180000+00:00
 guid: 500d7172-c7b9-4b67-8bd6-44fca98f5b00
 redirects: []

--- a/public/uploads/rules/cross-approvals/rule.mdx
+++ b/public/uploads/rules/cross-approvals/rule.mdx
@@ -10,7 +10,7 @@ authors:
 - title: Rick Su
   url: https://ssw.com.au/people/rick-su
 - title: Ulysses Maclaren
-  url: https://ssw.com.au/people/uly
+  url: https://ssw.com.au/people/ulysses-maclaren
 - title: Matt Wicks
   url: https://ssw.com.au/people/matt-wicks
 - title: Seth Daily

--- a/public/uploads/rules/how-to-avoid-being-blocked/rule.mdx
+++ b/public/uploads/rules/how-to-avoid-being-blocked/rule.mdx
@@ -1,7 +1,7 @@
 ---
 authors:
 - title: Ulysses Maclaren
-  url: https://www.ssw.com.au/people/uly
+  url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-08-06 17:30:16.496000+00:00
 guid: d85c1ae4-6395-46af-8976-d846f450a183
 related:

--- a/public/uploads/rules/make-perplexity-your-default-search-engine/rule.mdx
+++ b/public/uploads/rules/make-perplexity-your-default-search-engine/rule.mdx
@@ -9,7 +9,7 @@ seoDescription: Learn how to set Perplexity as your default search engine and
 uri: make-perplexity-your-default-search-engine
 authors:
   - title: Ulysses Maclaren
-    url: https://www.ssw.com.au/people/uly
+    url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-08-15T20:53:13.541Z
 guid: 9fd16b38-a926-4905-a992-b6d7b1f0d742
 ---

--- a/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
+++ b/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
@@ -10,7 +10,7 @@ seoDescription: Learn how to manage the legal implications of adopting AI,
 uri: manage-legal-implications-of-ai
 authors:
   - title: Ulysses Maclaren
-    url: https://www.ssw.com.au/people/uly
+    url: https://www.ssw.com.au/people/ulysses-maclaren
 guid: c03804c7-9dda-4bd3-9fd8-4a9ae9e8cd1f
 ---
 Adopting AI comes with complex legal risks that businesses often overlook. From intellectual property disputes to compliance with regulations and ethical data usage, failure to address these issues can result in lawsuits, fines, or damaged reputations.

--- a/public/uploads/rules/manage-security-risks-when-adopting-ai-solutions/rule.mdx
+++ b/public/uploads/rules/manage-security-risks-when-adopting-ai-solutions/rule.mdx
@@ -8,7 +8,7 @@ seoDescription: Learn how to manage security risks when adopting AI solutions,
 uri: manage-security-risks-when-adopting-ai-solutions
 authors:
   - title: Ulysses Maclaren
-    url: https://www.ssw.com.au/people/uly
+    url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-10-07T21:17:00.000Z
 guid: 8474d43a-fe90-4824-984f-9e4020aa0d17
 ---

--- a/public/uploads/rules/microsoft-planner-for-tasks/rule.mdx
+++ b/public/uploads/rules/microsoft-planner-for-tasks/rule.mdx
@@ -8,7 +8,7 @@ seoDescription: Learn how to automate recurring tasks for your team using
 uri: microsoft-planner-for-tasks
 authors:
   - title: Ulysses Maclaren
-    url: https://www.ssw.com.au/people/uly
+    url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-11-04T12:00:00.000Z
 guid: ef38bffb-9659-4101-b70b-c1def85a3a4b
 ---

--- a/public/uploads/rules/mitigate-brand-risks-ai/rule.mdx
+++ b/public/uploads/rules/mitigate-brand-risks-ai/rule.mdx
@@ -8,7 +8,7 @@ seoDescription: Learn how to manage brand risks when adopting AI, including inac
 uri: mitigate-brand-risks-ai
 authors:
   - title: Ulysses Maclaren
-    url: https://www.ssw.com.au/people/uly
+    url: https://www.ssw.com.au/people/ulysses-maclaren
 guid: 0a42def3-ec40-443c-9125-a9ecfc441e04
 ---
 Adopting AI can pose significant risks to your brand’s reputation. AI systems, if not carefully managed, may produce inaccurate information, make biased decisions, or violate customer privacy. Any of these issues can severely damage customer trust and loyalty, affecting your bottom line.

--- a/public/uploads/rules/prepare-an-agenda/rule.mdx
+++ b/public/uploads/rules/prepare-an-agenda/rule.mdx
@@ -1,7 +1,7 @@
 ---
 authors:
 - title: Ulysses Maclaren
-  url: https://www.ssw.com.au/people/uly
+  url: https://www.ssw.com.au/people/ulysses-maclaren
 created: 2024-02-28 22:53:34.710000+00:00
 guid: f581f5f0-8e75-4bfa-a48d-724d4536a44d
 related:

--- a/public/uploads/rules/report-bugs-and-suggestions/rule.mdx
+++ b/public/uploads/rules/report-bugs-and-suggestions/rule.mdx
@@ -6,7 +6,7 @@ authors:
 - title: Cameron Shaw
   url: https://ssw.com.au/people/cameron-shaw
 - title: Ulysses Maclaren
-  url: https://ssw.com.au/people/uly
+  url: https://ssw.com.au/people/ulysses-maclaren
 created: 2009-03-25 04:53:21+00:00
 guid: 22b7ce50-2586-4fa0-999f-a76a3d60a44a
 redirects:

--- a/public/uploads/rules/use-ai-receptionist/rule.mdx
+++ b/public/uploads/rules/use-ai-receptionist/rule.mdx
@@ -1,7 +1,7 @@
 ---
 authors:
 - title: Ulysses Maclaren
-  url: https://www.ssw.com.au/people/uly
+  url: https://www.ssw.com.au/people/ulysses-maclaren
 - title: Levi Jackson
   url: https://www.ssw.com.au/people/levi-jackson
 - title: Kaique Biancatti


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Noticed Uly's profile pic was broken on a few rules, due to him being referenced as `uly` not `ulysses-maclaren`

> 2. What was changed?

Replaced `uly` with `ulysses-maclaren`

<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
