### PR TITLE
Add URL linting for missing www in SSW links

### DIFF
--- a/categories/company-operations/rules-to-better-business-intelligence.mdx
+++ b/categories/company-operations/rules-to-better-business-intelligence.mdx
@@ -14,5 +14,5 @@ index:
 - rule: public/uploads/rules/do-you-use-a-data-warehouse/rule.mdx
 - rule: public/uploads/rules/understanding-data-lakes/rule.mdx
 ---
-test
+
 Need professional Enterprise Reporting and BI solutions for your business? Check [SSW's Enterprise Reporting Consulting page](https://ssw.com.au/consulting/enterprise-reporting).

--- a/public/uploads/rules/3-steps-to-a-pbi/rule.mdx
+++ b/public/uploads/rules/3-steps-to-a-pbi/rule.mdx
@@ -42,7 +42,7 @@ lastUpdatedBy: 'Jake Bayliss [SSW]'
 lastUpdatedByEmail: jakebayliss@ssw.com.au
 archivedreason: null
 ---
-test
+
 A PBI (Product Backlog Item) is a term commonly used in Agile project management and software development to represent a unit of work. It refers to an item in the Product Backlog, which is a prioritized list of features, enhancements, or fixes to be addressed in a project.
 
 Before a PBI is worked on it should be added to the current Sprint Backlog during [Sprint Planning](/what-happens-at-a-sprint-planning-meeting). If your PBI doesn't exist, or is in an email then you need to [turn it into a PBI](/turn-emails-into-pbis) to be prioritized in Sprint Planning.


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1695

> 2. What was changed?

✏️ Split from https://github.com/SSWConsulting/SSW.Rules.Content/pull/12029 (@PothieuG )

Added a URL linter to check SSW URL without `www` prefix.

The linter check will leave a comment like this:
<img width="1723" height="1234" alt="image" src="https://github.com/user-attachments/assets/ac18a9a4-de69-4742-a7f9-ea9765843a9d" />


> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
@PothieuG 
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
