### PR TITLE
docs(rules): add unreachable-person guidance to email rule

### DIFF
--- a/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
@@ -34,7 +34,14 @@ As all these rules indicate, email can either be a blessing or a curse. One of t
 1. When you want to discuss an issue and **make a decision**
 2. When you are **dealing with a 'delicate' problem**
 
-![Figures: a Meta Group survey found that 81% of respondents preferred the phone above email to build relationships, but 80% preferred email generally](/uploads/rules/do-you-know-when-and-when-not-to-use-email/MetaGroupPhoneOverEmail.gif)
+<imageEmbed
+  alt="Image"
+  size="medium"
+  showBorder={true}
+  figurePrefix="none"
+  figure="A Meta Group survey found that 81% of respondents preferred the phone above email to build relationships, but 80% preferred email generally"
+  src="/uploads/rules/do-you-know-when-and-when-not-to-use-email/MetaGroupPhoneOverEmail.gif"
+/>
 
 ## Making a decision
 
@@ -67,13 +74,13 @@ Sometimes the person you need to speak with is unavailable, and waiting for a ca
     We tried calling you but couldn't get hold of you, so please find the draft below for your review...
   </>}
   figurePrefix="good"
-  figure="Good example - Acknowledge the attempted call at the top of the email, then send the draft"
+  figure="Acknowledge the attempted call at the top of the email, then send the draft"
 />
 
 <imageEmbed
   alt="Image"
-  size="large"
-  showBorder={false}
+  size="medium"
+  showBorder={true}
   figurePrefix="none"
   figure="Are you in the right frame of mind?"
   src="/uploads/rules/do-you-know-when-and-when-not-to-use-email/pic38-KeepDrasticThingsForImportantThings.gif"

--- a/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
@@ -5,6 +5,8 @@ authors:
   url: https://www.ssw.com.au/people/adam-cogan
 - title: Cameron Shaw
   url: https://www.ssw.com.au/people/cameron-shaw
+- title: Daniel Mackay
+  url: https://www.ssw.com.au/people/daniel-mackay
 created: 2009-04-15 02:27:06+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
@@ -54,6 +56,19 @@ Similarly, never bring up a tricky topic with someone by email. It's very easy t
 - Send the email
 
 This way you can review issues together, and, importantly, decisions are confirmed in writing.
+
+### When You Can't Reach the Other Person
+
+Sometimes the person you need to speak with is unavailable, and waiting for a call back would leave you blocked. In this case, don't let progress stall. Note at the top of the draft email that a call was attempted, then send it anyway. This keeps things moving while still showing that a conversation was the preferred first step.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    We tried calling you but couldn't get hold of you, so please find the draft below for your review...
+  </>}
+  figurePrefix="good"
+  figure="Good example - Acknowledge the attempted call at the top of the email, then send the draft"
+/>
 
 
 <imageEmbed

--- a/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-and-when-not-to-use-email/rule.mdx
@@ -36,7 +36,7 @@ As all these rules indicate, email can either be a blessing or a curse. One of t
 
 ![Figures: a Meta Group survey found that 81% of respondents preferred the phone above email to build relationships, but 80% preferred email generally](/uploads/rules/do-you-know-when-and-when-not-to-use-email/MetaGroupPhoneOverEmail.gif)
 
-### Making a Decision
+## Making a decision
 
 If you want to make a decision, asking for opinions via email is the best way to ensure one isn't made. Email discussions get off-topic, lose track, and generally go nowhere, with every email ending with "Yes, but what about..." or "Just my 2c". This leads to a lot of time-wasting.
 
@@ -44,7 +44,7 @@ You should either pick up the phone or have a meeting to discuss the issue, make
 
 The issue becomes even more important internally when you email someone in the next office and ask them a question. This is a great way of creating unnecessary emails. Instead, stand up, walk to their desk and ask them the question. Otherwise, have a folder called "AskDavid" or similar, file all your emails that you need to ask him about in there, and when he next comes to visit you, go through them and get an answer.
 
-### Dealing with Delicate Situations
+## Dealing with delicate situations
 
 Similarly, never bring up a tricky topic with someone by email. It's very easy to misunderstand or misrepresent via email. We always pick up the phone and speak to the person first when discussing important, sensitive, complex issues, or issues where some serious convincing is required. This is the standard we follow:
 
@@ -57,7 +57,7 @@ Similarly, never bring up a tricky topic with someone by email. It's very easy t
 
 This way you can review issues together, and, importantly, decisions are confirmed in writing.
 
-### When You Can't Reach the Other Person
+## When you can't reach the other person
 
 Sometimes the person you need to speak with is unavailable, and waiting for a call back would leave you blocked. In this case, don't let progress stall. Note at the top of the draft email that a call was attempted, then send it anyway. This keeps things moving while still showing that a conversation was the preferred first step.
 
@@ -69,7 +69,6 @@ Sometimes the person you need to speak with is unavailable, and waiting for a ca
   figurePrefix="good"
   figure="Good example - Acknowledge the attempted call at the top of the email, then send the draft"
 />
-
 
 <imageEmbed
   alt="Image"


### PR DESCRIPTION
## Summary

- Adds "When You Can't Reach the Other Person" section to the "Do you know when to NOT send an email?" rule
- Adds Daniel Mackay to the rule's authors list

## Changes

The existing rule defines a draft → call → adjust → send workflow for delicate situations, but doesn't address what happens when the call can't be made. This adds a short escape-hatch section so readers know not to stay blocked indefinitely, with a `boxEmbed` good-example snippet showing how to note the attempted call at the top of the draft before sending.

## Test Plan

- [ ] Frontmatter validator passes for the updated file
- [ ] On the staging render, new section appears between "Dealing with Delicate Situations" and the closing image
- [ ] `boxEmbed` renders with greybox style and "Good example" prefix
- [ ] Daniel Mackay shows in the authors list on the rendered page