### PR TITLE
XS ◾ Rename error handling category

### DIFF
--- a/categories/software-engineering/index.mdx
+++ b/categories/software-engineering/index.mdx
@@ -23,7 +23,7 @@ index:
   - category: categories/software-engineering/rules-to-better-power-platform.mdx
   - category: categories/software-engineering/rules-to-better-sharepoint-for-developers.mdx
   - category: categories/software-engineering/rules-to-better-code-commenting.mdx
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
   - category: categories/software-engineering/rules-to-better-kendo-ui.mdx
   - category: categories/software-engineering/rules-to-better-nuget.mdx
   - category: categories/software-engineering/rules-to-better-sql-server-schema-deployment.mdx

--- a/categories/software-engineering/rules-to-better-error-handling.mdx
+++ b/categories/software-engineering/rules-to-better-error-handling.mdx
@@ -1,7 +1,7 @@
 ---
 type: category
 title: Rules to Better Error Handling
-uri: rules-for-error-handling
+uri: rules-to-better-error-handling
 guid: 3691ee12-ee85-40dc-9236-ced69d3930ba
 index:
   - rule: >-

--- a/public/uploads/rules/best-trace-logging/rule.mdx
+++ b/public/uploads/rules/best-trace-logging/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Discover the best trace logging libraries in .NET Core and .NET 
   to enhance your logging infrastructure with built-in abstractions.
 title: Do you use the best trace logging library?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
   - category: categories/software-engineering/rules-to-better-architecture-and-code-review.mdx
 type: rule
 uri: best-trace-logging

--- a/public/uploads/rules/do-you-always-avoid-on-error-resume-next-vb-only/rule.mdx
+++ b/public/uploads/rules/do-you-always-avoid-on-error-resume-next-vb-only/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Never use On Error Resume Next in VB (and VB.NET) projects. If a
   syntax for better structural exception handling.
 title: Do you always avoid On Error Resume Next? (VB Only)
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-always-avoid-on-error-resume-next-vb-only
 ---

--- a/public/uploads/rules/do-you-catch-and-re-throw-exceptions-properly/rule.mdx
+++ b/public/uploads/rules/do-you-catch-and-re-throw-exceptions-properly/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Learn how to properly catch and re-throw exceptions to make debu
   easier by preserving stack traces.
 title: Do you catch and re-throw exceptions properly?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-catch-and-re-throw-exceptions-properly
 ---

--- a/public/uploads/rules/do-you-catch-exceptions-precisely/rule.mdx
+++ b/public/uploads/rules/do-you-catch-exceptions-precisely/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Catching specific exceptions instead of generic ones helps ident
   and enhanced debugging capabilities.
 title: Do you catch exceptions precisely?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-catch-exceptions-precisely
 ---

--- a/public/uploads/rules/do-you-present-the-user-with-a-nice-error-screen/rule.mdx
+++ b/public/uploads/rules/do-you-present-the-user-with-a-nice-error-screen/rule.mdx
@@ -26,7 +26,7 @@ seoDescription: Do you present the user with a nice error screen when an unexpec
   situation occurs on your ASP.NET Core application?
 title: Do you present the user with a nice error screen?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-present-the-user-with-a-nice-error-screen
 ---

--- a/public/uploads/rules/do-you-use-an-analytics-framework-to-help-manage-exceptions/rule.mdx
+++ b/public/uploads/rules/do-you-use-an-analytics-framework-to-help-manage-exceptions/rule.mdx
@@ -26,7 +26,7 @@ seoDescription: Use an analytics framework to gain control over your application
   effectively.
 title: Do you use an analytics framework to help manage exceptions?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-use-an-analytics-framework-to-help-manage-exceptions
 ---

--- a/public/uploads/rules/do-you-use-ladylog/rule.mdx
+++ b/public/uploads/rules/do-you-use-ladylog/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Monitor application errors with LadyLog and provide a profession
   error reporting experience to your users.
 title: Do you use LadyLog?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-use-ladylog
 ---

--- a/public/uploads/rules/do-you-use-the-best-exception-handling-library/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-best-exception-handling-library/rule.mdx
@@ -25,7 +25,7 @@ seoDescription: Discover the top exception handling libraries for software devel
   to manage errors effectively.
 title: Do you use the best exception handling library?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: do-you-use-the-best-exception-handling-library
 ---

--- a/public/uploads/rules/do-you-use-the-result-pattern/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-result-pattern/rule.mdx
@@ -7,7 +7,7 @@ categories:
   - category: >-
       categories/software-engineering/rules-to-better-vertical-slice-architecture.mdx
   - category: categories/software-engineering/rules-to-better-domain-driven-design.mdx
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
   - category: categories/software-engineering/rules-to-better-net-projects.mdx
 authors:
   - title: Daniel Mackay

--- a/public/uploads/rules/managing-errors-with-code-auditor/rule.mdx
+++ b/public/uploads/rules/managing-errors-with-code-auditor/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Code Auditor helps you identify and resolve broken links, HTML e
 type: rule
 title: Do you know how to manage errors with Code Auditor
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 uri: managing-errors-with-code-auditor
 authors:
   - title: Brook Jeynes

--- a/public/uploads/rules/never-throw-exception-using-system-exception/rule.mdx
+++ b/public/uploads/rules/never-throw-exception-using-system-exception/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Do not throw exceptions using System.Exception to avoid generic 
   meaning.
 title: Do you know that you should never throw an exception using System.Exception?
 categories:
-  - category: categories/software-engineering/rules-for-error-handling.mdx
+  - category: categories/software-engineering/rules-to-better-error-handling.mdx
 type: rule
 uri: never-throw-exception-using-system-exception
 ---


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2376

> 2. What was changed?

✏️ Make error-handling category name consistent with others

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
No
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
