### PR TITLE
XS ◾ Fixing all rules that have red and yellow highlights

### DIFF
--- a/public/uploads/rules/change-from-x-to-y/rule.mdx
+++ b/public/uploads/rules/change-from-x-to-y/rule.mdx
@@ -53,7 +53,7 @@ This process consists of including the original version of the content ("X") alo
 Make the changes even easier to see and understand by highlighting:
 
 * In ==yellow== - Content you want to add/update (only do this on the "To" section)
-* In <span style="background-color:#ff0000;color:#fff;font-weight:bolder;">red</span> (with white and bold text) Content you want to delete, whether it be specific text or an entire sentence (only do this on the "From" section)
+* In ==red:red== (with white and bold text) - Content you want to delete, whether it be specific text or an entire sentence (only do this on the "From" section)
   **Note:** Only indicate in red the content that will **not** be replaced/updated with something correlated.
 
 **Note:** All text we do not write ourselves [should be indented](/do-you-use-indentation-for-readability), so this includes paragraphs we are copying and pasting.
@@ -96,7 +96,7 @@ On CodeAuditor web page ssw.com.au/ssw/codeauditor
 
 From:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Scan all your projects for coding &lt;span style="background-color:#ff0000;color:#fff;font-weight:bolder;"&gt;bugs and&lt;/span&gt; errors:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Scan all your projects for coding ==red:bugs and== errors:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; - Enforce industry best practices.
 
@@ -215,7 +215,7 @@ Some websites use GitHub to manage their files (e.g. [SSW Rules](https://github.
 <boxEmbed
   style="info"
   body={<>
-    **Note:** When highlighting text in HTML/Markdown you [should avoid `&lt;font&gt;` tags](/do-you-know-font-tags-are-no-longer-used). Use `&lt;span&gt;` instead.
+    **Note:** When highlighting text in HTML/Markdown you [should avoid &#60;font&#62; tags](/do-you-know-font-tags-are-no-longer-used). Use &#60;span&#62; instead.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/rule.mdx
+++ b/public/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/rule.mdx
@@ -1,15 +1,23 @@
 ---
-seoDescription: Master consistent behavior in .NET Windows Forms by utilizing inherited forms and implementing best practices for design and coding.
 type: rule
 title: Do you use inherited forms for consistent behaviour?
-categories:
-  - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 uri: do-you-use-inherited-forms-for-consistent-behaviour
+categories:
+  - category: >-
+      categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 authors:
   - title: Adam Cogan
-    url: https://ssw.com.au/people/adam-cogan/
-created: 2014-03-14T02:44:00.000Z
+    url: 'https://ssw.com.au/people/adam-cogan/'
 guid: 15657e0f-3e98-42fd-98b0-d9545579c334
+seoDescription: >-
+  Master consistent behavior in .NET Windows Forms by utilizing inherited forms
+  and implementing best practices for design and coding.
+created: 2014-03-14T02:44:00.000Z
+createdBy: Unknown
+createdByEmail: Unknown
+lastUpdated: 2026-01-12T19:52:31.918Z
+lastUpdatedBy: ''
+lastUpdatedByEmail: ''
 ---
 
 If you ask a new .NET developer (from the Access or VB6 world) what is the best thing about .NET Windows Forms, most of your answers will be "Form Inheritance" that allows them to keep a nice consistent look for all forms. If you ask them a couple of months later, they will probably tell you the worst thing about .NET Windows Forms is "Form Inheritance". This is because they have had too many problems with the bugs in the form designer regarding this feature. Many abandon them altogether and jump on the user control band wagon. Please don't... we have a solution to this...
@@ -25,20 +33,11 @@ We try to keep the number of controls on inherited forms, and the levels of inhe
 Every form in your application should inherit from a base form which has code common to every form, for example:
 
 * Company Icon
-* Remembering its size and location - Code sample <span style="background-color: red">to come</span> in the [SSW .NET Toolkit](https://ssw.com.au/ssw/NETToolkit)
+* Remembering its size and location - Code sample ==red\:to come==  in the [SSW .NET Toolkit](https://ssw.com.au/ssw/NETToolkit)
 * Adding itself to a global forms collection if SDI (to find forms that are already open, or to close all open forms)
 * Logging usage frequency and performance of forms (load time)
 
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure="Base Form for all SSW applications with SSW icon"
-  src="/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/baseform.gif"
-/>
-
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Base Form for all SSW applications with SSW icon" src="/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/baseform.gif" />
 
 a) Sorting out the **StartPosition**:
 
@@ -66,16 +65,7 @@ c) Sorting out a base data entry form:
 3. Menu control
 4. Toolbar with New, Search and Delete
 
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure="Base data entry form with menu, toolbar and OK, Cancel & Apply buttons"
-  src="/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/dataentrybaseform.gif"
-/>
-
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Base data entry form with menu, toolbar and OK, Cancel & Apply buttons" src="/uploads/rules/do-you-use-inherited-forms-for-consistent-behaviour/dataentrybaseform.gif" />
 
 **Note:** The data entry base form has no heading - we simply use the Title Bar.
 

--- a/public/uploads/rules/do-you-use-red-and-yellow-colours-to-distinguish-elements-in-the-designer/rule.mdx
+++ b/public/uploads/rules/do-you-use-red-and-yellow-colours-to-distinguish-elements-in-the-designer/rule.mdx
@@ -1,32 +1,32 @@
 ---
-seoDescription: Designers use red and yellow colours to distinguish incomplete and invisible controls on prototypes, enhancing UI feedback and tester clarity.
 type: rule
 title: Do you use red and yellow colours to distinguish elements in the designer?
-categories:
-  - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 uri: do-you-use-red-and-yellow-colours-to-distinguish-elements-in-the-designer
+categories:
+  - category: >-
+      categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 authors:
   - title: Adam Cogan
-    url: https://ssw.com.au/people/adam-cogan
-created: 2014-03-14T02:22:00.000Z
+    url: 'https://ssw.com.au/people/adam-cogan'
 guid: a6e9e6e8-a58b-4af3-9559-027a18cf6e12
+seoDescription: >-
+  Designers use red and yellow colours to distinguish incomplete and invisible
+  controls on prototypes, enhancing UI feedback and tester clarity.
+created: 2014-03-14T02:22:00.000Z
+createdBy: Unknown
+createdByEmail: Unknown
+lastUpdated: 2026-01-12T19:54:20.277Z
+lastUpdatedBy: ''
+lastUpdatedByEmail: ''
 ---
 
 Use colours on incomplete is so useful in design time:
 
-- <span style="background-color:red">Red</span> = Controls which are incomplete, e.g. An incomplete button
-- <span style="background-color:yellow">Yellow</span> = Controls which are deliberately invisible that are used by developers e.g. Test buttons
+* \==red\:Red== Controls which are incomplete, e.g. An incomplete button
+* \==Yellow== Controls which are deliberately invisible that are used by developers e.g. Test buttons
 
 <endIntro />
 
 Usually these controls are always yellow. However sometimes new areas on forms are made red and visible, so you can get UI feedback on your prototypes. Since they are red, the testers know not to report this unfinished work as a bug.
 
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure="Invisible controls highlighted in yellow, and incomplete items highlighted in red"
-  src="/uploads/rules/do-you-use-red-and-yellow-colours-to-distinguish-elements-in-the-designer/redyellowdesigner.gif"
-/>
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Invisible controls highlighted in yellow, and incomplete items highlighted in red" src="/uploads/rules/do-you-use-red-and-yellow-colours-to-distinguish-elements-in-the-designer/redyellowdesigner.gif" />


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2293
This PR is related to this one in the Rules Repository - https://github.com/SSWConsulting/SSW.Rules/pull/2314

> 2. What was changed?

I've updated the syntax of highlighted element using `==`

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

N/A
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
