### PR TITLE
XS ◾ Remove duplicate rule entry in PCs category

### DIFF
--- a/categories/infrastructure-and-networking/rules-to-better-pcs.mdx
+++ b/categories/infrastructure-and-networking/rules-to-better-pcs.mdx
@@ -13,7 +13,6 @@ index:
 - rule: public/uploads/rules/call-sysadmins-before-formatting-company-owned-laptops/rule.mdx
 - rule: public/uploads/rules/use-a-standard-local-admin-account/rule.mdx
 - rule: public/uploads/rules/compare-and-synchronize-your-files/rule.mdx
-- rule: public/uploads/rules/call-sysadmins-before-formatting-company-owned-laptops/rule.mdx
 
 lastUpdated: 2016-03-23T02:03:47.000Z
 lastUpdatedBy: StanleySidik


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

I noticed this rule was listed twice on the **Rules to better PCs** page

> 2. What was changed?

Removed duplicate rule for calling sysadmins before formatting company-owned laptops.
