### PR TITLE
Update rule: Do you follow your Outlook Group in your inbox?

### DIFF
--- a/public/uploads/rules/choosing-large-language-models/rule.mdx
+++ b/public/uploads/rules/choosing-large-language-models/rule.mdx
@@ -20,10 +20,12 @@ authors:
     url: https://www.ssw.com.au/people/luke-cook
   - title: Lewis Toh
     url: https://www.ssw.com.au/people/lewis-toh
+  - title: Hajir Lesani
+    url: https://www.ssw.com.au/people/hajir-lesani
 guid: e6891815-5e9b-4626-a1f7-42f13ce53aec
 ---
 
-When building an AI-powered solution, developers will inevitably need to choose which Large Language Model (LLM) to use. Many powerful models exist (Llama, GPT, Gemini, Mistral, Grok, DeepSeek, etc.), and they are always changing and subject to varying levels of news and hype.
+When building an AI-powered solution, developers will inevitably need to choose which Large Language Model (LLM) to use. Many powerful models exist (Llama, GPT, Claude, Gemini, Mistral, Grok, DeepSeek, etc.), and they are always changing and subject to varying levels of news and hype.
 
 When choosing one for a project, it can be hard to know which to pick, and if you're making the right choice - being wrong could cost valuable performance and UX points.
 
@@ -37,7 +39,7 @@ Because different LLMs are good at different things, it's essential to test them
 
 ## Challenges in Implementing AI
 
-* **Decision fatigue** - There's  an overwhelming number of Language Models to choose from
+* **Decision fatigue** - There's an overwhelming number of Language Models to choose from
 * **Different implementations** - Not all models use the same libraries
 * **Tweaking parameters** - To get the best result involves testing different parameters such as the temperature (creativity), token limit, and more
 * **Cost accumulates rapidly** - Costs from API calls during testing can accumulate, particularly with large prompts or frequent calls
@@ -57,12 +59,13 @@ These platforms simplify testing and deploying different AI models from a variet
 ### [GitHub Models](https://github.com/marketplace/models) (⭐ Recommended for Development)
 
 * **Free offering, rate-limited for development purposes.**
-* Easy Model Switching – Change models with a single API parameter using the Azure AI Inference library
-* Flexible Model Choices – Select larger models for power or compressed (e.g. distilled or quantized) models for efficiency
-* Broad Ecosystem – GitHub Models simplifies testing and selecting the best LLMs
+* Easy Model Switching - Change models with a single API parameter using the Azure AI Inference library
+* Flexible Model Choices - Select larger models for power or compressed (e.g. distilled or quantized) models for efficiency
+* Broad Ecosystem - GitHub Models simplifies testing and selecting the best LLMs
 * Available models include models from...
 
   * OpenAI (GPTs)
+  * Anthropic (Claude)
   * Microsoft (Phi)
   * Meta (Llama)
   * and more...

--- a/public/uploads/rules/follow-outlook-group-in-inbox/rule.mdx
+++ b/public/uploads/rules/follow-outlook-group-in-inbox/rule.mdx
@@ -10,19 +10,30 @@ uri: follow-outlook-group-in-inbox
 authors:
   - title: Matt Wicks
     url: https://www.ssw.com.au/people/matt-wicks
+  - title: Hajir Lesani
+    url: https://www.ssw.com.au/people/hajir-lesani/
 guid: 3c658529-fcd3-4f0d-b1cd-802f7a3dfcfc
 ---
 If you've ever missed important emails from an Outlook Group, despite being a member, it's likely you weren't following the group in your inbox. This can be especially confusing when those messages don't show up in search results or your inbox, even though you technically "have access."
 
 <endIntro />
 
-When you're added to an Outlook Group, you **don't automatically receive group messages in your inbox** - they only show up in the group's shared mailbox. If you want those messages to behave like regular emails (appear in your inbox and show up in search), you need to explicitly follow the group.
+When you're added to an Outlook Group (also called a Microsoft 365 Group), you **don't automatically receive group messages in your inbox** - they only show up in the group's shared mailbox. If you want those messages to behave like regular emails (appear in your inbox and show up in search), you need to explicitly follow the group.
 
 ### How to follow an Outlook Group in your inbox
+
+**Option 1 - Using the group card:**
 
 1. Open Outlook and go to the left-hand navigation pane.
 2. Under **Groups**, find the group you're a member of.
 3. Click on the group (e.g. "SSW TinaCloud").
+4. In the group card, use the **Follow in Inbox** toggle switch to enable receiving group messages in your inbox.
+
+**Option 2 - Via the group ribbon:**
+
+1. Open Outlook and go to the left-hand navigation pane.
+2. Under **Groups**, find the group you're a member of.
+3. Click on the group to open it.
 4. At the top-right of the message panel, click the dropdown next to **Following in inbox**.
 5. Select **Receive all email and events**.
 
@@ -44,6 +55,8 @@ If you're an admin of the group, you can set this to be the default so all membe
 2. Click the pencil icon to edit the group settings.
 3. Check the **Subscription** box:\
    *"Members will receive all group conversations and events in their inboxes."*
+
+**Tip:** Checking this box will also reset all existing members to "Follow in Inbox," not just new members.
 
 <imageEmbed
   alt="Image"

--- a/scripts/frontmatter-validator/package-lock.json
+++ b/scripts/frontmatter-validator/package-lock.json
@@ -15,7 +15,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",


### PR DESCRIPTION
Reviewed and fact-checked rule content. Updated outdated information. Added Hajir Lesani as author.

Changes:
- Clarified the group is also called a 'Microsoft 365 Group'
- Added Option 1 (using the group card toggle) alongside existing Option 2 (ribbon method), reflecting updated Outlook UI
- Added helpful tip about the subscription checkbox also resetting existing members, not just new ones
- Added Hajir Lesani as author