### PR TITLE
ContentHawk Snapshot: archive-rules-cars

### DIFF
--- a/.github/ContentHawk/TODO/2026-04-01_Snapshot_archive-rules-cars.md
+++ b/.github/ContentHawk/TODO/2026-04-01_Snapshot_archive-rules-cars.md
@@ -1,0 +1,20 @@
+# Content Catalog Snapshot
+
+## Agent Configuration
+
+| Field               | Value                                                              |
+|---------------------|--------------------------------------------------------------------|
+| Intent              | Archive all rules to better cars                                   |
+| Search Scope        | All rules in categories/others/rules-to-better-cars.mdx that are not archived |
+| Processing Priority | Sort by lastUpdated ascending                                      |
+| Issue Preferences   | Create up to 5 issues per run                                      |
+| PR Preferences      | Bundle up to 3 PRs per issue                                       |
+| Label               | `archive-rules-cars`                                               |
+| Created             | 2026-04-01                                                         |
+
+## Files to Review
+
+| Path                                                                        | CategoryList                                    | Created    | LastUpdated | CheckedDate | CheckResult |
+|-----------------------------------------------------------------------------|-------------------------------------------------|------------|-------------|-------------|-------------|
+| public/uploads/rules/do-you-have-a-dash-cam/rule.mdx                       | categories/others/rules-to-better-cars.mdx      | 2013-03-13 | 2016-11-04  | -           | pending     |
+| public/uploads/rules/do-you-have-an-usb-adaptor-in-your-car/rule.mdx       | categories/others/rules-to-better-cars.mdx      | 2012-09-27 | 2017-11-24  | -           | pending     |


### PR DESCRIPTION
## Intent

Archive all rules to better cars

## Search Scope

All rules in categories/others/rules-to-better-cars.mdx that are not archived

## Processing Priority

Sort by lastUpdated ascending

## Label for flagged issues

archive-rules-cars

## Issue Preferences (for Agent 2)

Create up to 5 issues per run

## PR Preferences (for Agent 3)

Bundle up to 3 PRs per issue

## Snapshot file

The full file list with metadata is in `.github/ContentHawk/TODO/2026-04-01_Snapshot_archive-rules-cars.md` on this branch.

- **Agent 2** will iterate over the table rows in order, check each file against the intent, update `CheckedDate` and `CheckResult`, and open issues with the `archive-rules-cars` label.
- **Agent 3** will read issues labelled `archive-rules-cars` and raise PRs to resolve them.