### PR TITLE
fix: Fix mermaid flowchart rendering in choosing-authentication rule

### DIFF
--- a/public/uploads/rules/choosing-authentication/rule.mdx
+++ b/public/uploads/rules/choosing-authentication/rule.mdx
@@ -66,7 +66,7 @@ Note that some of the options listed below support or include the features liste
 
 Each project is different, and you will need to consider your individual needs and circumstances when choosing how to implement identity and authentication in your solution. There are countless options available for authentication, but the chart below can provide a guide for some of the major decisions, and help you narrow down to some of the relevant options. Use this to get started and be sure to consider all the other information in this rule before making a decision.
 
-```mermaid-svg
+```mermaid
 flowchart
 
  Start(["Start"]) --> CustomLogic{"Need Custom/\nComplex Logic?"}


### PR DESCRIPTION
The flowchart in the `choosing-authentication` rule was using the non-standard `mermaid-svg` language tag which caused it to render as plain text.

## Changes
- Changed ```mermaid-svg` to ```mermaid` in the flowchart block

## Why
The standard language identifier for Mermaid diagrams is `mermaid` (used by GitHub, TinaCMS, and other Markdown engines). The `mermaid-svg` tag is not recognised and causes the diagram to display as a raw code block.