### PR TITLE
public/uploads/rules/event booth-success/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/event-booth-success/rule.mdx
+++ b/public/uploads/rules/event-booth-success/rule.mdx
@@ -132,7 +132,7 @@ A good opener is specific and gives the attendee an invite to ask questions and 
 Other openers that work:
 
 * **Have an interesting activity** - People inevitably get tired from multiple conversations throughout the day, having an interesting activity gives them something to break up the monotony of constant presentations and provides an interesting starting point for a conversation
-* **Reference their lanyard** - “Oh, you're from {{ COMPANY }} - I saw this {{ PROJECT }} you guys were working on, how does {{ FEATURE }} work?”
+* **Reference their lanyard** - “Oh, you're from &#123;&#123; COMPANY &#125;&#125; - I saw this &#123;&#123; PROJECT &#125;&#125; you guys were working on, how does &#123;&#123; FEATURE &#125;&#125; work?”
 * **Ask why they're here** - “What brings you to the conference - any particular topics you're focused on?” beats "Are you looking for consulting?"
 * **Comment on a session** - “Did you catch the keynote? What did you think?”
 * **Dress up in a costume** - Like Gandalf or another recognisable character. It's a magnet for photos and an easy conversation starter
@@ -227,4 +227,4 @@ The event ends. The work doesn't.
 
 * **Run a retrospective** - What worked, who to follow up, what to fix next time. Memories fade fast.
   For more details, see [Do you do a retrospective after an activity ends?](https://www.ssw.com.au/rules/do-a-retrospective)
-* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at {{ EVENT }} - here's that link I mentioned"
+* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at &#123;&#123; EVENT &#125;&#125; - here's that link I mentioned"

--- a/public/uploads/rules/event-booth-success/rule.mdx
+++ b/public/uploads/rules/event-booth-success/rule.mdx
@@ -29,7 +29,7 @@ seoDescription: 'How to get the most out of your event booth by executing across
 created: 2026-04-29T07:39:58.157Z
 createdBy: Michael Qiu
 createdByEmail: MichaelQiu@ssw.com.au
-lastUpdated: 2026-05-01T05:48:32.973Z
+lastUpdated: 2026-05-01T05:52:37.032Z
 lastUpdatedBy: Hark
 lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null
@@ -132,7 +132,7 @@ A good opener is specific and gives the attendee an invite to ask questions and 
 Other openers that work:
 
 * **Have an interesting activity** - People inevitably get tired from multiple conversations throughout the day, having an interesting activity gives them something to break up the monotony of constant presentations and provides an interesting starting point for a conversation
-* **Reference their lanyard** - “Oh, you're from &#123;&#123; COMPANY &#125;&#125; - I saw this &#123;&#123; PROJECT &#125;&#125; you guys were working on, how does &#123;&#123; FEATURE &#125;&#125; work?”
+* **Reference their lanyard** - “Oh, you're from {{ COMPANY }} - I saw this {{ PROJECT }} you guys were working on, how does {{ FEATURE }} work?”
 * **Ask why they're here** - “What brings you to the conference - any particular topics you're focused on?” beats "Are you looking for consulting?"
 * **Comment on a session** - “Did you catch the keynote? What did you think?”
 * **Dress up in a costume** - Like Gandalf or another recognisable character. It's a magnet for photos and an easy conversation starter
@@ -197,7 +197,7 @@ For each conversation, capture:
   body={<>
     **Optional tip:** Add the lead to your personal LinkedIn. A connection made on the day is worth more than a cold request sent a week later.
     
-    See more on [Do you maintain your connections on LinkedIn?](https://www.ssw.com.au/rules/linkedin-maintain-connections)
+    See more on [Do you know how to connect with people on LinkedIn?](https://www.ssw.com.au/rules/linkedin-connect-with-people)
   </>}
   figurePrefix="none"
   figure=""
@@ -227,4 +227,4 @@ The event ends. The work doesn't.
 
 * **Run a retrospective** - What worked, who to follow up, what to fix next time. Memories fade fast.
   For more details, see [Do you do a retrospective after an activity ends?](https://www.ssw.com.au/rules/do-a-retrospective)
-* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at &#123;&#123; EVENT &#125;&#125; - here's that link I mentioned"
+* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at {{ EVENT }} - here's that link I mentioned"

--- a/public/uploads/rules/event-booth-success/rule.mdx
+++ b/public/uploads/rules/event-booth-success/rule.mdx
@@ -29,9 +29,9 @@ seoDescription: 'How to get the most out of your event booth by executing across
 created: 2026-04-29T07:39:58.157Z
 createdBy: Michael Qiu
 createdByEmail: MichaelQiu@ssw.com.au
-lastUpdated: 2026-04-30T22:46:09.158Z
-lastUpdatedBy: Caleb Williams
-lastUpdatedByEmail: CalebWilliams@ssw.com.au
+lastUpdated: 2026-05-01T05:48:32.973Z
+lastUpdatedBy: Hark
+lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null
 ---
 
@@ -132,7 +132,7 @@ A good opener is specific and gives the attendee an invite to ask questions and 
 Other openers that work:
 
 * **Have an interesting activity** - People inevitably get tired from multiple conversations throughout the day, having an interesting activity gives them something to break up the monotony of constant presentations and provides an interesting starting point for a conversation
-* **Reference their lanyard** - “Oh, you're from &#123;&#123; COMPANY &#125;&#125; - I saw this &#123;&#123; PROJECT &#125;&#125; you guys were working on, how does &#123;&#123; FEATURE &#125;&#125; work?”
+* **Reference their lanyard** - “Oh, you're from {{ COMPANY }} - I saw this {{ PROJECT }} you guys were working on, how does {{ FEATURE }} work?”
 * **Ask why they're here** - “What brings you to the conference - any particular topics you're focused on?” beats "Are you looking for consulting?"
 * **Comment on a session** - “Did you catch the keynote? What did you think?”
 * **Dress up in a costume** - Like Gandalf or another recognisable character. It's a magnet for photos and an easy conversation starter
@@ -158,7 +158,7 @@ Other openers that work:
 <boxEmbed
   body={<>
     **Important:** If the conversation moves toward “what does your product actually do?”, that's where you have to [pitch your product](/pitch-a-product).
-</>}
+  </>}
   figurePrefix="none"
   figure=""
   style="warning"
@@ -195,7 +195,7 @@ For each conversation, capture:
 
 <boxEmbed
   body={<>
-    **Optional tip:** Add the lead to your personal [LinkedIn](https://www.linkedin.com/). A connection made on the day is worth more than a cold request sent a week later.
+    **Optional tip:** Add the lead to your personal LinkedIn. A connection made on the day is worth more than a cold request sent a week later.
     
     See more on [Do you maintain your connections on LinkedIn?](https://www.ssw.com.au/rules/linkedin-maintain-connections)
   </>}
@@ -225,6 +225,6 @@ Merch is a tool, not a transaction - you're not there to sell merch, but to use 
 
 The event ends. The work doesn't.
 
-* **Run a retrospective** - What worked, who to follow up, what to fix next time. Memories fade fast. 
+* **Run a retrospective** - What worked, who to follow up, what to fix next time. Memories fade fast.
   For more details, see [Do you do a retrospective after an activity ends?](https://www.ssw.com.au/rules/do-a-retrospective)
-* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at &#123;&#123; EVENT &#125;&#125; - here's that link I mentioned"
+* **Follow-ups within 48 hours** - “Strike while the iron is hot”, you should send off promised follow ups to people while you're still recognisable. For example, "Great to meet you at {{ EVENT }} - here's that link I mentioned"


### PR DESCRIPTION
What triggered the change?

As per my conversation with Adam, we need to remove linkedin link
and change the linkedin connection rule

What was changed?
I removed the link & change the related linkedin rule to https://www.ssw.com.au/rules/linkedin-connect-with-people