### PR TITLE
Reorder project delivery categories so important are at the top

### DIFF
--- a/categories/project-delivery/index.mdx
+++ b/categories/project-delivery/index.mdx
@@ -4,27 +4,27 @@ type: top-category
 title: Project Delivery
 uri: project-delivery
 index:
-- category: categories/project-delivery/rules-to-better-scrum.mdx
-- category: categories/project-delivery/rules-to-better-product-owners.mdx
-- category: categories/project-delivery/rules-to-better-scrum-using-github.mdx
-- category: categories/project-delivery/rules-to-better-scrum-using-azure-devops.mdx
-- category: categories/project-delivery/rules-to-better-scaled-agile-framework.mdx
-- category: categories/project-delivery/rules-to-better-jira.mdx
-- category: categories/project-delivery/rules-to-better-github.mdx
-- category: categories/project-delivery/rules-to-better-pull-requests.mdx
-- category: categories/project-delivery/rules-to-better-version-control-with-tfs-aka-source-control.mdx
-- category: categories/project-delivery/rules-to-better-version-control-with-git.mdx
-- category: categories/project-delivery/rules-to-better-tfs-migration-to-the-cloud.mdx
-- category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
-- category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
-- category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
-- category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
-- category: categories/project-delivery/rules-to-better-octopus-deploy.mdx
-- category: categories/project-delivery/rules-to-better-branching-and-builds.mdx
-- category: categories/project-delivery/rules-to-better-tfs-administration.mdx
-- category: categories/project-delivery/rules-to-better-tfs-customization.mdx
-- category: categories/project-delivery/rules-to-better-devops.mdx
-- category: categories/project-delivery/rules-to-better-devops-using-github.mdx
-- category: categories/project-delivery/rules-to-better-devops-using-azure-devops.mdx
-- category: categories/project-delivery/rules-to-better-azure-marketplace.mdx
+category: categories/project-delivery/rules-to-better-scrum.mdx
+category: categories/project-delivery/rules-to-better-product-owners.mdx
+category: categories/project-delivery/rules-to-better-scaled-agile-framework.mdx
+category: categories/project-delivery/rules-to-better-devops.mdx
+category: categories/project-delivery/rules-to-better-version-control-with-git.mdx
+category: categories/project-delivery/rules-to-better-branching-and-builds.mdx
+category: categories/project-delivery/rules-to-better-pull-requests.mdx
+category: categories/project-delivery/rules-to-better-github.mdx
+category: categories/project-delivery/rules-to-better-scrum-using-github.mdx
+category: categories/project-delivery/rules-to-better-scrum-using-azure-devops.mdx
+category: categories/project-delivery/rules-to-better-devops-using-github.mdx
+category: categories/project-delivery/rules-to-better-devops-using-azure-devops.mdx
+category: categories/project-delivery/rules-to-better-jira.mdx
+category: categories/project-delivery/rules-to-better-octopus-deploy.mdx
+category: categories/project-delivery/rules-to-better-azure-marketplace.mdx
+category: categories/project-delivery/rules-to-better-version-control-with-tfs-aka-source-control.mdx
+category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
+category: categories/project-delivery/rules-to-better-tfs-administration.mdx
+category: categories/project-delivery/rules-to-better-tfs-customization.mdx
+category: categories/project-delivery/rules-to-better-tfs-migration-to-the-cloud.mdx
+category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
+category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
+category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 ---

--- a/categories/project-delivery/index.mdx
+++ b/categories/project-delivery/index.mdx
@@ -4,27 +4,27 @@ type: top-category
 title: Project Delivery
 uri: project-delivery
 index:
-category: categories/project-delivery/rules-to-better-scrum.mdx
-category: categories/project-delivery/rules-to-better-product-owners.mdx
-category: categories/project-delivery/rules-to-better-scaled-agile-framework.mdx
-category: categories/project-delivery/rules-to-better-devops.mdx
-category: categories/project-delivery/rules-to-better-version-control-with-git.mdx
-category: categories/project-delivery/rules-to-better-branching-and-builds.mdx
-category: categories/project-delivery/rules-to-better-pull-requests.mdx
-category: categories/project-delivery/rules-to-better-github.mdx
-category: categories/project-delivery/rules-to-better-scrum-using-github.mdx
-category: categories/project-delivery/rules-to-better-scrum-using-azure-devops.mdx
-category: categories/project-delivery/rules-to-better-devops-using-github.mdx
-category: categories/project-delivery/rules-to-better-devops-using-azure-devops.mdx
-category: categories/project-delivery/rules-to-better-jira.mdx
-category: categories/project-delivery/rules-to-better-octopus-deploy.mdx
-category: categories/project-delivery/rules-to-better-azure-marketplace.mdx
-category: categories/project-delivery/rules-to-better-version-control-with-tfs-aka-source-control.mdx
-category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
-category: categories/project-delivery/rules-to-better-tfs-administration.mdx
-category: categories/project-delivery/rules-to-better-tfs-customization.mdx
-category: categories/project-delivery/rules-to-better-tfs-migration-to-the-cloud.mdx
-category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
-category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
-category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
+- category: categories/project-delivery/rules-to-better-scrum.mdx
+- category: categories/project-delivery/rules-to-better-product-owners.mdx
+- category: categories/project-delivery/rules-to-better-scaled-agile-framework.mdx
+- category: categories/project-delivery/rules-to-better-devops.mdx
+- category: categories/project-delivery/rules-to-better-version-control-with-git.mdx
+- category: categories/project-delivery/rules-to-better-branching-and-builds.mdx
+- category: categories/project-delivery/rules-to-better-pull-requests.mdx
+- category: categories/project-delivery/rules-to-better-github.mdx
+- category: categories/project-delivery/rules-to-better-scrum-using-github.mdx
+- category: categories/project-delivery/rules-to-better-scrum-using-azure-devops.mdx
+- category: categories/project-delivery/rules-to-better-devops-using-github.mdx
+- category: categories/project-delivery/rules-to-better-devops-using-azure-devops.mdx
+- category: categories/project-delivery/rules-to-better-jira.mdx
+- category: categories/project-delivery/rules-to-better-octopus-deploy.mdx
+- category: categories/project-delivery/rules-to-better-azure-marketplace.mdx
+- category: categories/project-delivery/rules-to-better-version-control-with-tfs-aka-source-control.mdx
+- category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
+- category: categories/project-delivery/rules-to-better-tfs-administration.mdx
+- category: categories/project-delivery/rules-to-better-tfs-customization.mdx
+- category: categories/project-delivery/rules-to-better-tfs-migration-to-the-cloud.mdx
+- category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
+- category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
+- category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 ---


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Found myself... seeing TFS stuff at the top 

> 2. What was changed?

Reordered
