### PR TITLE
XS ◾ Update Structured Tender Responses URI

### DIFF
--- a/categories/client-engagement/rules-to-better-tenders.mdx
+++ b/categories/client-engagement/rules-to-better-tenders.mdx
@@ -7,7 +7,7 @@ index:
   - rule: public/uploads/rules/create-comprehensive-tender-proposal/rule.mdx
   - rule: public/uploads/rules/listed-on-tender-platforms/rule.mdx
   - rule: public/uploads/rules/network-with-decision-makers-tendering/rule.mdx
-  - rule: public/uploads/rules/rules-to-better-tenders/rule.mdx
+  - rule: public/uploads/rules/personalised-tender-responses/rule.mdx
   - rule: public/uploads/rules/do-you-define-win-strategies-and-win-themes/rule.mdx
 _template: category
 ---

--- a/public/uploads/rules/personalised-tender-responses/rule.mdx
+++ b/public/uploads/rules/personalised-tender-responses/rule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Do you structure your tender responses around the customer’s problem?
-uri: rules-to-better-tenders
+uri: personalised-tender-responses
 categories:
   - category: categories/client-engagement/rules-to-better-tenders.mdx
 authors:


### PR DESCRIPTION
Fix the URL for the new rule. It had a matching URI to the category it was in. Forming a link loop.