### PR TITLE
Fix category paths to 'office-automation'

### DIFF
--- a/categories/office-automation/index.mdx
+++ b/categories/office-automation/index.mdx
@@ -3,9 +3,9 @@ title: Office Automation
 type: top-category
 uri: office-automation
 index:
-  - category: categories/infrastructure-and-networking/rules-to-better-automation.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-home-assistant.mdx
+  - category: categories/office-automation/rules-to-better-automation.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-home-assistant.mdx
 lastUpdated: 2026-02-27T00:17:17.988Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: tiagoaraujo@ssw.com.au

--- a/public/uploads/rules/automation-essentials/rule.mdx
+++ b/public/uploads/rules/automation-essentials/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Discover how automating essentials such as security, temperature
   and reduced energy consumption.
 title: Do you automate your essentials?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-automation.mdx
+  - category: categories/office-automation/rules-to-better-automation.mdx
 type: rule
 uri: automation-essentials
 ---

--- a/public/uploads/rules/automation-lightning/rule.mdx
+++ b/public/uploads/rules/automation-lightning/rule.mdx
@@ -10,7 +10,7 @@ seoDescription: Improve lighting automation at your Newcastle office with DMX co
   KNX integration and Gira mobile app.
 title: Do you know how to do lighting automation?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-automation.mdx
+  - category: categories/office-automation/rules-to-better-automation.mdx
 type: rule
 uri: automation-lightning
 ---

--- a/public/uploads/rules/best-practices-office-automation/rule.mdx
+++ b/public/uploads/rules/best-practices-office-automation/rule.mdx
@@ -3,8 +3,8 @@ seoDescription: Understand best practices in office automation to choose between
 type: rule
 title: Do you know the best practices for automating the office with Control4?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-automation.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-automation.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 uri: best-practices-office-automation
 authors:
   - title: Rob Thomlinson

--- a/public/uploads/rules/control4-agents/rule.mdx
+++ b/public/uploads/rules/control4-agents/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Control4 Agents enable smart home automation and customization, 
 type: rule
 title: Do you know what Agents are in Control4?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 uri: control4-agents
 authors:
   - title: Kaique Biancatti

--- a/public/uploads/rules/control4-get-help/rule.mdx
+++ b/public/uploads/rules/control4-get-help/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Get expert help for Control4 issues through dealerships, tech co
 type: rule
 title: Do you know where to get help for Control4?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 uri: control4-get-help
 authors:
   - title: Kaique Biancatti

--- a/public/uploads/rules/control4-project-creation-steps/rule.mdx
+++ b/public/uploads/rules/control4-project-creation-steps/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Control4 project creation involves connecting the controller, ad
 type: rule
 title: Do you know the Control4 Project Creation stages and steps?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 uri: control4-project-creation-steps
 authors:
   - title: Kaique Biancatti

--- a/public/uploads/rules/control4-separate-user-accounts/rule.mdx
+++ b/public/uploads/rules/control4-separate-user-accounts/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Establish separate Control4 user accounts to simplify access man
   and ensure secure authentication for each individual.
 title: Do you set up separate user accounts in Control4?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: control4-separate-user-accounts
 ---

--- a/public/uploads/rules/do-you-backup-your-control4-projects-to-the-cloud/rule.mdx
+++ b/public/uploads/rules/do-you-backup-your-control4-projects-to-the-cloud/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Backup your Control4 projects to the cloud and safeguard against
   loss or corruption with automated backups.
 title: Do you backup your Control4 projects to the cloud?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: do-you-backup-your-control4-projects-to-the-cloud
 ---

--- a/public/uploads/rules/do-you-know-what-to-check-if-your-control4-director-is-running-slowly/rule.mdx
+++ b/public/uploads/rules/do-you-know-what-to-check-if-your-control4-director-is-running-slowly/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Optimize Control4 Director performance by monitoring CPU and mem
   usage with System Diagnostics tool.
 title: Do you know what to check if your Control4 Director is running slowly?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: do-you-know-what-to-check-if-your-control4-director-is-running-slowly
 ---

--- a/public/uploads/rules/do-you-send-control4-notifications-to-a-slack-channel/rule.mdx
+++ b/public/uploads/rules/do-you-send-control4-notifications-to-a-slack-channel/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Control4 notifications seamlessly integrated with Slack channels
   real-time updates and collaboration.
 title: Do you send Control4 notifications to a Slack channel?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: do-you-send-control4-notifications-to-a-slack-channel
 ---

--- a/public/uploads/rules/do-you-send-control4-notifications-when-to-let-people-know-when-an-alarm-is-triggered/rule.mdx
+++ b/public/uploads/rules/do-you-send-control4-notifications-when-to-let-people-know-when-an-alarm-is-triggered/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Stay informed with timely notifications when an alarm is trigger
 title: Do you send Control4 notifications when to let people know when an Alarm is
   triggered?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: do-you-send-control4-notifications-when-to-let-people-know-when-an-alarm-is-triggered
 ---

--- a/public/uploads/rules/eliminate-light-switches/rule.mdx
+++ b/public/uploads/rules/eliminate-light-switches/rule.mdx
@@ -4,8 +4,8 @@ title: Do you eliminate light switches?
 uri: eliminate-light-switches
 categories:
   - category: categories/company-operations/rules-to-better-offices.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-home-assistant.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/home-assistant-app/rule.mdx
+++ b/public/uploads/rules/home-assistant-app/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you use the Home Assistant app?
 uri: home-assistant-app
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-home-assistant.mdx
+  - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:
   - title: Kiki Biancatti
     url: 'https://www.ssw.com.au/people/kaique-biancatti'

--- a/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
+++ b/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you know how to connect to multiple homes in Home Assistant?
 uri: how-to-connect-multiple-homes-home-assistant
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-home-assistant.mdx
+  - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:
   - title: Kiki Biancatti
     url: 'https://www.ssw.com.au/people/kaique-biancatti'

--- a/public/uploads/rules/secure-access-system/rule.mdx
+++ b/public/uploads/rules/secure-access-system/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Use an NFC Secure Access System for building access, ensuring wh
 title: Do you use mobile NFC for easy office access?
 categories:
   - category: categories/company-operations/rules-to-better-offices.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
   - category: categories/infrastructure-and-networking/rules-to-better-security.mdx
 type: rule
 uri: secure-access-system

--- a/public/uploads/rules/use-control4-app/rule.mdx
+++ b/public/uploads/rules/use-control4-app/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: Control4 app lets you control and manage smart home/office featu
   from your smartphone, eliminating the need for physical remote controls.
 title: Do you use the Control4 app?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 type: rule
 uri: use-control4-app
 ---

--- a/public/uploads/rules/use-emojis/rule.mdx
+++ b/public/uploads/rules/use-emojis/rule.mdx
@@ -6,7 +6,7 @@ categories:
   - category: categories/communication/rules-to-better-calendars.mdx
   - category: categories/communication/rules-to-better-microsoft-teams.mdx
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/zigbee-design-principles/rule.mdx
+++ b/public/uploads/rules/zigbee-design-principles/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Optimize your Control4 smart home network performance by followi
 type: rule
 title: Do you know what Zigbee is and follow its design principles?
 categories:
-  - category: categories/infrastructure-and-networking/rules-to-better-control4.mdx
+  - category: categories/office-automation/rules-to-better-control4.mdx
 uri: zigbee-design-principles
 authors:
   - title: Kaique Biancatti


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Deployment failed. Log: https://github.com/SSWConsulting/SSW.Rules/actions/runs/22567611481/job/65367388577

> 2. What was changed?

✏️ Update category paths to the correct one

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
No
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
