### PR TITLE
fix: correct IdentityServer license name, pricing, .NET version reference, and Better Auth investors

### DIFF
--- a/public/uploads/rules/choosing-authentication/rule.mdx
+++ b/public/uploads/rules/choosing-authentication/rule.mdx
@@ -124,7 +124,7 @@ While there are too many options to cover them all, this chart will help you nar
 
 ASP.NET Core has some built-in identity functionality that allows you to create users and roles, and manage the security of your web applications. It is extremely capable and can be used to support a broad number of scenarios. However, it is intended for use in simple web applications, and while it can be extended to support other clients, you will need to build and wire up a lot of the UI for these scenarios yourself.
 
-[With the new Identity endpoints in .NET 8](https://devblogs.microsoft.com/dotnet/improvements-auth-identity-aspnetcore-8/?WT.mc_id=ES-MVP-33518), you can now support even more scenarios (like using API endpoints to exchange a username and password for an access token).
+[Identity Endpoints were introduced in .NET 8](https://devblogs.microsoft.com/dotnet/improvements-auth-identity-aspnetcore-8/?WT.mc_id=ES-MVP-33518) and have continued to evolve in .NET 9 and .NET 10, allowing you to support even more scenarios (like using API endpoints to exchange a username and password for an access token).
 
 However, the most important consideration is that this approach is intended for use in a single, standalone application.
 
@@ -150,7 +150,7 @@ However, the most important consideration is that this approach is intended for 
 
 ## 2. IdentityServer (full control)
 
-[Identity Server](https://duendesoftware.com/products/identityserver) is a source-available, OIDC compliant solution from [Duende](https://duendesoftware.com/) that is built on top of ASP.NET Core. It is dual-licensed under the RPL (free for open-source projects) and a commercial license (required for production use). It has extensive support for a number of authentication and authorization scenarios and supports multiple external identity providers out of the box (meaning it can easily integrate with Microsoft, Google, etc. accounts). IdentityServer extends ASP.NET Core Identity to natively support multiple client types (e.g. web, mobile, machine-to-machine, etc.) and can be used as a single identity across multiple applications.
+[Identity Server](https://duendesoftware.com/products/identityserver) is a source-available, OIDC compliant solution from [Duende](https://duendesoftware.com/) that is built on top of ASP.NET Core. It is licensed under the [Duende Software License](https://duendesoftware.com/license), which is free via the [Community Edition](https://duendesoftware.com/products/communityedition) for qualifying small companies (less than $1M projected annual revenue and less than $3M in capital). Production use by larger organizations requires a paid license (Starter at $1,500/year, Business at $9,000/year, or Enterprise at $20,000/year). It has extensive support for a number of authentication and authorization scenarios and supports multiple external identity providers out of the box (meaning it can easily integrate with Microsoft, Google, etc. accounts). IdentityServer extends ASP.NET Core Identity to natively support multiple client types (e.g. web, mobile, machine-to-machine, etc.) and can be used as a single identity across multiple applications.
 
 IdentityServer provides unmatched flexibility and control over your authentication process. While some other options provide ways to execute custom logic as part of a login process, for anything beyond the most basic of scenarios, IdentityServer will be orders of magnitude easier to implement.
 
@@ -158,7 +158,7 @@ By running your own IdentityServer, you can provide and manage your own SSO IDP 
 
 **✅ Advantages:**  
 
-* Inexpensive
+* Free via Community Edition for small companies (under $1M revenue / $3M capital); paid tiers from $1,500/year
 * Allows you to define custom authentication logic (see ['Complexity' in authentication](#complexity-in-authentication) above)
 * Supports multiple applications/identity consumers
 * Supports multiple clients and client types
@@ -170,7 +170,7 @@ By running your own IdentityServer, you can provide and manage your own SSO IDP 
 * Requires additional hosting resources
 * Requires additional skill set
 * Requires ongoing maintenance
-* Annual license fee
+* Annual license fee for larger organizations ($1,500-$20,000+/year depending on tier)
 
 **Use this option if...**
 
@@ -355,7 +355,7 @@ Because of this, it provides even more flexibility than IdentityServer; but this
 
 ## 10. Better Auth (TypeScript-first open-source auth)
 
-[Better Auth](https://better-auth.com) is a comprehensive, framework-agnostic authentication framework for TypeScript that emerged in 2024 as the spiritual successor to [NextAuth.js / Auth.js](https://authjs.dev). In 2025, Auth.js (formerly NextAuth.js) was handed over to the Better Auth team for ongoing maintenance, consolidating the JavaScript/TypeScript open-source auth ecosystem under one roof. Better Auth has become one of the most widely adopted authentication solutions in the TypeScript ecosystem, backed by [Y Combinator (S25)](https://www.ycombinator.com/companies/better-auth) and a $5M seed round. It is self-hosted by default, fully open-source (MIT), and built from the ground up with end-to-end TypeScript type safety in mind.
+[Better Auth](https://better-auth.com) is a comprehensive, framework-agnostic authentication framework for TypeScript that emerged in 2024 as the spiritual successor to [NextAuth.js / Auth.js](https://authjs.dev). In 2025, Auth.js (formerly NextAuth.js) was handed over to the Better Auth team for ongoing maintenance, consolidating the JavaScript/TypeScript open-source auth ecosystem under one roof. Better Auth has become one of the most widely adopted authentication solutions in the TypeScript ecosystem, backed by [Y Combinator](https://www.ycombinator.com/companies/better-auth), Peak XV (formerly Sequoia), and a $5M seed round. It is self-hosted by default, fully open-source (MIT), and built from the ground up with end-to-end TypeScript type safety in mind.
 
 Unlike IdentityServer (which targets .NET), Better Auth is designed for JavaScript and TypeScript stacks, including Next.js, SvelteKit, Nuxt, Astro, Express, Hono, and more. It also provides plug-and-play integrations for mobile and desktop: the official [@better-auth/expo](https://www.npmjs.com/package/@better-auth/expo) plugin adds authentication to Expo (React Native) apps for both iOS and Android, while the [@better-auth/electron](https://better-auth.com/docs/integrations/electron) plugin (added in v1.5) handles the full OAuth flow for Electron desktop apps, including opening the system browser, exchanging authorization codes via custom protocol, and managing cookies securely. It ships with email/password auth, 2FA (TOTP/SMS), organisation/team management, and an extensible plugin system out of the box, without requiring third-party packages for common scenarios. If you are coming from NextAuth.js, an official migration guide is provided.
 


### PR DESCRIPTION
## Summary

Fact-check pass on the choosing-authentication rule surfaced 3 issues, one critical.

---

## Section 2 (IdentityServer) - CRITICAL fix

The previous PR (#12187) introduced two new factual errors when fixing the license description:

**Error 1: Wrong license name**
- Was: "dual-licensed under the RPL (free for open-source projects)"
- Problem: The RPL (Reciprocal Public License) is a completely unrelated open-source license by someone else. Duende uses their own proprietary "Duende Software License"
- Fixed: Updated to reference the Duende Software License with a link to duendesoftware.com/license

**Error 2: Wrong Community Edition qualification criteria**
- Was: "free for open-source projects"
- Problem: Open-source status is irrelevant. The Community Edition is free for companies/individuals with < $1M projected annual revenue AND < $3M in capital
- Fixed: Accurate criteria stated with link to Community Edition page

**Bonus: Added actual pricing tiers** (verified at duendesoftware.com/products/identityserver):
- Community Edition: Free (revenue/capital threshold)
- Starter: $1,500/year
- Business: $9,000/year
- Enterprise: $20,000/year

Replaced vague "Inexpensive" advantage label with factual pricing. Updated disadvantage to include the actual price range.

---

## Section 1 (ASP.NET Core Identity) - Minor

- Was: "With the new Identity endpoints in .NET 8"
- Problem: .NET 10 is now released (Nov 2025). Implied .NET 8 is current.
- Fixed: Clarified Identity Endpoints were introduced in .NET 8 and have evolved through .NET 9 and .NET 10.

---

## Section 10 (Better Auth) - Minor

- Was: "backed by Y Combinator (S25)"
- Problem: The S25 (Summer 2025) batch designation could not be verified. TechCrunch (June 2025) confirms YC and Peak XV as investors but does not specify the batch.
- Fixed: Removed unverified batch designation, added Peak XV (formerly Sequoia India and Southeast Asia) as a confirmed investor.

---

## Sources
- Duende license: https://duendesoftware.com/license
- Duende pricing: https://duendesoftware.com/products/identityserver
- Duende Community Edition: https://duendesoftware.com/products/communityedition
- Better Auth raise: https://techcrunch.com/2025/06/25/this-self-taught-ethiopian-dev-built-an-authentication-tool-and-got-into-yc/