### PR TITLE
XS ◾ Fix prompt curly braces for yak character generation

### DIFF
--- a/public/uploads/rules/consistent-ai-generated-characters/rule.mdx
+++ b/public/uploads/rules/consistent-ai-generated-characters/rule.mdx
@@ -28,7 +28,7 @@ You generate a great AI image for marketing, then the next one looks like a dist
 
 <imageEmbed alt="Three side-by-side illustrations of a yak character writing at a desk, each rendered in a different visual style." size="large" showBorder={false} figurePrefix="bad" figure="The same text prompt can produce varied results across different image generation models" src="/uploads/rules/consistent-ai-generated-characters/Yak-Character-Inconsistent.jpg" />
 
-Prompt: “Generate a 3d stylized, cartoon-like yak covering his eyes with his hooves. The yak has small curved horns, shaggy light-brown hair on its head, large expressive eyes, and a friendly, slightly smiling expression. It is wearing a short-sleeved red shirt. The background is plain white, giving the image a clean, studio-like appearance. Make the yak \&#123;&#123; ACTION }\}”
+Prompt: “Generate a 3d stylized, cartoon-like yak covering his eyes with his hooves. The yak has small curved horns, shaggy light-brown hair on its head, large expressive eyes, and a friendly, slightly smiling expression. It is wearing a short-sleeved red shirt. The background is plain white, giving the image a clean, studio-like appearance. Make the yak &lbrace;&lbrace; ACTION &rbrace;&rbrace;”
 
 Attached file: N/A
 
@@ -40,7 +40,7 @@ Image model (left to right): Google Whisk, Open AI GPT Image, Google Nano Banana
 
 <imageEmbed alt="Three side-by-side images of the same 3D yak character wearing a red shirt, shown in different poses." size="large" showBorder={false} figurePrefix="good" figure="By using a source-of-truth image, you can use shorter prompts and ensure character consistency across different scenarios and models" src="/uploads/rules/consistent-ai-generated-characters/Yak-Character-Consistent-v3.jpg" />
 
-Prompt: ==“Use the provided character sheet as the exact character reference. Do not change colors, facial features, proportions, or style. Make Jack the Yak \&#123;&#123; ACTION }\}”==
+Prompt: ==“Use the provided character sheet as the exact character reference. Do not change colors, facial features, proportions, or style. Make Jack the Yak &lbrace;&lbrace; ACTION &rbrace;&rbrace;”==
 
 Attached file: ==source-of-truth.png==
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

chore: auto-fix MDX issues was automatically converting "Make the yak {{ ACTION }}" to "Make the yak \&#123;&#123; ACTION }\}".

> 2. What was changed?

Replaced unicode characters with HTML characters:
from `{{ ACTION }}`
to `&lbrace;&lbrace; ACTION &rbrace;&rbrace;`
