### PR TITLE
Fix image formatting in sort column rule

### DIFF
--- a/public/uploads/rules/visually-indicate-active-sort-column/rule.mdx
+++ b/public/uploads/rules/visually-indicate-active-sort-column/rule.mdx
@@ -28,10 +28,20 @@ There are 2 key visual cues to provide:
 
 Users frequently sort tables and then scroll or scan the data. If the sorted column isn't visually distinct, they have to remember which column they clicked - or worse, they may not realize the data is sorted at all. Bold headers solve this with minimal visual noise.
 
-::: bad
-![Figure: Bad example - The table is sorted but nothing visually indicates which column is sorted or in what direction](/uploads/rules/visually-indicate-active-sort-column/tina-grid-sorted-bad.png)
-:::
+<imageEmbed
+  alt="Table sorted but nothing visually indicates which column is sorted or in what direction"
+  size="large"
+  showBorder={true}
+  figurePrefix="bad"
+  figure="The table is sorted but nothing visually indicates which column is sorted or in what direction"
+  src="/uploads/rules/visually-indicate-active-sort-column/tina-grid-sorted-bad.png"
+/>
 
-::: good
-![Figure: Good example - The sorted column header is bold with a direction arrow, making the active sort obvious at a glance](/uploads/rules/visually-indicate-active-sort-column/tina-grid-sorted-good.png)
-:::
+<imageEmbed
+  alt="Sorted column header is bold with a direction arrow"
+  size="large"
+  showBorder={true}
+  figurePrefix="good"
+  figure="The sorted column header is bold with a direction arrow, making the active sort obvious at a glance"
+  src="/uploads/rules/visually-indicate-active-sort-column/tina-grid-sorted-good.png"
+/>


### PR DESCRIPTION
## Summary

- Replace markdown image syntax with `imageEmbed` components in the "Do you visually indicate the active sort column?" rule
- Fixes bad/good example images not rendering correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)