### PR TITLE
Handle missing rule references in category sync

### DIFF
--- a/scripts/category-sync-validator/category-sync-validator.js
+++ b/scripts/category-sync-validator/category-sync-validator.js
@@ -28,7 +28,7 @@ function readFrontmatter(filePath) {
   return parseFrontmatter(raw);
 }
 
-function getRulePathFromFile(filePath) {
+function normalizePath(filePath) {
   return filePath
     .replace(/\\/g, "/")
     .replace(/^\.\.\/\.\.\//, "")
@@ -172,7 +172,7 @@ function removeRuleFromCategoryFile(categoryPath, rulePath) {
     const m = /^\s*-\s+rule:\s*(.+?)\s*$/.exec(line);
     if (!m) continue;
 
-    const entryRule = getRulePathFromFile(m[1]);
+    const entryRule = normalizePath(m[1]);
     if (entryRule === rulePath) {
       lines.splice(i, 1);
       i--; // adjust index after removal
@@ -192,7 +192,7 @@ function getChangedCategoryFiles(changedFiles) {
         f.endsWith(".mdx") &&
         fs.existsSync(path.resolve(repoRoot, f))
     )
-    .map((f) => getRulePathFromFile(f));
+    .map((f) => normalizePath(f));
 }
 
 function removeMissingRuleReferencesFromCategoryFile(categoryPath) {
@@ -208,7 +208,7 @@ function removeMissingRuleReferencesFromCategoryFile(categoryPath) {
   const removedRulePaths = [];
 
   for (const entry of indexEntries) {
-    const rulePath = getRulePathFromFile(entry);
+    const rulePath = normalizePath(entry);
     const ruleFullPath = path.resolve(repoRoot, rulePath);
 
     if (!fs.existsSync(ruleFullPath)) {
@@ -244,7 +244,7 @@ function fixCategorySync(changedFiles) {
     const categories = getCategoriesFromRule(ruleFrontmatter);
     if (categories.length === 0) continue;
 
-    const rulePath = getRulePathFromFile(ruleFile);
+    const rulePath = normalizePath(ruleFile);
 
     for (const categoryPath of categories) {
       const categoryFullPath = path.resolve(repoRoot, categoryPath);
@@ -266,14 +266,14 @@ function fixCategorySync(changedFiles) {
 
       const indexEntries = getIndexFromCategory(categoryFrontmatter);
       const isRuleInIndex = indexEntries.some(
-        (entry) => getRulePathFromFile(entry) === rulePath
+        (entry) => normalizePath(entry) === rulePath
       );
 
       if (!isRuleInIndex) {
         try {
           appendRuleToCategoryFile(categoryPath, rulePath);
           fixed.push({ action: "added", rulePath, categoryPath });
-          categoryFilesToValidate.add(getRulePathFromFile(categoryPath));
+          categoryFilesToValidate.add(normalizePath(categoryPath));
         } catch (e) {
           errors.push(String(e.message || e));
         }
@@ -283,11 +283,11 @@ function fixCategorySync(changedFiles) {
     // Remove stale index entries:
     // If any category index references this rule but the rule no longer lists that category, remove it.
     const desiredCategorySet = new Set(
-      categories.map((c) => getRulePathFromFile(c))
+      categories.map((c) => normalizePath(c))
     );
 
     for (const catFile of allCategoryFiles) {
-      const normalizedCat = getRulePathFromFile(catFile);
+      const normalizedCat = normalizePath(catFile);
 
       // Only remove from categories that are NOT currently referenced by the rule
       if (desiredCategorySet.has(normalizedCat)) continue;
@@ -297,7 +297,7 @@ function fixCategorySync(changedFiles) {
 
       const indexEntries = getIndexFromCategory(catFrontmatter);
       const hasRule = indexEntries.some(
-        (entry) => getRulePathFromFile(entry) === rulePath
+        (entry) => normalizePath(entry) === rulePath
       );
 
       if (hasRule) {


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2489

> 2. What was changed?

✏️ This pull request refactors and improves the `category-sync-validator.js` script to make path normalization consistent and to ensure that category files do not reference missing rule files. The changes also enhance the script's ability to auto-correct category files and provide clearer output on what was fixed.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
🤖
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
