### PR TITLE
public/uploads/rules/do you-provide-red-errors-next-to-the-field/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/do-you-provide-red-errors-next-to-the-field/rule.mdx
+++ b/public/uploads/rules/do-you-provide-red-errors-next-to-the-field/rule.mdx
@@ -1,35 +1,27 @@
 ---
-archivedreason: null
-authors:
-- title: Adam Cogan
-  url: https://www.ssw.com.au/people/adam-cogan
-created: 2014-12-22 11:51:26+00:00
-createdBy: Tiago Araujo
-createdByEmail: TiagoAraujo@ssw.com.au
-guid: ed4a7e24-3a93-4313-bb39-cd5b5d665197
-isArchived: false
-lastUpdated: 2014-12-22 11:51:26+00:00
-lastUpdatedBy: Tiago Araujo
-lastUpdatedByEmail: TiagoAraujo@ssw.com.au
-redirects: []
-seoDescription: Provide red error messages next to each field for a more intuitive
-  and user-friendly experience.
+type: rule
 title: Do you provide red errors next to the field?
+uri: do-you-provide-red-errors-next-to-the-field
 categories:
   - category: categories/design/rules-to-better-interfaces-forms.mdx
-type: rule
-uri: do-you-provide-red-errors-next-to-the-field
+authors:
+  - title: Adam Cogan
+    url: 'https://www.ssw.com.au/people/adam-cogan'
+redirects: []
+guid: ed4a7e24-3a93-4313-bb39-cd5b5d665197
+seoDescription: Provide red error messages next to each field for a more intuitive and user-friendly experience.
+created: 2014-12-22T11:51:26.000Z
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-04-17T22:38:06.107Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
+isArchived: true
+archivedreason: 'Replaced by https://www.ssw.com.au/rules/forms-do-you-indicate-which-fields-are-required-and-validate-them'
 ---
 
 Too often error messages are a summary at the top or the bottom of the page. Instead please provide an error message per validation error, next to the field (and in red!).
 
 <endIntro />
 
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="good"
-  figure="Provide red errors next to the field"
-  src="/uploads/rules/do-you-provide-red-errors-next-to-the-field/red-error.jpg"
-/>
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="good" figure="Provide red errors next to the field" src="/uploads/rules/do-you-provide-red-errors-next-to-the-field/red-error.jpg" />


### PR DESCRIPTION
archived 

Note: The other rule it links to is being updated on https://github.com/SSWConsulting/SSW.Rules.Content/pull/12507