### PR TITLE
CheckMDX - Skip double-brace expressions in applyFixes to prevent regex conflicts

### DIFF
--- a/scripts/check-mdx/check-mdx.js
+++ b/scripts/check-mdx/check-mdx.js
@@ -392,6 +392,15 @@ function applyFixes({ source, exprFixes }) {
     const original = out.slice(f.start, f.end);
     if (original.startsWith("{") && original.endsWith("}")) {
       const inner = original.slice(1, -1);
+
+      // Skip double-brace expressions like {{ LINK }} — these will be
+      // converted to HTML entities by convertDoubleBraces* functions that
+      // run after applyFixes. Backslash-escaping the outer braces here
+      // would break the regex patterns those functions rely on.
+      if (inner.startsWith("{") && inner.endsWith("}")) {
+        continue;
+      }
+
       const replacement = `\\{${inner}\\}`;
       out = out.slice(0, f.start) + replacement + out.slice(f.end);
     }


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

PBI: https://github.com/SSWConsulting/SSW.Rules/issues/2555
Email: Rules does not allow {{ LINK }}

> 2. What was changed?

Updated the check-mdx script to ignore the '{{' / '}}' so the regex can pick it up further in the script

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
-

