### PR TITLE
alex/update rule-v2/avoid-using-mailto (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid displaying valid email addresses on your website to preven
 created: 2016-11-16T17:15:32.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-04-17T07:35:53.941Z
+lastUpdated: 2026-04-20T00:02:20.778Z
 lastUpdatedBy: AlexBlum-SSW
 lastUpdatedByEmail: alexblum@ssw.com.au
 isArchived: false
@@ -70,7 +70,7 @@ Form submissions, by contrast, are confirmed actions with full funnel visibility
 
 ## The alternatives
 
-### `mailto:` done correctly (rare cases)
+### `mailto:` done correctly (used in rare cases)
 
 When `mailto:` is genuinely needed, build it correctly:
 
@@ -79,7 +79,9 @@ When `mailto:` is genuinely needed, build it correctly:
 * [Track clicks via GTM](https://hallam.agency/blog/mailto-link-analytics-tag-manager/) (preferred) or a `gtag.js` click listener
 * Encrypyt or obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
 
-1\. Store email addresses in the web.config file
+#### Example encryption method:
+
+##### Step 1 - Store email addresses in the web.config file
 
 ```xml
 <configuration>
@@ -90,7 +92,7 @@ When `mailto:` is genuinely needed, build it correctly:
 </configuration>
 ```
 
-2. Encode them on the server using the BitConverter class
+##### Step 2 - Encode them on the server using the BitConverter class
 
 ```vbnet
 Dim email As String = ConfigurationSettings
@@ -101,7 +103,7 @@ Application("SampleEncodedEmailAddress") = BitConverter
         .Replace("-", "")
 ```
 
-3. Decode on the client with a JavaScript function in the JavaScript
+##### Step 3 - Decode on the client with a JavaScript function in the JavaScript
 
 ```htmlbars
 <a
@@ -112,7 +114,7 @@ Application("SampleEncodedEmailAddress") = BitConverter
 </a>
 ```
 
-**🙂 Figure: OK example - hide the address from spam bots using an encryption technique**
+**🙂 Figure: OK example - hides the email address from spam bots**
 
 ### 2. Contact form (⭐ recommended)
 

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid displaying valid email addresses on your website to preven
 created: 2016-11-16T17:15:32.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-04-17T06:58:19.768Z
+lastUpdated: 2026-04-17T07:23:41.914Z
 lastUpdatedBy: AlexBlum-SSW
 lastUpdatedByEmail: alexblum@ssw.com.au
 isArchived: false
@@ -70,15 +70,35 @@ Form submissions, by contrast, are confirmed actions with full funnel visibility
 
 ## The alternatives
 
-### 1. `mailto:` done correctly
+### 1. `mailto:` done correctly (rare cases)
 
 When `mailto:` is genuinely needed, build it correctly:
 
 * Pre-populate `subject`, `body` and `cc` parameters to reduce friction
-* Use the actual email address as the visible link text, not "click here" or "Contact Us"
 * Add an `aria-label` and a visible cue that the link opens an email client
-* Obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
+* Encrypyt or obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
 * [Track clicks via GTM](https://hallam.agency/blog/mailto-link-analytics-tag-manager/) (preferred) or a `gtag.js` click listener
+
+### 2. Contact form (⭐ recommended)
+
+A contact form keeps users on the page, requires no configured mail client, works identically on every device, and provides [structured data with full analytics](https://support.google.com/analytics/answer/9216061?sjid=1750661119632285480-NC)
+
+* Works on every device and every browser, regardless of email client configuration
+* Keeps the email address off the front end entirely, eliminating harvesting risk
+* Gives users a consistent, guided experience
+* Enables server-side validation, spam filtering (e.g. reCAPTCHA), and structured data collection
+* Can trigger an auto-reply confirmation, improving perceived responsiveness
+
+<imageEmbed alt="An example contact form" size="medium" showBorder={false} figurePrefix="good" figure="improves the user experience across all mediums" src="/uploads/rules/avoid-using-mailto-on-your-website/mailto_good-form.jpg" />
+
+<boxEmbed
+  body={<>
+    **Note:** On a mobile-first platform, if not using a form, a `mailto:` link is acceptable. Mobile email apps handle `mailto:` well, and **over 41%** of email opens are on mobile. Be sure to obfuscate the email address to avoid spam.
+  </>}
+  figurePrefix="none"
+  figure=""
+  style="info"
+/>
 
 ***
 

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid displaying valid email addresses on your website to preven
 created: 2016-11-16T17:15:32.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-04-16T05:20:22.239Z
+lastUpdated: 2026-04-17T06:58:19.768Z
 lastUpdatedBy: AlexBlum-SSW
 lastUpdatedByEmail: alexblum@ssw.com.au
 isArchived: false
@@ -68,55 +68,17 @@ Form submissions, by contrast, are confirmed actions with full funnel visibility
 
 ***
 
-## User contact methods
+## The alternatives
 
-### 1. Contact form (⭐️ recommended)
-
-A contact form keeps users on the page, requires no configured mail client, works identically on every device, and provides [structured data with full analytics](https://www.campaignmonitor.com/blog/email-marketing/should-i-use-a-mailto-or-link-to-a-contact-form/).
-
-* Works on every device and every browser, regardless of email client configuration
-* Keeps the email address off the front end entirely, eliminating harvesting risk
-* Gives users a consistent, guided experience
-* Enables server-side validation, spam filtering (e.g. reCAPTCHA, honeypot fields), and structured data collection
-* Can trigger an auto-reply confirmation, improving perceived responsiveness
-
-<imageEmbed alt="a contact form with email input, message text area, and send button" size="medium" showBorder={true} figurePrefix="good" figure="improves the user experience across all mediums" src="/uploads/rules/avoid-using-mailto-on-your-website/mailto_good-form.jpg" />
-
-### 2. Display email as selectable text with a copy-to-clipboard button (rare cases)
-
-When a form is overkill, show the email as visible text and let users copy it with one click.
-
-<imageEmbed alt="email address displayed as selectable text with a Copy button" size="medium" showBorder={false} figurePrefix="none" figure="Showing the address as visible text generally should be avoided" src="/uploads/rules/avoid-using-mailto-on-your-website/mailto_good-button.jpg" />
-
-```htmlbars
-<span id="email-text">hello@example.com</span>
-<button onclick="navigator.clipboard.writeText('hello@example.com')
-  .then(() => this.textContent = 'Copied!')
-  .catch(() => alert('Copy failed'))">
-  Copy
-</button>
-```
-
-**Code: Address is copyable, no `mailto:` used**
-
-<boxEmbed
-  body={<>
-    **Note:** On mobile, fall back to a `mailto:` link - native email apps handle it well and **over 41%** of email opens are on mobile.
-  </>}
-  figurePrefix="none"
-  figure=""
-  style="info"
-/>
-
-### 3. If `mailto:` must be used (rare cases)
+### 1. `mailto:` done correctly
 
 When `mailto:` is genuinely needed, build it correctly:
 
-* Pre-populate `subject`, `body`, and `cc` parameters to reduce friction
+* Pre-populate `subject`, `body` and `cc` parameters to reduce friction
 * Use the actual email address as the visible link text, not "click here" or "Contact Us"
 * Add an `aria-label` and a visible cue that the link opens an email client
 * Obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
-* [Track clicks via GTM](https://measureu.com/track-mailto-email-links-google-analytics-4/) (preferred) or a `gtag.js` click listener
+* [Track clicks via GTM](https://hallam.agency/blog/mailto-link-analytics-tag-manager/) (preferred) or a `gtag.js` click listener
 
 ***
 
@@ -133,7 +95,7 @@ When `mailto:` is genuinely needed, build it correctly:
 </configuration>
 ```
 
-2. Encode them on the server using the BitConverter class
+1. Encode them on the server using the BitConverter class
 
 ```vbnet
 Dim email As String = ConfigurationSettings
@@ -144,7 +106,7 @@ Application("SampleEncodedEmailAddress") = BitConverter
         .Replace("-", "")
 ```
 
-3. Decode on the client with a JavaScript function in the JavaScript
+1. Decode on the client with a JavaScript function in the JavaScript
 
 ```htmlbars
 <a

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid displaying valid email addresses on your website to preven
 created: 2016-11-16T17:15:32.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-04-17T07:23:41.914Z
+lastUpdated: 2026-04-17T07:35:53.941Z
 lastUpdatedBy: AlexBlum-SSW
 lastUpdatedByEmail: alexblum@ssw.com.au
 isArchived: false
@@ -70,14 +70,49 @@ Form submissions, by contrast, are confirmed actions with full funnel visibility
 
 ## The alternatives
 
-### 1. `mailto:` done correctly (rare cases)
+### `mailto:` done correctly (rare cases)
 
 When `mailto:` is genuinely needed, build it correctly:
 
 * Pre-populate `subject`, `body` and `cc` parameters to reduce friction
 * Add an `aria-label` and a visible cue that the link opens an email client
-* Encrypyt or obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
 * [Track clicks via GTM](https://hallam.agency/blog/mailto-link-analytics-tag-manager/) (preferred) or a `gtag.js` click listener
+* Encrypyt or obfuscate the address using one of many [documented methods](https://spencermortensen.com/articles/email-obfuscation/)
+
+1\. Store email addresses in the web.config file
+
+```xml
+<configuration>
+    <appSettings>
+        <add key="SampleEncodedEmailAddress" value="hello@example.com.au" />
+        ...
+    </appSettings>
+</configuration>
+```
+
+2. Encode them on the server using the BitConverter class
+
+```vbnet
+Dim email As String = ConfigurationSettings
+        .AppSettings("SampleEncodedEmailAddress")
+
+Application("SampleEncodedEmailAddress") = BitConverter
+        .ToString( _ ASCIIEncoding.ASCII.GetBytes(email))
+        .Replace("-", "")
+```
+
+3. Decode on the client with a JavaScript function in the JavaScript
+
+```htmlbars
+<a
+  id="linkContact"
+  href="javascript:sendEmail('44617669644073616D706C652E636F6D2E6175')"
+>
+  Contact Us
+</a>
+```
+
+**🙂 Figure: OK example - hide the address from spam bots using an encryption technique**
 
 ### 2. Contact form (⭐ recommended)
 
@@ -98,50 +133,4 @@ A contact form keeps users on the page, requires no configured mail client, work
   figurePrefix="none"
   figure=""
   style="info"
-/>
-
-***
-
-## 🪦 Encryption technique (legacy)
-
-1. Store email addresses in the web.config file
-
-```xml
-<configuration>
-    <appSettings>
-        <add key="SampleEncodedEmailAddress" value="hello@example.com.au" />
-        ...
-    </appSettings>
-</configuration>
-```
-
-1. Encode them on the server using the BitConverter class
-
-```vbnet
-Dim email As String = ConfigurationSettings
-        .AppSettings("SampleEncodedEmailAddress")
-
-Application("SampleEncodedEmailAddress") = BitConverter
-        .ToString( _ ASCIIEncoding.ASCII.GetBytes(email))
-        .Replace("-", "")
-```
-
-1. Decode on the client with a JavaScript function in the JavaScript
-
-```htmlbars
-<a
-  id="linkContact"
-  href="javascript:sendEmail('44617669644073616D706C652E636F6D2E6175')"
->
-  Contact Us
-</a>
-```
-
-<boxEmbed
-  body={<>
-    **Tip:** We have a program called [SSW CodeAuditor](https://codeauditor.com/) to check for this rule.
-  </>}
-  figurePrefix="none"
-  figure=""
-  style="tips"
 />


### PR DESCRIPTION
## Summary
Updated the rule content for **“Avoid using mailto on your website”** to improve structure, clarify recommendations, and refresh the guidance around when `mailto:` links are appropriate.

## Changes
- Renamed **User contact methods** to **The alternatives**
- Reworked the page structure and reordered the recommended approaches
- Updated the `mailto:` guidance and reframed it as **used in rare cases**
- Refined the implementation advice for `mailto:` links, including:
  - pre-populated parameters
  - accessibility cues
  - click tracking guidance
  - email obfuscation/encryption
- Reformatted the encryption example into clearer step-by-step headings
- Refreshed the **Contact form** recommendation and supporting copy
- Updated image alt text and figure presentation
- Replaced the CodeAuditor tip with a note about mobile-first scenarios where `mailto:` may still be acceptable
- Updated the metadata timestamp

## Why
This improves readability and makes the rule guidance clearer by:
- reinforcing contact forms as the preferred option
- clarifying when `mailto:` may still be appropriate
- making the implementation examples easier to follow

## Files changed
- `public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx`