### PR TITLE
Add rule use-zod-for-runtime-validation to Rules to Better TypeScript category

### DIFF
--- a/categories/software-engineering/rules-to-better-typescript.mdx
+++ b/categories/software-engineering/rules-to-better-typescript.mdx
@@ -12,6 +12,7 @@ index:
 - rule: public/uploads/rules/good-typescript-configuration/rule.mdx
 - rule: public/uploads/rules/only-export-what-is-necessary/rule.mdx
 - rule: public/uploads/rules/test-your-javascript/rule.mdx
+- rule: public/uploads/rules/use-zod-for-runtime-validation/rule.mdx
 
 ---
 


### PR DESCRIPTION
Closes feedback from @tiagov8 on #12209

## Summary
Added `use-zod-for-runtime-validation` rule to the **Rules to Better TypeScript** category (`categories/software-engineering/rules-to-better-typescript.mdx`).

Zod is a TypeScript-first schema validation library, so the TypeScript category is the most appropriate home for this rule.

## Changes
- Added rule to `rules-to-better-typescript.mdx` index