### PR TITLE
Format placeholders with backticks and emphasize curly brackets

### DIFF
--- a/public/uploads/rules/placeholder-for-replaceable-text/rule.mdx
+++ b/public/uploads/rules/placeholder-for-replaceable-text/rule.mdx
@@ -42,49 +42,48 @@ However, everyone has their own preferences about which placeholder character to
 
 For example:
 
-* SSW Rules historically used xxx
+* SSW Rules historically used `xxx`
 
-> The quick brown fox xxx over the lazy dog
+> The quick brown fox `xxx` over the lazy dog
 
-* SSW Intranet | Sales templates use ❌❌❌
+* SSW Intranet | Sales templates use `❌❌❌`
 
-> The quick brown fox ❌❌❌ over the lazy dog
+> The quick brown fox `❌❌❌` over the lazy dog
 
-* SSW GitHub Sprint Templates use ✏️xxx
+* SSW GitHub Sprint Templates use `✏️xxx`
 
-> The quick brown fox ✏️xxx over the lazy dog
+> The quick brown fox `✏️xxx` over the lazy dog
 
-* SQL developers are used to \[ ]
+* SQL developers are used to `[ ]`
 
-> The quick brown fox \[ action ] over the lazy dog
+> The quick brown fox `[ action ]` over the lazy dog
 
-* Word Mail Merge users are used to « »
+* Word Mail Merge users are used to `« »`
 
-> The quick brown fox « action » over the lazy dog
+> The quick brown fox `« action »` over the lazy dog
 
-* API and React developers are used to { }
+* API and React developers are used to `{ }`
 
-> The quick brown fox { action } over the lazy dog
+> The quick brown fox `{ action }` over the lazy dog
 
-* Angular developers are used to &#123;&#123; &#125;&#125;   
+* Angular developers are used to `{{  }}`   
   (currently the standard in SugarLearning and SSW Rules)
 
-> The quick brown fox &#123;&#123; action &#125;&#125; over the lazy dog\
->
+> The quick brown fox `{{ action }}` over the lazy dog
 
-> The quick brown fox &#123;&#123; ACTION &#125;&#125; over the lazy dog 
+> The quick brown fox `{{ ACTION }}` over the lazy dog 
 
-* Visual Studio code reviewers are used to TODO:
+* Visual Studio code reviewers are used to `TODO:`
 
-> The quick brown fox TODO\:action over the lazy dog
+> The quick brown fox `TODO\:action` over the lazy dog
 
-So, double curly brackets are recommended instead of square brackets to indicate replaceable text.
+So, double **curly brackets** are recommended instead of square brackets to indicate replaceable text.
 
 **In certain places such as Sales templates, you cannot afford to miss a single placeholder**
 
-Of course, if you want to make it even more obvious then highlight the text in yellow... however you can't do it in many places like Microsoft Forms... so another option is to use an emoji like the ✏️ or to make it super obvious the three ❌❌❌
+Of course, if you want to make it even more obvious then highlight the text in yellow... however you can't do it in many places like Microsoft Forms... so another option is to use an emoji like the ✏️ or to make it super obvious the three ❌❌❌.
 
-Another way to draw attention to text is to make the placeholder all caps.
+To draw even more attention to text you should make the placeholder all caps.
 
   subject="\\[Project name\\] - Test please"
   shouldDisplayBody={true}

--- a/public/uploads/rules/placeholder-for-replaceable-text/rule.mdx
+++ b/public/uploads/rules/placeholder-for-replaceable-text/rule.mdx
@@ -66,12 +66,12 @@ For example:
 
 > The quick brown fox `{ action }` over the lazy dog
 
-* Angular developers are used to `{{  }}`   
+* Angular developers are used to `&#123;&#123;  &#125;&#125;`   
   (currently the standard in SugarLearning and SSW Rules)
 
-> The quick brown fox `{{ action }}` over the lazy dog
+> The quick brown fox `&#123;&#123; action &#125;&#125;` over the lazy dog
 
-> The quick brown fox `{{ ACTION }}` over the lazy dog 
+> The quick brown fox `&#123;&#123; ACTION &#125;&#125;` over the lazy dog 
 
 * Visual Studio code reviewers are used to `TODO:`
 


### PR DESCRIPTION
Updated placeholder characters to use backticks for better formatting and emphasized curly brackets for replaceable text.


https://github.com/SSWConsulting/SSW.Rules.Content/pull/12480/changes Broke the rule...


<img width="1555" height="962" alt="Screenshot 2026-04-15 at 7 48 36 PM" src="https://github.com/user-attachments/assets/ebfd2a04-d2c5-4a9a-857a-5701932526fb" />
