### PR TITLE
Agents md scoped rules and copilot symlink

### DIFF
--- a/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -14,6 +14,7 @@ index:
   - rule: public/uploads/rules/github-copilot-chat-modes/rule.mdx
   - rule: public/uploads/rules/best-ai-powered-ide/rule.mdx
   - rule: public/uploads/rules/write-agents-md/rule.mdx
+  - rule: public/uploads/rules/scoped-rules-for-ai-agents/rule.mdx
   - rule: public/uploads/rules/keep-task-summaries-from-ai-assisted-development/rule.mdx
   - rule: public/uploads/rules/attribute-ai-assisted-commits-with-co-authors/rule.mdx
   - rule: public/uploads/rules/ai-assistants-work-in-repository-directory/rule.mdx

--- a/public/uploads/rules/scoped-rules-for-ai-agents/rule.mdx
+++ b/public/uploads/rules/scoped-rules-for-ai-agents/rule.mdx
@@ -1,0 +1,118 @@
+---
+type: rule
+title: Do you split your AGENTS.md into scoped rule files?
+uri: scoped-rules-for-ai-agents
+guid: 1b79a72b-2245-445b-8059-6c4324c03d28
+seoDescription: Learn how to split AGENTS.md into scoped rule files that AI agents only load when working in matching paths — avoiding context bloat in large projects.
+created: 2026-04-30T00:00:00.000Z
+authors:
+  - title: Brady Stroud
+    url: 'https://www.ssw.com.au/people/brady-stroud'
+  - title: Daniel Mackay
+    url: 'https://www.ssw.com.au/people/daniel-mackay'
+  - title: Gordon Beeming
+    url: 'https://www.ssw.com.au/people/gordon-beeming'
+related:
+  - rule: public/uploads/rules/write-agents-md/rule.mdx
+  - rule: public/uploads/rules/symlink-agents-to-claude/rule.mdx
+categories:
+  - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+---
+
+A single, monolithic `AGENTS.md` doesn't scale. As your project grows, agents waste context window on rules that aren't relevant to the current task. Scoped rule files solve this — they're auto-loaded only when the agent works in matching paths.
+
+<endIntro />
+
+## The problem with one big AGENTS.md
+
+If your `AGENTS.md` covers backend, frontend, database, testing, and security, every agent invocation pulls in all of it — even when the task only touches one area. Large rule files get truncated, slow context loading, and bury the rules that matter for the current task.
+
+[Multiple AGENTS.md](/write-agents-md) help by scoping rules per directory. But sometimes rules apply to file *patterns* rather than directories — e.g. "all `.razor` files" or "all `*Effects.cs` files across the codebase".
+
+## The solution: path-scoped rule files
+
+Claude Code supports rule files in `.claude/rules/` with a `paths:` frontmatter that tells the agent when to load them.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    ```yaml
+    ---
+    paths:
+      - "src/Northwind.Web/**/*"
+      - "**/*.razor"
+    ---
+
+    # UI — Blazor
+
+    ## Components
+
+    - One component per feature folder
+    - Use `@bind-Value` for form inputs
+    - Validation via `EditForm` + `DataAnnotationsValidator`
+    ...
+    ```
+  </>}
+  figurePrefix="good"
+  figure="Path-scoped rule file — only loaded when the agent touches matching files"
+/>
+
+The `AGENTS.md` at the root then acts as a lightweight index pointing to the scoped files:
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    ```markdown
+    ## Rules
+
+    Detailed conventions are in `.claude/rules/` (auto-loaded by Claude Code):
+
+    | File | Covers |
+    |---|---|
+    | `architecture.md` | Clean Architecture layers, MediatR |
+    | `coding-standards.md` | naming, async, enums, records |
+    | `database.md` | EF Core migrations |
+    | `testing.md` | xUnit, FluentAssertions |
+    | `ui-blazor.md` | components, validation, accessibility |
+    ```
+  </>}
+  figurePrefix="good"
+  figure="Root AGENTS.md as an index pointing to scoped rule files"
+/>
+
+## Example: a Northwind app
+
+Imagine a Northwind sample app structured with Clean Architecture. Instead of cramming every convention into one giant `AGENTS.md`, split the detail across `.claude/rules/` by concern. Each file declares the paths it applies to, so the agent only loads what's relevant to the file currently being edited.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    ```
+    ├── 🤖 AGENTS.md                       ← Index + project overview
+    └── .claude/
+        └── rules/
+            ├── architecture.md            ← paths: src/Northwind.Application/**, src/Northwind.Domain/**
+            ├── coding-standards.md        ← paths: **/*.cs
+            ├── database.md                ← paths: **/Migrations/**, **/*DbContext.cs
+            ├── ddd-patterns.md            ← paths: src/Northwind.Domain/**
+            ├── security.md                ← paths: **/*Authorization*.cs
+            ├── testing.md                 ← paths: **/*.Tests/**
+            └── ui-blazor.md               ← paths: **/*.razor
+    ```
+  </>}
+  figurePrefix="good"
+  figure="Scoped rule files keep each concern targeted, the agent's context lean, and the root AGENTS.md skimmable"
+/>
+
+## When to use scoped rules vs. multiple AGENTS.md
+
+* **Multiple AGENTS.md** — when rules align with directory structure (e.g. one `AGENTS.md` per package in a monorepo). See [Do you write an AGENTS.md?](/write-agents-md).
+* **Scoped rule files** — when rules apply to file patterns that cross directories (e.g. "all migration files", "all `.razor` files"), or when you want one short index at the root.
+
+The two patterns can coexist — a `AGENTS.md` per package, with `.claude/rules/` for cross-cutting patterns within each.
+
+## Further reading
+
+* [Claude Code — Project rules](https://docs.claude.com/en/docs/claude-code/memory)
+* [Do you write an AGENTS.md?](/write-agents-md)
+* [Do you symlink your AGENTS.md to other tool-specific files?](/symlink-agents-to-claude)

--- a/public/uploads/rules/symlink-agents-to-claude/rule.mdx
+++ b/public/uploads/rules/symlink-agents-to-claude/rule.mdx
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Do you symlink your AGENTS.md and skills to .claude?
+title: Do you symlink your AGENTS.md to other tool-specific files?
 uri: symlink-agents-to-claude
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -15,22 +15,22 @@ related:
   - rule: public/uploads/rules/write-agents-md/rule.mdx
   - rule: public/uploads/rules/ai-agents-with-skills/rule.mdx
 guid: f7a3c1e2-8d45-4b91-a6e0-2c9f17d58b34
-seoDescription: Learn how to use symlinks so your AGENTS.md and skills work across both AGENTS.md-compatible tools and Claude Code without duplicating files.
+seoDescription: Learn how to use symlinks so your AGENTS.md works across Claude Code, GitHub Copilot, and other AI tools without duplicating files.
 created: 2026-03-11T00:00:00.000Z
 createdBy: Gordon Beeming
 createdByEmail: gordonbeeming@ssw.com.au
-lastUpdated: 2026-03-11T00:00:00.000Z
-lastUpdatedBy: Gordon Beeming
-lastUpdatedByEmail: gordonbeeming@ssw.com.au
+lastUpdated: 2026-04-30T00:00:00.000Z
+lastUpdatedBy: Brady Stroud
+lastUpdatedByEmail: bradystroud@ssw.com.au
 ---
 
-`AGENTS.md` is the cross-tool standard for AI coding instructions, but Claude Code still looks for `CLAUDE.md` and `.claude/skills/`. Instead of maintaining two copies, use symlinks so both conventions resolve to the same files.
+`AGENTS.md` is the cross-tool standard for AI coding instructions, but some tools still look for their own files — Claude Code wants `CLAUDE.md` and `.claude/skills/`, and GitHub Copilot's PR review reads `.github/copilot-instructions.md`. Instead of maintaining multiple copies, use symlinks so every convention resolves to the same source.
 
 <endIntro />
 
 ## The problem
 
-Most AI coding tools (Cursor, GitHub Copilot, OpenCode) read `AGENTS.md` and `.agents/skills/`. Claude Code reads `CLAUDE.md` and `.claude/skills/`. If you maintain separate files, they drift apart and your team gets inconsistent AI behavior depending on which tool they use.
+Most AI coding tools (Cursor, GitHub Copilot, OpenCode) read `AGENTS.md` and `.agents/skills/`. Claude Code reads `CLAUDE.md` and `.claude/skills/`. GitHub Copilot's pull request review feature reads `.github/copilot-instructions.md`. If you maintain separate files, they drift apart and your team gets inconsistent AI behavior depending on which tool they use.
 
 ## The solution: symlinks
 
@@ -42,6 +42,14 @@ Keep your instructions in `AGENTS.md` (the cross-tool standard) and symlink `CLA
 
 ```bash
 ln -s AGENTS.md CLAUDE.md
+```
+
+### AGENTS.md → .github/copilot-instructions.md
+
+GitHub Copilot's pull request review feature reads `.github/copilot-instructions.md`. Symlink it to `AGENTS.md` so PR reviews use the same instructions:
+
+```bash
+ln -s ../AGENTS.md .github/copilot-instructions.md
 ```
 
 ### .agents/skills/ → .claude/skills/
@@ -62,6 +70,8 @@ ln -s ../.agents/skills .claude/skills
     ```
     ├── AGENTS.md
     ├── CLAUDE.md               ← copy of AGENTS.md (manually maintained)
+    ├── .github/
+    │   └── copilot-instructions.md   ← another copy (manually maintained)
     ├── .agents/
     │   └── skills/
     │       └── commit/
@@ -82,6 +92,8 @@ ln -s ../.agents/skills .claude/skills
     ```
     ├── AGENTS.md                ← single source of truth
     ├── CLAUDE.md → AGENTS.md   ← symlink
+    ├── .github/
+    │   └── copilot-instructions.md → ../AGENTS.md   ← symlink
     ├── .agents/
     │   └── skills/              ← single source of truth
     │       └── commit/
@@ -100,8 +112,8 @@ ln -s ../.agents/skills .claude/skills
 Git tracks symlinks natively. When you commit and push, your teammates get the same symlinks when they clone or pull — no extra setup needed.
 
 ```bash
-git add CLAUDE.md .claude/skills
-git commit -m "Add symlinks from .claude to .agents for Claude Code compatibility"
+git add CLAUDE.md .github/copilot-instructions.md .claude/skills
+git commit -m "Symlink tool-specific files to AGENTS.md for cross-tool compatibility"
 ```
 
 <boxEmbed

--- a/public/uploads/rules/write-agents-md/rule.mdx
+++ b/public/uploads/rules/write-agents-md/rule.mdx
@@ -46,6 +46,7 @@ An `AGENTS.md` file acts as a "manual" for AI agents. It provides a centralized 
 ## 👎 What does **not** go into an AGENTS.md?
 
 * **Secrets** - Never put API keys, secrets, or sensitive internal information, it's committed to source control
+* **Pull request descriptions** - PR description format belongs in `.github/pull_request_template.md`, not `AGENTS.md`. AI tools already pick up the template when opening PRs
 
 By providing this information, you ensure that the AI's suggestions are consistent with your project's existing structure, reducing the need for manual corrections.
 
@@ -132,6 +133,8 @@ Multiple AGENTS.md is particularly useful for architectures like [Modular Monoli
 />
 
 You could also have a separate AGENTS.md for your tests!
+
+For an alternative pattern that scopes rules by file *patterns* rather than directories, see [Do you split your AGENTS.md into scoped rule files?](/scoped-rules-for-ai-agents).
 
 ## Writing tips
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

New Rule - Using GitHub Copilot Instructions

> 2. What was changed?

This pull request introduces a new rule about splitting `AGENTS.md` into scoped rule files for AI agents, and updates related documentation to reflect best practices for cross-tool compatibility and organization of AI coding instructions. The changes improve clarity on how to structure AI agent rules for large projects and ensure consistency across different AI development tools.

**New rule and documentation improvements:**

* Added a new rule file, `scoped-rules-for-ai-agents`, explaining how to split `AGENTS.md` into scoped rule files that are loaded by AI agents only when working in matching paths, reducing context bloat and improving scalability in large projects.
* Updated the AI-assisted development rules index to include the new scoped rules for AI agents.

**Cross-tool compatibility enhancements:**

* Improved the "symlink AGENTS.md" rule to clarify that `AGENTS.md` should be symlinked to other tool-specific files (such as `.github/copilot-instructions.md` for GitHub Copilot and `CLAUDE.md` for Claude Code), ensuring a single source of truth and consistent AI behavior across tools. [[1]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4L3-R3) [[2]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4L18-R33)
* Added instructions and examples for symlinking `AGENTS.md` to `.github/copilot-instructions.md`, and updated directory structure examples to reflect these symlinks. [[1]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4R47-R54) [[2]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4R73-R74) [[3]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4R95-R96) [[4]](diffhunk://#diff-94d348a1c55190a08c37a571a0e72e21bf121883bafc51a3faca5948808d4bf4L103-R116)

**Clarifications and best practices:**

* Clarified that pull request description formats belong in `.github/pull_request_template.md` rather than `AGENTS.md`, as AI tools already use the template when opening PRs.
* Added a reference in the "write AGENTS.md" rule to the new pattern for scoping rules by file patterns, directing readers to the new rule for more details.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

no
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
