### PR TITLE
public/uploads/rules/the best-file-transfer-techniques-to-and-from-china/rule (PR from TinaCMS)

### DIFF
--- a/categories/marketing-and-video/rules-to-better-video-recording.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -1,10 +1,8 @@
 ---
-_template: category
 type: category
 title: Rules to Better Video Recording
-guid: 60485409-d17d-4be3-b2a0-1ab5cdd4d82d
 uri: rules-to-better-video-recording
-seoDescription: Best practices for recording professional videos. Learn about camera setup, lighting, audio, and editing for high-quality video content.
+guid: 60485409-d17d-4be3-b2a0-1ab5cdd4d82d
 index:
   - rule: public/uploads/rules/easy-recording-space/rule.mdx
   - rule: public/uploads/rules/done-video/rule.mdx
@@ -77,12 +75,14 @@ index:
   - rule: public/uploads/rules/recording-screen/rule.mdx
   - rule: public/uploads/rules/screen-recording-spotlight/rule.mdx
   - rule: public/uploads/rules/use-autopod-for-editing-multi-camera-interviews/rule.mdx
-lastUpdated: 2025-11-23T23:04:44.000Z
-lastUpdatedBy: Tiago Araújo [SSW]
-lastUpdatedByEmail: tiagov8@gmail.com
+  - rule: public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
 created: 2021-05-17T02:16:52.000Z
-createdBy: Jayden Alchin [SSW]
+createdBy: 'Jayden Alchin [SSW]'
 createdByEmail: 75593567+jaydenalchin@users.noreply.github.com
+lastUpdated: 2025-11-23T23:04:44.000Z
+lastUpdatedBy: 'Tiago Araújo [SSW]'
+lastUpdatedByEmail: tiagov8@gmail.com
+_template: category
 ---
 
 Need a video for your business? Check [SSW's Video Production consulting page](https://www.ssw.com.au/consulting/video-production).

--- a/categories/marketing-and-video/rules-to-better-video-recording.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -3,6 +3,7 @@ type: category
 title: Rules to Better Video Recording
 uri: rules-to-better-video-recording
 guid: 60485409-d17d-4be3-b2a0-1ab5cdd4d82d
+seoDescription: Best practices for recording professional videos. Learn about camera setup, lighting, audio, and editing for high-quality video content.
 index:
   - rule: public/uploads/rules/easy-recording-space/rule.mdx
   - rule: public/uploads/rules/done-video/rule.mdx

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -10,7 +10,7 @@ guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T08:02:01.440Z
+lastUpdated: 2026-04-09T08:03:36.841Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---
@@ -21,7 +21,7 @@ When working on international projects, especially video editing and remote coll
 
 **The Pain**
 
-OneDrive is our default at SSW, but it is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
+SharePoint is our default at SSW, but it is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
 
 * Broken video editing workflows
 * Delays in remote team collaboration
@@ -34,3 +34,5 @@ OneDrive is our default at SSW, but it is heavily throttled or inconsistent for 
 * Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
 
 <imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />
+
+<imageEmbed alt="Googledrive-takes-6-seconds" size="large" showBorder={false} figurePrefix="good" figure="353 MB files shared through GoogleDrive takes 6 seconds" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/googledrive-takes-6-seconds.png" />

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -1,5 +1,5 @@
 ---
-title: " Do you know the best file transfer techniques to and from China? \U0001F1E8\U0001F1F3"
+title: "Do you know the best ways to transfer files to and from China?  \U0001F1E8\U0001F1F3"
 uri: the-best-file-transfer-techniques-to-and-from-china
 categories:
   - category: categories/marketing-and-video/rules-to-better-video-recording.mdx

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -10,13 +10,27 @@ guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T06:58:37.628Z
+lastUpdated: 2026-04-09T08:02:01.440Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---
 
-Intro
+When working on international projects, especially video editing and remote collaboration - large file transfers are a common bottleneck. Between Australia and China, the "Great Firewall" often makes standard tools unusable or painfully slow.
 
 <endIntro />
 
-Body
+**The Pain**
+
+OneDrive is our default at SSW, but it is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
+
+* Broken video editing workflows
+* Delays in remote team collaboration
+* Frustration for both the Australia and China teams
+
+**The Solution: Google Drive**
+
+* Speed: Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route.
+* Reliability: Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio).
+* Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
+
+<imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -20,7 +20,7 @@ When working on international projects, especially video editing and remote coll
 
 <endIntro />
 
-**The Pain**
+## The pain
 
 SharePoint is our default at SSW, but it is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -22,7 +22,7 @@ When working on international projects, especially video editing and remote coll
 
 ## The pain
 
-SharePoint is our default at SSW, but it is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
+SharePoint (default at SSW) is heavily throttled or inconsistent for users in China. Download speeds are often extremely slow, leading to:
 
 * Broken video editing workflows
 * Delays in remote team collaboration

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -1,11 +1,16 @@
 ---
 title: " Do you know the best file transfer techniques to and from China? \U0001F1E8\U0001F1F3"
 uri: the-best-file-transfer-techniques-to-and-from-china
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
+authors:
+  - title: Lydia Cheng
+    url: 'https://www.ssw.com.au/people/lydia-cheng/'
 guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T06:44:39.659Z
+lastUpdated: 2026-04-09T06:58:37.628Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -10,7 +10,7 @@ guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T08:03:36.841Z
+lastUpdated: 2026-04-09T08:09:58.495Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -28,7 +28,7 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 * Delays in remote team collaboration
 * Frustration for both the Australia and China teams
 
-**The Solution: Google Drive**
+## The solution: Google Drive
 
 * Speed: Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route.
 * Reliability: Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio).

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -7,10 +7,11 @@ authors:
   - title: Lydia Cheng
     url: 'https://www.ssw.com.au/people/lydia-cheng/'
 guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
+seoDescription: Learn the best file transfer techniques for China. Discover why Google Drive outperforms SharePoint for high-speed video and audio collaboration between Australia and China.
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T08:09:58.495Z
+lastUpdated: 2026-04-09T08:17:30.642Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -1,0 +1,17 @@
+---
+title: " Do you know the best file transfer techniques to and from China? \U0001F1E8\U0001F1F3"
+uri: the-best-file-transfer-techniques-to-and-from-china
+guid: c8763b75-80de-4a67-9d03-bca6f9513c7a
+created: 2026-04-09T06:43:01.274Z
+createdBy: 'LydiaCheng [SSW]'
+createdByEmail: lydiacheng@ssw.com.au
+lastUpdated: 2026-04-09T06:44:39.659Z
+lastUpdatedBy: 'LydiaCheng [SSW]'
+lastUpdatedByEmail: lydiacheng@ssw.com.au
+---
+
+Intro
+
+<endIntro />
+
+Body

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Learn the best file transfer techniques for China. Discover why 
 created: 2026-04-09T06:43:01.274Z
 createdBy: 'LydiaCheng [SSW]'
 createdByEmail: lydiacheng@ssw.com.au
-lastUpdated: 2026-04-09T08:17:30.642Z
+lastUpdated: 2026-04-09T09:50:59.821Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 ---
@@ -33,6 +33,8 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 * Speed: Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route.
 * Reliability: Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio).
 * Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
+
+💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384) . 
 
 <imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />
 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -34,7 +34,7 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 * **Reliability** - Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio)
 * **Collaboration** - Smoother "Hand-off" between AU editors and China-based video teams
 
-💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384) . 
+💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384). 
 
 <imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />
 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -31,7 +31,7 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 ## The solution: Google Drive
 
 * **Speed** - Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route
-* Reliability: Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio).
+* **Reliability** - Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio)
 * Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
 
 💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384) . 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -32,7 +32,7 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 
 * **Speed** - Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route
 * **Reliability** - Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio)
-* Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
+* **Collaboration** - Smoother "Hand-off" between AU editors and China-based video teams
 
 💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384) . 
 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -30,7 +30,7 @@ SharePoint is our default at SSW, but it is heavily throttled or inconsistent fo
 
 ## The solution: Google Drive
 
-* Speed: Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route.
+* **Speed** - Google Drive's infrastructure currently handles the cross-border traffic more efficiently for our specific route
 * Reliability: Fewer interrupted uploads/downloads for large files (4K footage, high-bitrate audio).
 * Collaboration: Smoother "Hand-off" between AU editors and China-based video teams.
 


### PR DESCRIPTION
**Summary**
Added a new rule under the  **Marketing and Video | Video Recording** category to guide team members on the most efficient way to transfer large media files between Australia and China.

**The Problem**
Currently, many team members use SharePoint by default for all file transfers. However, due to the Great Firewall and routing issues, SharePoint speeds from Australia to China are extremely slow and unreliable for large video/audio assets. This causes significant delays in our cross-border video editing workflow.

**The Solution**
Based on recent successful tests, this rule recommends switching to Google Drive for large file transfers to China. It outlines the specific scenario where Google Drive outperforms SharePoint and provides clear "✅Good" and "❌Bad" examples to help the team make the right choice.