### PR TITLE
XS ◾ Add delay and draft re-check to PR draft reminder workflow

### DIFF
--- a/.github/workflows/pr-draft-reminder.yml
+++ b/.github/workflows/pr-draft-reminder.yml
@@ -18,6 +18,10 @@ jobs:
     if: github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:
+      - name: Wait before commenting
+        shell: bash
+        run: sleep 600  # wait 10 mins
+
       - name: Determine target user and check for existing comment
         id: check_comment
         shell: pwsh
@@ -29,7 +33,7 @@ jobs:
           Write-Output "Checking PR #$prNumber (author: $prAuthor)..."
 
           try {
-            $thisPr = gh pr view $prNumber --repo $repoFull --json number,isCrossRepository | ConvertFrom-Json
+            $thisPr = gh pr view $prNumber --repo $repoFull --json number,isCrossRepository,isDraft | ConvertFrom-Json
           } catch {
             Write-Output "Failed to view PR (isCrossRepository check): $_"
             Write-Output "Skipping workflow."
@@ -40,6 +44,13 @@ jobs:
           # Check if this is a cross-repository PR (from a fork)
           if ($thisPr.isCrossRepository) {
             Write-Output "Skipping cross repository PR"
+            echo "skip=true" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          # Re-check: PR may no longer be draft after the sleep
+          if (-not $thisPr.isDraft) {
+            Write-Output "PR is no longer draft. Skipping reminder."
             echo "skip=true" >> $env:GITHUB_OUTPUT
             exit 0
           }


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2363#issuecomment-3874985399

> 2. What was changed?

✏️  Introduces a 10-minute delay before posting draft reminders to avoid prematurely notifying authors. Adds a re-check to ensure the PR is still in draft after the delay, preventing unnecessary comments on non-draft PRs.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
🤖
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
