### PR TITLE
Enhances category sync workflow for fork PRs

### DIFF
--- a/.github/workflows/check-category-sync.yml
+++ b/.github/workflows/check-category-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
 
     steps:
       # Step 1: Check out the source code of the pull request.
@@ -55,29 +55,33 @@ jobs:
             git push
           fi
 
-      # Step 6: Comment on fork PR when auto-fix cannot be pushed
-      - name: Comment on fork PR if category sync is needed
+      # Step 6: For fork PRs, save PR number + affected files as an artifact so the
+      # companion workflow_run workflow can post a comment with a write token safely.
+      - name: Upload category sync artifact for fork PR
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: actions/github-script@v7
+        run: |
+          diff=$(git diff --name-only categories/)
+          if [ -z "$diff" ]; then
+            echo "No category sync changes needed."
+            exit 0
+          fi
+          mkdir -p /tmp/category-sync-artifact
+          echo "${{ github.event.pull_request.number }}" > /tmp/category-sync-artifact/pr-number.txt
+          echo "$diff" > /tmp/category-sync-artifact/files.txt
+
+      - name: Upload artifact
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { execSync } = require('child_process');
+          name: category-sync-needed
+          path: /tmp/category-sync-artifact/
+          retention-days: 1
+          if-no-files-found: ignore
 
-            const diff = execSync('git diff --name-only categories/').toString().trim();
-            if (!diff) {
-              console.log('No category sync changes needed.');
-              return;
-            }
-
-            const files = diff.split('\n').filter(Boolean);
-            const fileList = files.map(f => `- \`${f}\``).join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `### ⚠️ Category Index Sync Required\n\nThis PR adds a rule with a \`categories\` field, but the corresponding category file \`index\` list was not updated.\n\nBecause this PR is from a fork, the bot cannot push the fix automatically. Please update the following file(s) by adding the new rule to the \`index\` list in the frontmatter:\n\n${fileList}`
-            });
-
-            core.setFailed('Category index sync required — see PR comment for which files to update.');
+      - name: Fail if category sync needed on fork PR
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          if [ -f /tmp/category-sync-artifact/files.txt ]; then
+            echo "Category sync required. See the PR comment posted by the companion workflow."
+            exit 1
+          fi

--- a/.github/workflows/check-category-sync.yml
+++ b/.github/workflows/check-category-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       # Step 1: Check out the source code of the pull request.
@@ -54,3 +54,30 @@ jobs:
             git commit -m "XS ◾ Auto-update category index list to include new rule"
             git push
           fi
+
+      # Step 6: Comment on fork PR when auto-fix cannot be pushed
+      - name: Comment on fork PR if category sync is needed
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { execSync } = require('child_process');
+
+            const diff = execSync('git diff --name-only categories/').toString().trim();
+            if (!diff) {
+              console.log('No category sync changes needed.');
+              return;
+            }
+
+            const files = diff.split('\n').filter(Boolean);
+            const fileList = files.map(f => `- \`${f}\``).join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### ⚠️ Category Index Sync Required\n\nThis PR adds a rule with a \`categories\` field, but the corresponding category file \`index\` list was not updated.\n\nBecause this PR is from a fork, the bot cannot push the fix automatically. Please update the following file(s) by adding the new rule to the \`index\` list in the frontmatter:\n\n${fileList}`
+            });
+
+            core.setFailed('Category index sync required — see PR comment for which files to update.');

--- a/.github/workflows/comment-fork-pr-category-sync.yml
+++ b/.github/workflows/comment-fork-pr-category-sync.yml
@@ -1,0 +1,54 @@
+name: Comment on Fork PR - Category Sync
+
+on:
+  workflow_run:
+    workflows: ["Check-Category-Sync"]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Only run when triggered by a fork PR and the check workflow failed
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Download category sync artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: category-sync-needed
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/category-sync-artifact
+        continue-on-error: true
+
+      - name: Post comment on PR
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const prNumber = parseInt(fs.readFileSync('/tmp/category-sync-artifact/pr-number.txt', 'utf8').trim());
+            const files = fs.readFileSync('/tmp/category-sync-artifact/files.txt', 'utf8').trim().split('\n').filter(Boolean);
+            const fileList = files.map(f => `- \`${f}\``).join('\n');
+
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `### ⚠️ Category Index Sync Required\n\nOne or more category index files are out of sync with the rules in this PR.\n\nBecause this PR is from a fork, the bot cannot push the fix automatically. Please update the following file(s) to bring the \`index\` list in the frontmatter in sync:\n\n${fileList}`
+              });
+            } catch (err) {
+              core.error(`Failed to post PR comment: ${err.message}`);
+              core.error(`Category index out of sync. The following file(s) need updating:\n${fileList}`);
+              core.setFailed('Category index sync required — see log above for which files to update.');
+            }


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Sometimes the Category Sync workflow cannot post comments because the PR is opened from a fork. 

> 2. What was changed?

✏️ Adds a step to comment on fork PRs when category sync changes are needed but cannot be pushed automatically.  

Comment example:
<img alt="image" src="https://github.com/user-attachments/assets/08977699-2e41-49a2-b6bf-0693e9230dad" />


> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->
No
<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
