### PR TITLE
Automatic assigning when creating a PR via TinaCMS

### DIFF
--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -3,7 +3,7 @@ name: "PR - Assign TinaBot PR to Real Author"
 on:
   pull_request:
     types: [opened]
-    branches: [main, 2406-Automatically_Assign_PR, tina/public/uploads/rules/consistent-notifications/rule]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2406

> 2. What was changed?

I've implemented a workflow that will check if a bot creates the PR, if yes it will look for the commit author and add it to the PR as assignee

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

N/A
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
