### PR TITLE
XS ◾ Update rule.mdx to clarify inline reply guidance

### DIFF
--- a/public/uploads/rules/reply-done/rule.mdx
+++ b/public/uploads/rules/reply-done/rule.mdx
@@ -165,8 +165,10 @@ Jason
 Bob
   </>}
   figurePrefix="bad"
-  figure="It is clear which tasks have been done, however, [replying inline should be avoided](/email-avoid-inline) as it messes up the history"
+  figure="It is clear which tasks have been done, however, replying inline messes up the history"
 />
+
+More on [avoiding inline email replies](/email-avoid-inline).
 
 <emailEmbed
   from=""


### PR DESCRIPTION
Removed the link from the figure text and added a note about avoiding inline replies.

Links won't work in captions