### PR TITLE
🦅 ContentHawk - Fix PRs being opened for issues already tagged on open PRs

### DIFF
--- a/.github/workflows/content-fixer.lock.yml
+++ b/.github/workflows/content-fixer.lock.yml
@@ -23,12 +23,12 @@
 #
 # Agent 3 (Fixer) of the ContentHawk pipeline. Runs on a cron schedule (or manually) and picks up the first available snapshot from the TODO folder. Reads the snapshot to obtain the Label, PR Preferences, and Intent, then bundles eligible issues into groups and creates one PR per bundle that applies the content fixes and closes the linked issues. Skips issues already referenced in existing open fixer PRs to avoid duplicate work. Exits gracefully if no snapshot file is found in the TODO folder.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"37ef392177ddaf2488831140da591b7c66b6498ecebe959d572b4588277e5355","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"363b9b4dd2c152e828a62dfb50bfc1ccdc3062b2516256b66a5e0cf1aee1dcb3","compiler_version":"v0.59.0","strict":true}
 
 name: "Content Fixer (Agent 3a)"
 "on":
   schedule:
-  - cron: "0 * * * */7"
+  - cron: "0 0 * * */7"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/content-fixer.md
+++ b/.github/workflows/content-fixer.md
@@ -139,7 +139,17 @@ If `snapshot_issue_numbers` is empty, **stop immediately** with a message:
 
 > No issues found in the snapshot file. Nothing to fix. Exiting.
 
-#### 2b. Fetch issue details and filter to open issues
+#### 2b. Filter out issues already referenced in open pull requests
+
+For each issue number in `snapshot_issue_numbers`, use the GitHub `pull_requests` toolset to search for **open** pull requests in this repository whose body contains `#<number>` (e.g. `#42` for issue 42).
+
+If **any** open PR is found that references the issue number in its body, **remove that issue number** from `snapshot_issue_numbers` — it is already being addressed by an in-flight PR.
+
+If `snapshot_issue_numbers` is empty after filtering, **stop immediately** with a message:
+
+> All issues in the snapshot are already referenced in open pull requests. Nothing to fix. Exiting.
+
+#### 2c. Fetch issue details and filter to open issues
 
 For each issue number in `snapshot_issue_numbers`, fetch the issue from GitHub. Only include issues that are **open** — closed issues have already been resolved and should be skipped. For each open issue, record:
 

--- a/.github/workflows/content-fixer.md
+++ b/.github/workflows/content-fixer.md
@@ -13,7 +13,7 @@ name: Content Fixer (Agent 3a)
 
 on:
   schedule:
-    - cron: "0 * * * */7"
+    - cron: "0 0 * * */7"
   workflow_dispatch:
 
 engine:

--- a/.github/workflows/content-judge.lock.yml
+++ b/.github/workflows/content-judge.lock.yml
@@ -23,12 +23,12 @@
 #
 # Agent 2a (Judge) of the ContentHawk pipeline. Runs on a cron schedule (or manually) and picks up the first available snapshot from the TODO folder. Reads the snapshot to obtain the Label, Intent, and Issue Preferences, then iterates over every pending row in order. For each file it reads the content, judges whether the file needs action based on the Intent captured by Agent 1, and opens a labelled GitHub issue for files that need fixing. After all affordable rows have been processed a post-step dispatches Agent 2b (content-judge-pr) which reads the created issues and opens a pull request to update the snapshot. Stops immediately if the number of open labelled issues already meets or exceeds max_open_issues without making any changes.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"c448c3f542bbbd78620fb78e50cb5e6e61c56e32cfe8132493ec352b194013af","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1cb34d5a4ac029342debf3fc8006feba8793768c4c329dc07a117e34a588bffc","compiler_version":"v0.59.0","strict":true}
 
 name: "Content Judge (Agent 2a)"
 "on":
   schedule:
-  - cron: "0 * * * */7"
+  - cron: "0 0 * * */7"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/content-judge.md
+++ b/.github/workflows/content-judge.md
@@ -15,7 +15,7 @@ description: >
 name: Content Judge (Agent 2a)
 on:
   schedule:
-    - cron: "0 * * * */7"
+    - cron: "0 0 * * */7"
   workflow_dispatch:
 
 engine:


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

See issue: https://github.com/SSWConsulting/SSW.ContentHawk/issues/7

> 2. What was changed?

Updated **Agent 3a of ContentHawk** with a new guard: if an issue that is part of a content check is already referenced in an open PR, that issue will be omitted from the content check.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

N/A

<img width="1421" height="730" alt="image" src="https://github.com/user-attachments/assets/c75b74c7-3435-419e-a8d1-bb81228799a4" />



**Figure: Changes to content fixer working as expected on test repo**
