### PR TITLE
M ◾ Add AI database access and Handy dictation rules

### DIFF
--- a/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -22,6 +22,7 @@ index:
   - rule: public/uploads/rules/run-llms-locally/rule.mdx
   - rule: public/uploads/rules/automatic-code-reviews-github/rule.mdx
   - rule: public/uploads/rules/mcp-servers-for-context/rule.mdx
+  - rule: public/uploads/rules/ai-database-access/rule.mdx
   - rule: public/uploads/rules/utilize-back-pressure-for-agents/rule.mdx
   - rule: public/uploads/rules/build-custom-agents/rule.mdx
   - rule: public/uploads/rules/ai-agents-with-skills/rule.mdx

--- a/categories/artificial-intelligence/rules-to-better-ai.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai.mdx
@@ -37,6 +37,7 @@ index:
   - rule: public/uploads/rules/chatgpt-security-risks/rule.mdx
   - rule: public/uploads/rules/avoid-leading-prompt-questions/rule.mdx
   - rule: public/uploads/rules/choose-language-mcp/rule.mdx
+  - rule: public/uploads/rules/handy-dictation-tool/rule.mdx
 created: 2025-02-21T01:14:33.000Z
 createdBy: 'Marcus Irmscher [SSW]'
 createdByEmail: 129343825+MarcusIrmscherSSW@users.noreply.github.com

--- a/categories/communication/rules-to-better-email.mdx
+++ b/categories/communication/rules-to-better-email.mdx
@@ -81,6 +81,7 @@ index:
 - rule: public/uploads/rules/avoid-sarcasm-misunderstanding/rule.mdx
 - rule: public/uploads/rules/autocorrect-in-outlook/rule.mdx
 - rule: public/uploads/rules/dictate-emails/rule.mdx
+- rule: public/uploads/rules/handy-dictation-tool/rule.mdx
 - rule: public/uploads/rules/readable-screenshots/rule.mdx
 - rule: public/uploads/rules/screenshots-avoid-walls-of-text/rule.mdx
 - rule: public/uploads/rules/screenshots-add-branding/rule.mdx

--- a/public/uploads/rules/ai-database-access/rule.mdx
+++ b/public/uploads/rules/ai-database-access/rule.mdx
@@ -80,7 +80,7 @@ See [Do you give your AI agents context with MCP servers and skills?](/mcp-serve
 
 ### 2. CLI + A skill file (project-specific, high context)
 
-The AI development tool will probably attempt to do this anyway, a skill file guides it with project-specific context and saves it getting caught on the gotchas.
+The AI development tool will probably attempt to do this anyway. A skill file guides it with project-specific context and saves it getting caught on the gotchas.
 
 For a real project with multiple databases, Aspire, containerized SQL, or non-standard conventions, a skill file usually beats a generic MCP server. A skill teaches the agent **how to connect, which database owns which module, and which queries to start with** — context a vanilla MCP server doesn't know.
 

--- a/public/uploads/rules/ai-database-access/rule.mdx
+++ b/public/uploads/rules/ai-database-access/rule.mdx
@@ -62,7 +62,7 @@ An AI agent investigating a bug without DB access is like someone debugging over
 
 ## Safety first
 
-Obviously, dont give the AI access to a production database.
+Obviously, don't give the AI access to a production database.
 
 ## Two ways to wire it up
 

--- a/public/uploads/rules/ai-database-access/rule.mdx
+++ b/public/uploads/rules/ai-database-access/rule.mdx
@@ -1,0 +1,151 @@
+---
+type: rule
+title: Do you give your AI agents access to your database?
+uri: ai-database-access
+guid: 4b7bceda-3220-4dc8-a6c4-dbfded15c790
+seoDescription: Giving AI coding assistants safe access to your local database lets them investigate bugs, verify data, and write accurate queries — instead of guessing at schemas and asking you to paste results.
+created: 2026-04-23T00:00:00.000Z
+authors:
+  - title: Brady Stroud
+    url: https://www.ssw.com.au/people/brady-stroud
+related:
+  - rule: public/uploads/rules/mcp-servers-for-context/rule.mdx
+  - rule: public/uploads/rules/ai-agents-with-skills/rule.mdx
+  - rule: public/uploads/rules/guardrails-for-vibe-coding/rule.mdx
+  - rule: public/uploads/rules/use-mcp-to-standardize-llm-connections/rule.mdx
+categories:
+  - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+---
+
+When an AI agent is helping you debug a feature, the most valuable question is usually *"what does the data actually look like?"* — and the answer lives in your database. Without access to it, the agent has to guess at schema, hallucinate column names, or keep asking you to paste in query results.
+
+Give your AI agent safe access to your database and the debugging experience transforms. Instead of guessing, it runs a discovery query, checks a row count, inspects a specific record, and forms a real hypothesis — the same way a senior developer would.
+
+<endIntro />
+
+## Why it matters
+
+An AI agent investigating a bug without DB access is like someone debugging over the phone — they can describe what they *think* is happening, but they can't look. With direct DB access, the agent can:
+
+* **Confirm the schema** - use real table and column names instead of guessing
+* **Verify data state** - "is the row actually missing, or is my filter wrong?"
+* **Write accurate queries** - generated SQL matches your real schema, not a hallucinated one
+* **Find root causes faster** - spot null columns, orphaned rows, wrong foreign keys
+* **Generate realistic test data** - modelled on records that actually exist
+
+<boxEmbed
+  body={<>
+    **User:** The orders page is blank for customer ALFKI. Can you check what's going on?
+
+    **Agent:** I can't see your database, but possibilities are:
+    1. The `CustomerId` is wrong
+    2. The Order rows are soft-deleted
+    3. Permissions are blocking the read
+
+    Can you run `SELECT * FROM Orders WHERE CustomerId = 'ALFKI'` and paste the result?
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - The agent can't investigate on its own; you ferry data back and forth"
+/>
+
+<boxEmbed
+  body={<>
+    **User:** The orders page is blank for customer ALFKI. Can you check what's going on?
+
+    **Agent:** *(queries `Sales.Orders` directly)*
+
+    Found it — 6 orders exist for ALFKI but all have `IsDeleted = 1`. The page filter correctly excludes soft-deleted rows, but the archive view should include them. Investigating `OrdersController` now.
+  </>}
+  figurePrefix="good"
+  figure="Good example - The agent queries the DB directly, diagnoses, and moves to the fix"
+/>
+
+## Safety first
+
+Obviously, dont give the AI access to a production database.
+
+## Two ways to wire it up
+
+### 1. MCP server (quick, vendor-provided)
+
+A Model Context Protocol server exposes a curated set of DB tools (`query`, `list-tables`, `describe-table`) that the agent can call directly. Good for standard databases where you want minimal setup.
+
+Examples:
+
+* [Microsoft MSSQL MCP](https://github.com/microsoft/mssql-mcp)
+* [Postgres MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)
+* [SQLite MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)
+
+See [Do you give your AI agents context with MCP servers and skills?](/mcp-servers-for-context).
+
+### 2. CLI + A skill file (project-specific, high context)
+
+The AI development tool will probably attempt to do this anyway, a skill file guides it with project-specific context and saves it getting caught on the gotchas.
+
+For a real project with multiple databases, Aspire, containerized SQL, or non-standard conventions, a skill file usually beats a generic MCP server. A skill teaches the agent **how to connect, which database owns which module, and which queries to start with** — context a vanilla MCP server doesn't know.
+
+<boxEmbed
+  body={<>
+    Example skill for a multi-database Northwind project (`.claude/skills/northwind-db-query/SKILL.md`):
+
+    ```markdown
+    ---
+    name: northwind-db-query
+    description: Connect to the local Northwind SQL Server, identify the correct
+      database and schema for a module, and run ad hoc SQL queries safely.
+    ---
+
+    ## Northwind Local Database Layout
+    - SQL Server runs in Docker on localhost:1433
+    - Main databases: Sales, Customers, Inventory, Identity
+    - Orders.*     → Sales
+    - Invoicing.*  → Sales
+    - Customers.*  → Customers
+    - Products.*   → Inventory
+
+    ## Safety Rules
+    - Default to read-only queries
+    - Do not modify data unless the user explicitly asks
+    - Never run destructive SQL on shared or production environments
+
+    ## Discovery queries
+    List databases → list tables → inspect columns → row counts
+
+    ## Known Pitfalls
+    - Host sqlcmd breaks on `!` in passwords — pipe queries instead of -Q
+    - SmartEnum columns store GUIDs, not ints — check *Enum.cs files
+    - Schemas match module names (Orders.Order, not dbo.Orders)
+    ```
+  </>}
+  figurePrefix="good"
+  figure="Good example - A skill teaches the agent your DB layout, connection details, safety rules, and starter queries"
+  style="greybox"
+/>
+
+A good DB skill should cover:
+
+* **How to connect** - host, port, container name, whether to use `docker exec` or host `sqlcmd`
+* **Where the data lives** - which database owns which module or schema
+* **Known pitfalls** - shell escaping, enum encoding, schema naming conventions
+* **Safety rules** - read-only default, no prod, no destructive ops
+
+See [Do you use skills to standardize your AI workflows?](/ai-agents-with-skills) for more on writing skills.
+
+## When to use each
+
+* **Simple single-database project** → MCP server
+* **Local Docker / Aspire environment with many DBs** → skill file
+* **Team-wide consistency needed** → commit the skill to the repo
+* **Personal helpers across projects** → personal MCP server or `~/.claude/skills/`
+* **Investigating production (rare!)** → read-only MCP with audited connection string + explicit approval
+
+Nothing stops you from combining both — an MCP server for the raw connection plus a skill that layers project-specific knowledge on top.
+
+<boxEmbed
+  body={<>
+    **Tip:** Once the agent has DB access, ask it to start every investigation with a discovery query — row counts and a sample row — before forming any hypothesis. It prevents confident-sounding answers based on a hallucinated schema.
+  </>}
+  figurePrefix="none"
+  figure=""
+  style="tips"
+/>

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -1,0 +1,61 @@
+---
+type: rule
+title: Do you use Handy for hands-free dictation?
+uri: handy-dictation-tool
+seoDescription: Handy is a free, open-source, cross-platform dictation tool that runs Whisper locally for private, offline speech-to-text in any text field.
+guid: 37041b24-e07b-4422-a259-7f4eb865a38b
+created: 2026-04-23T00:00:00.000Z
+authors:
+  - title: Brady Stroud
+    url: https://www.ssw.com.au/people/brady-stroud
+related:
+  - rule: public/uploads/rules/dictate-emails/rule.mdx
+  - rule: public/uploads/rules/best-ai-tools/rule.mdx
+categories:
+  - category: categories/communication/rules-to-better-email.mdx
+  - category: categories/artificial-intelligence/rules-to-better-ai.mdx
+isArchived: false
+---
+
+Typing is slow, hard on your wrists, and breaks your flow - especially when working with AI. A good prompt to ChatGPT, Claude, or Cursor is often a paragraph of detailed context, and typing that out is painful. Built-in OS dictation helps, but it's usually cloud-based, locked to one language, or only works inside specific apps.
+
+[Handy](https://handy.computer/) is a free, open-source dictation tool that solves all of this - press a shortcut, speak, and your words are pasted into whatever text field you're in.
+
+<endIntro />
+
+### Why Handy?
+
+* ✅ **Free and open source** (MIT licensed) - see the code on [GitHub](https://github.com/cjpais/Handy)
+* ✅ **Runs 100% locally** - your voice never leaves your computer
+* ✅ **Cross-platform** - works on macOS (Intel + Apple Silicon), Windows, and Linux
+* ✅ **Uses Whisper and Parakeet models** - industry-leading accuracy with automatic language detection
+* ✅ **Works anywhere** - any text field, any app (email, Slack, Teams, IDEs, browsers)
+* ✅ **Push-to-talk or toggle mode** with a customizable keyboard shortcut
+
+### Perfect for AI prompts
+
+Handy shines when working with AI tools. The quality of an answer from ChatGPT, Claude, Copilot, or Cursor is directly tied to the quality of your prompt - and good prompts are **long**. Typing out a paragraph of context every time you ask for help is tedious, so most people cut corners and get worse results.
+
+Dictating is 3-5x faster than typing, which means:
+
+* You give the AI much richer context in the same amount of time
+* You're more likely to include the "why", constraints, and examples
+* You stay in flow instead of switching between thinking and typing
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** Try dictating your next Claude or ChatGPT prompt - aim for a full paragraph rather than a one-liner. The difference in output quality is dramatic.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+### Other great uses
+
+* Drafting long emails or docs without RSI
+* Dictating commit messages and PR descriptions
+* Chat replies in Slack or Teams
+* Accessibility - hands-free text input
+
+See also: [Do you use Dictate for emails?](/dictate-emails) for the Microsoft 365 built-in equivalent.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Conversation with Brady — brainstormed 20 ideas for new AI-focused rules, then wrote up the top pick (giving AI agents safe DB access for better bug investigation) plus a separate rule on Handy for hands-free dictation.

> 2. What was changed?

Two new rules + category index entries:

- **`ai-database-access`** — *Do you give your AI agents access to your database?* Covers why DB access transforms debugging (no more guessing at schema), safety rules (local/dev only, read-only by default), two wiring options (MCP server vs project skill file), and when to use each. Added to `rules-to-better-ai-assisted-development`.
- **`handy-dictation-tool`** — *Do you use Handy for hands-free dictation?* Free, local-only, open-source dictation tool ideal for writing long AI prompts. Added to `rules-to-better-ai` and `rules-to-better-email`.

Good/bad examples use a generic Northwind-style project — no client-identifying data.

> 3. I paired or mob programmed with:

🤖 Paired with Claude Code