### PR TITLE
fix: Add mermaid language tag to code fence in use-mermaid-diagrams rule

### DIFF
--- a/public/uploads/rules/use-mermaid-diagrams/rule.mdx
+++ b/public/uploads/rules/use-mermaid-diagrams/rule.mdx
@@ -30,7 +30,7 @@ When your product owner asks for an architecture Diagram on your project choosin
 
 Mermaid is a Javascript, node based charting tool inspired by markdown. It's supported by a number of Markdown parsing engines like [GitHub](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams), and [TinaCMS](https://tina.io/blog/mermaid-tina-progress).
 
-```
+```mermaid
 flowchart LR
     A[Add Item to Cart] --> B[Go to Checkout]
     B --> C[Enter Payment Details]


### PR DESCRIPTION
The flowchart example in this rule was using a plain ```` fence with no language tag, so it rendered as a raw code block instead of a Mermaid diagram.

## Changes
- Changed ```` to ````mermaid` on the checkout flow example

## Why
The rule is about using Mermaid diagrams - it should demonstrate a rendered diagram, not plain text.