### PR TITLE
Rules/toast notifications/rule.mdx

### DIFF
--- a/public/uploads/rules/toast-notifications/rule.mdx
+++ b/public/uploads/rules/toast-notifications/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: 'Where should toast notifications appear in modern web apps? Thi
 created: 2026-03-02T22:07:37.937Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-03-16T00:36:05.034Z
+lastUpdated: 2026-03-16T00:46:02.348Z
 lastUpdatedBy: Griffen Edge
 lastUpdatedByEmail: GriffenEdge@ssw.com.au
 ---
@@ -26,7 +26,7 @@ Poor placement creates confusion. Good placement feels invisible and intentional
 
 If users hesitate for even a second wondering “Was that my system or the app?”, you have introduced friction.
 
-For most modern web applications, there is a clear default: **Bottom center** is the safest and most predictable choice.
+For most modern web applications, there is a clear default: **Bottom center** the safest and least obstructive choice.
 
 <endIntro />
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Teams conversation with @tiagov8  and @micsblank:

> **@griffenedge**: Also I was looking over our new toast rule [Do you place toast notifications where users expect them?](https://www.ssw.com.au/rules/toast-notifications) and had some thoughts.
We make a big point of avoiding the top-right corner because it conflicts with the macOS notification center, yet recommend the bottom-right corner which conflicts with the Windows notification center. Would it make more sense to recommend bottom-center if that is a real concern for us?
>
> **@tiagov8**: I am happy with that. 
The toast rule was created based on Adam's AI research (Claude Opus 4.6) and I just went with it.

> 2. What was changed?

Rewrote the rule to recommend bottom-center toast placement and improve readability.