### PR TITLE
fix: Add category link and missing frontmatter fields to use-zod-for-runtime-validation

### DIFF
--- a/public/uploads/rules/use-zod-for-runtime-validation/rule.mdx
+++ b/public/uploads/rules/use-zod-for-runtime-validation/rule.mdx
@@ -5,10 +5,18 @@ uri: use-zod-for-runtime-validation
 authors:
   - title: Hajir Lesani
     url: 'https://www.ssw.com.au/people/hajir-lesani/'
+categories:
+  - category: categories/software-engineering/rules-to-better-typescript.mdx
 related: []
 redirects: []
 created: 2026-03-15T00:00:00.000Z
+createdBy: Hajir Lesani
+createdByEmail: hajirlesani@ssw.com.au
+lastUpdated: 2026-03-18T00:00:00.000Z
+lastUpdatedBy: Hajir Lesani
+lastUpdatedByEmail: hajirlesani@ssw.com.au
 archivedreason: null
+isArchived: false
 guid: f960a0cc-533c-46b5-9685-57db48eb0536
 seoDescription: Learn why Zod is essential for runtime validation in TypeScript applications and how it prevents runtime errors from invalid data.
 ---


### PR DESCRIPTION
Fixes the issue raised in #12209 by @tiagov8.

## Changes
- Added `categories:` back-link pointing to `rules-to-better-typescript`
- Added missing frontmatter fields: `createdBy`, `createdByEmail`, `lastUpdated`, `lastUpdatedBy`, `lastUpdatedByEmail`, `isArchived`

## Why
The rule was missing the `categories:` field, which means it wouldn't show up in search/category pages. Also aligning with the full frontmatter template for consistency.