### PR TITLE
Update rule: Do you know Teams meeting chats aren’t visible to non-attendees?

### DIFF
--- a/public/uploads/rules/teams-meetings-vs-group-chats/rule.mdx
+++ b/public/uploads/rules/teams-meetings-vs-group-chats/rule.mdx
@@ -4,6 +4,8 @@ authors:
   url: https://www.ssw.com.au/people/adam-cogan
 - title: Tiago Araujo
   url: https://www.ssw.com.au/people/tiago-araujo
+- title: Hajir Lesani
+  url: https://www.ssw.com.au/people/hajir-lesani
 guid: c02271bd-ea8e-4806-9d21-9082b1fa51d5
 related:
 - rule: public/uploads/rules/easy-questions/rule.mdx


### PR DESCRIPTION
## Summary
- Reviewed and fact-checked rule content
- Updated outdated information
- Added Hajir Lesani as author
- Ensured formatting consistency with repo standards

Rule: https://www.ssw.com.au/rules/teams-meetings-vs-group-chats