### PR TITLE
fix: rewrite stale category references for 8 moved categories

### DIFF
--- a/public/uploads/rules/404-error-avoid-changing-the-url/rule.mdx
+++ b/public/uploads/rules/404-error-avoid-changing-the-url/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Do not change the URL on a 404 error, keep the original URL inta
   to enable easy corrections for users
 title: Do you avoid changing the URL on a 404 error?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: 404-error-avoid-changing-the-url
 ---

--- a/public/uploads/rules/404-useful-error-page/rule.mdx
+++ b/public/uploads/rules/404-useful-error-page/rule.mdx
@@ -23,8 +23,8 @@ seoDescription: Enhance your ASP.NET site's user experience with a custom 404 er
   page that redirects visitors effectively.
 title: Do you have a useful 404 error page?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: 404-useful-error-page
 ---

--- a/public/uploads/rules/always-have-a-default-index-page/rule.mdx
+++ b/public/uploads/rules/always-have-a-default-index-page/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: A default/index page ensures a seamless user experience by preve
   404 errors when navigating via URL
 title: Do you always have a default/index page?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: always-have-a-default-index-page
 ---

--- a/public/uploads/rules/always-put-javascript-in-a-separate-file/rule.mdx
+++ b/public/uploads/rules/always-put-javascript-in-a-separate-file/rule.mdx
@@ -17,8 +17,8 @@ seoDescription: Always put JavaScript in a separate file to maintain consistent 
   numbers during debugging and improve performance through browser caching
 title: Do you always put JavaScript in a separate file?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: always-put-javascript-in-a-separate-file
 ---

--- a/public/uploads/rules/always-use-query-strings/rule.mdx
+++ b/public/uploads/rules/always-use-query-strings/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Use query strings to enable bookmarking and parameter modificati
   for a more engaging user experience
 title: Do you always use query strings?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: always-use-query-strings
 ---

--- a/public/uploads/rules/analyze-website-performance/rule.mdx
+++ b/public/uploads/rules/analyze-website-performance/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Optimize website performance to enhance user experience and impr
   database queries
 title: Do you analyze your website performance?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: analyze-website-performance
 ---

--- a/public/uploads/rules/avoid-deploying-source-code-on-the-production-server/rule.mdx
+++ b/public/uploads/rules/avoid-deploying-source-code-on-the-production-server/rule.mdx
@@ -18,8 +18,8 @@ seoDescription: Avoid deploying source code on production servers by using tools
   and identifying potential errors.
 title: Do you avoid deploying source code on the production server?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: avoid-deploying-source-code-on-the-production-server
 ---

--- a/public/uploads/rules/avoid-height-width-in-img-tag/rule.mdx
+++ b/public/uploads/rules/avoid-height-width-in-img-tag/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Avoid specifying height and width attributes in your image tags 
   maintain responsiveness and prevent images from being stretched or distorted.
 title: Do you avoid having height/width in an image tag?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: avoid-height-width-in-img-tag
 ---

--- a/public/uploads/rules/avoid-using-asp-asp-net-tags-in-plain-html/rule.mdx
+++ b/public/uploads/rules/avoid-using-asp-asp-net-tags-in-plain-html/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using ASP/ASP.NET tags in plain HTML pages to prevent unne
   file size increase and browser confusion.
 title: Do you avoid using ASP/ASP.NET tags in plain HTML?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: avoid-using-asp-asp-net-tags-in-plain-html
 ---

--- a/public/uploads/rules/avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element/rule.mdx
+++ b/public/uploads/rules/avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element/rule.mdx
@@ -20,7 +20,7 @@ title: Do you avoid using document.getElementById(id) and document.all(id) to ge
   a single element, instead use selector $(#id)?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element
 ---

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: 'Do you avoid using mailto: on your website?'
 uri: avoid-using-mailto-on-your-website
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
   - category: categories/design/rules-to-better-interfaces-forms.mdx
   - category: categories/design/rules-to-better-accessibility.mdx
   - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx

--- a/public/uploads/rules/avoid-using-reportviewer-local-processing-mode/rule.mdx
+++ b/public/uploads/rules/avoid-using-reportviewer-local-processing-mode/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using ReportViewer local processing mode to improve applic
   performance and reduce server load.
 title: Do you avoid using ReportViewer local processing mode?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: avoid-using-reportviewer-local-processing-mode
 ---

--- a/public/uploads/rules/avoid-using-uncs-in-hrefs/rule.mdx
+++ b/public/uploads/rules/avoid-using-uncs-in-hrefs/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using UNC paths (Uniform Naming Conventions) in HREFs as i
   can cause issues when pages are uploaded to the web.
 title: Do you avoid using UNCs in HREFs?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: avoid-using-uncs-in-hrefs
 ---

--- a/public/uploads/rules/avoid-using-web-site-projects/rule.mdx
+++ b/public/uploads/rules/avoid-using-web-site-projects/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using website projects and instead opt for web application
   which provide a single assembly compilation and improved project management.
 title: Do you avoid using Website Projects?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: avoid-using-web-site-projects
 ---

--- a/public/uploads/rules/best-commenting-engine/rule.mdx
+++ b/public/uploads/rules/best-commenting-engine/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Allowing visitors to comment and rate your pages can be a great 
   to collect feedback and make it easier to maintain your content.
 title: Do you allow users to comment and rate your pages?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: best-commenting-engine
 ---

--- a/public/uploads/rules/best-online-documentation-site/rule.mdx
+++ b/public/uploads/rules/best-online-documentation-site/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Discover the best documentation sites like TinaCMS, GitBook, Rea
   documentation process with the right platform.
 title: Do you know the best online documentation site?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: best-online-documentation-site
 ---

--- a/public/uploads/rules/best-practices-for-frontmatter-in-markdown/rule.mdx
+++ b/public/uploads/rules/best-practices-for-frontmatter-in-markdown/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Learn effective Frontmatter practices in Markdown for better met
 type: rule
 title: Do you know the best practices for Frontmatter in markdown?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 uri: best-practices-for-frontmatter-in-markdown
 authors:
   - title: Gert Marx

--- a/public/uploads/rules/best-static-site-tech-stack/rule.mdx
+++ b/public/uploads/rules/best-static-site-tech-stack/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Discover the best static site tech stack and create lightning-fa
   and Jekyll, find the perfect fit for your project's needs.
 title: Do you use the best static site tech stack?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: best-static-site-tech-stack
 ---

--- a/public/uploads/rules/best-way-to-display-code-on-your-website/rule.mdx
+++ b/public/uploads/rules/best-way-to-display-code-on-your-website/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you know how to display code in HTML?
 uri: best-way-to-display-code-on-your-website
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/build-criteria-by-using-a-where-clause/rule.mdx
+++ b/public/uploads/rules/build-criteria-by-using-a-where-clause/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Build criteria by using a WHERE clause, allowing for more comple
   filtering and similar matches with LIKE statements.
 title: Do you build criteria by using a where clause?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: build-criteria-by-using-a-where-clause
 ---

--- a/public/uploads/rules/centralize-downloadable-files/rule.mdx
+++ b/public/uploads/rules/centralize-downloadable-files/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Centralize downloadable files to simplify organization, updating
   and tracking of content while improving website performance and accessibility.
 title: Do you centralize downloadable files?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: centralize-downloadable-files
 ---

--- a/public/uploads/rules/check-your-website-is-running/rule.mdx
+++ b/public/uploads/rules/check-your-website-is-running/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Website monitoring made easy with WhatsUp - real-time checks for
   availability and performance.
 title: Do you check if your website is running?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: check-your-website-is-running
 ---

--- a/public/uploads/rules/close-quotations-of-html-attributes/rule.mdx
+++ b/public/uploads/rules/close-quotations-of-html-attributes/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Ensure accurate HTML coding by closing all opening quotations of
   results.
 title: Do you close quotations of all HTML attributes?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: close-quotations-of-html-attributes
 ---

--- a/public/uploads/rules/cms-solutions/rule.mdx
+++ b/public/uploads/rules/cms-solutions/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Kontent.ai vs Contentful - Which Headless CMS Reigns Supreme? Be
 title: Do you know the best CMS solutions for websites?
 categories:
   - category: categories/company-operations/rules-to-successful-projects.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: cms-solutions
 ---

--- a/public/uploads/rules/create-friendly-short-urls/rule.mdx
+++ b/public/uploads/rules/create-friendly-short-urls/rule.mdx
@@ -4,7 +4,7 @@ title: Do you make URLs short and readable?
 uri: create-friendly-short-urls
 categories:
   - category: categories/marketing-and-video/rules-to-better-social-media-for-business.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/design-to-improve-your-google-ranking/rule.mdx
+++ b/public/uploads/rules/design-to-improve-your-google-ranking/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Design a website that improves your Google ranking by using rele
   keywords, meta tags, and internal linking to boost search engine visibility.
 title: Do you design your website to improve your Google Ranking?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: design-to-improve-your-google-ranking
 ---

--- a/public/uploads/rules/do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero/rule.mdx
+++ b/public/uploads/rules/do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero/rule.mdx
@@ -20,7 +20,7 @@ title: Data - Do you not allow NULLs in number fields if it has the same meaning
   zero?
 categories:
   - category: categories/software-engineering/rules-to-better-sql-databases-developers.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero
 ---

--- a/public/uploads/rules/do-not-use-linkbutton/rule.mdx
+++ b/public/uploads/rules/do-not-use-linkbutton/rule.mdx
@@ -17,8 +17,8 @@ seoDescription: Learn why not to use LinkButton for postback and implement corre
   in ASP.NET
 title: Do you know not to use LinkButton?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: do-not-use-linkbutton
 ---

--- a/public/uploads/rules/do-you-add-width-and-height-properties-to-images-in-user-controls/rule.mdx
+++ b/public/uploads/rules/do-you-add-width-and-height-properties-to-images-in-user-controls/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn whether adding width and height properties to images in us
   controls improves load times or impacts responsiveness.
 title: Do you add width and height properties to images in user controls?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-add-width-and-height-properties-to-images-in-user-controls
 ---

--- a/public/uploads/rules/do-you-avoid-bmps-for-the-internet-at-all-times/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-bmps-for-the-internet-at-all-times/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid using BMP files on your website or in emails due to their 
   file sizes; opt for PNG for better performance online
 title: Do you avoid BMPs for web at all times?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-avoid-bmps-for-the-internet-at-all-times
 ---

--- a/public/uploads/rules/do-you-avoid-publishing-from-visual-studio/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-publishing-from-visual-studio/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid publishing from Visual Studio and instead use a defined Bu
 title: Do you avoid publishing from Visual Studio?
 categories:
   - category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: do-you-avoid-publishing-from-visual-studio
 ---

--- a/public/uploads/rules/do-you-backup-your-wordpress-site-to-an-external-provider-like-dropbox/rule.mdx
+++ b/public/uploads/rules/do-you-backup-your-wordpress-site-to-an-external-provider-like-dropbox/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Backup your WordPress site to an external provider like Dropbox 
   the BackWPup plugin for secure and automated daily backups.
 title: Do you backup your WordPress site to an external provider like Dropbox?
 categories:
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: do-you-backup-your-wordpress-site-to-an-external-provider-like-dropbox
 ---

--- a/public/uploads/rules/do-you-check-your-website-is-multi-browser-compatible/rule.mdx
+++ b/public/uploads/rules/do-you-check-your-website-is-multi-browser-compatible/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Ensure your website displays correctly across multiple browsers,
 title: Do you check your website is multi-browser compatible?
 categories:
   - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: do-you-check-your-website-is-multi-browser-compatible
 ---

--- a/public/uploads/rules/do-you-choose-the-best-way-to-send-emails-for-application/rule.mdx
+++ b/public/uploads/rules/do-you-choose-the-best-way-to-send-emails-for-application/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: When choosing the best way to send emails for your application, 
 type: rule
 title: Do you choose the best way to send emails for your application?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 uri: do-you-choose-the-best-way-to-send-emails-for-application
 authors:
   - title: Kiki Biancatti

--- a/public/uploads/rules/do-you-deploy-to-azure-from-team-foundation-service/rule.mdx
+++ b/public/uploads/rules/do-you-deploy-to-azure-from-team-foundation-service/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Deploy websites to Azure using Team Foundation Service and achie
   continuous deployment with ease.
 title: Do you deploy to Azure from Team Foundation Service?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: do-you-deploy-to-azure-from-team-foundation-service
 ---

--- a/public/uploads/rules/do-you-get-ready-to-wait/rule.mdx
+++ b/public/uploads/rules/do-you-get-ready-to-wait/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Optimize Sitefinity performance with essential tips to speed up 
   usage.
 title: Do you get ready to wait?
 categories:
-  - category: categories/software-engineering/rules-to-better-sitefinity.mdx
+  - category: categories/websites-and-cms/rules-to-better-sitefinity.mdx
 type: rule
 uri: do-you-get-ready-to-wait
 ---

--- a/public/uploads/rules/do-you-have-a-cookie-banner/rule.mdx
+++ b/public/uploads/rules/do-you-have-a-cookie-banner/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Discover how to craft a cookie consent banner and why you must b
   careful about how you collect user data
 title: Do you have a cookie consent banner?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-have-a-cookie-banner
 ---

--- a/public/uploads/rules/do-you-know-how-to-create-nice-urls-using-asp-net-4/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-create-nice-urls-using-asp-net-4/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Create nice URLs with ASP.NET 4 using routing features, improvin
   user experience and search engine ranking.
 title: Do you know how to create nice URLs using ASP.NET 4?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-know-how-to-create-nice-urls-using-asp-net-4
 ---

--- a/public/uploads/rules/do-you-know-how-to-create-posts-via-email/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-create-posts-via-email/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn how to create new posts on your WordPress blog without acc
   to the admin area using the Jetpack plugin and Ben Cull's video.
 title: Do you know how to create posts via email?
 categories:
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: do-you-know-how-to-create-posts-via-email
 ---

--- a/public/uploads/rules/do-you-know-how-to-filter-data/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-filter-data/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn how to filter data effectively and efficiently in DataGrid
   ASP.NET and RadGrid features.
 title: Do you know how to filter data?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-know-how-to-filter-data
 ---

--- a/public/uploads/rules/do-you-know-how-to-render-html-strings/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-render-html-strings/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Prevent cross-site scripting (XSS) attacks and double encoding i
 type: rule
 title: Do you know how to render HTML strings?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 uri: do-you-know-how-to-render-html-strings
 authors:
   - title: Charles Vionnet

--- a/public/uploads/rules/do-you-know-how-to-share-a-private-link-of-a-draft-post/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-share-a-private-link-of-a-draft-post/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Discover how to share private links of draft posts using the Pub
   Post Preview plugin in WordPress.
 title: Do you know how to share a private link of a draft post?
 categories:
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: do-you-know-how-to-share-a-private-link-of-a-draft-post
 ---

--- a/public/uploads/rules/do-you-know-how-to-use-balloons-in-screenshots-for-instructions/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-use-balloons-in-screenshots-for-instructions/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Enhance screenshot-based instructions by using balloons to highl
   specific parts and improve problem-solving comprehension.
 title: Do you know how to use balloons in screenshots for instructions?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-know-how-to-use-balloons-in-screenshots-for-instructions
 ---

--- a/public/uploads/rules/do-you-know-that-caching-is-disabled-when-debug-true/rule.mdx
+++ b/public/uploads/rules/do-you-know-that-caching-is-disabled-when-debug-true/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Sitefinity disables caching when debug="true", impacting perform
   in test and production environments.
 title: Do you know that caching is disabled when debug="true"
 categories:
-  - category: categories/software-engineering/rules-to-better-sitefinity.mdx
+  - category: categories/websites-and-cms/rules-to-better-sitefinity.mdx
 type: rule
 uri: do-you-know-that-caching-is-disabled-when-debug-true
 ---

--- a/public/uploads/rules/do-you-know-the-best-framework-to-build-an-admin-interface/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-best-framework-to-build-an-admin-interface/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Find the best framework for your admin interface. Explore top ch
   like React, Blazor, and Angular, based on your tech stack and project needs
 title: Do you know the best framework to build an admin interface for Web Apps?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: do-you-know-the-best-framework-to-build-an-admin-interface
 ---

--- a/public/uploads/rules/do-you-know-to-create-a-custom-library-provider/rule.mdx
+++ b/public/uploads/rules/do-you-know-to-create-a-custom-library-provider/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn how to create a custom library provider in Sitefinity for 
   asset management.
 title: Do you know to create a Custom Library Provider?
 categories:
-  - category: categories/software-engineering/rules-to-better-sitefinity.mdx
+  - category: categories/websites-and-cms/rules-to-better-sitefinity.mdx
 type: rule
 uri: do-you-know-to-create-a-custom-library-provider
 ---

--- a/public/uploads/rules/do-you-know-to-use-the-sitefinity-thunder-visual-studio-extension/rule.mdx
+++ b/public/uploads/rules/do-you-know-to-use-the-sitefinity-thunder-visual-studio-extension/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Optimize your Sitefinity development workflow by using Thunder, 
   multiple projects.
 title: Do you know to use the Sitefinity Thunder Visual Studio extension?
 categories:
-  - category: categories/software-engineering/rules-to-better-sitefinity.mdx
+  - category: categories/websites-and-cms/rules-to-better-sitefinity.mdx
 type: rule
 uri: do-you-know-to-use-the-sitefinity-thunder-visual-studio-extension
 ---

--- a/public/uploads/rules/do-you-know-when-to-use-jpg/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-to-use-jpg/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Mastering JPG format - Compress images effectively to balance qu
   and file size, while ensuring a smooth online experience.
 title: Do you know when to use JPG?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-know-when-to-use-jpg
 ---

--- a/public/uploads/rules/do-you-know-when-to-use-png/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-to-use-png/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: PNG images offer high-quality alternatives to JPG and BMP, featu
   alpha blending, unlimited color palettes, and multiple CRCs for integrity checks.
 title: Do you know when to use PNG?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-know-when-to-use-png
 ---

--- a/public/uploads/rules/do-you-know-when-to-use-svg/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-to-use-svg/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: When to use SVG? Use SVG format for line art graphics and well-d
   results.
 title: Do you know when to use SVG?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-know-when-to-use-svg
 ---

--- a/public/uploads/rules/do-you-know-where-to-host-your-frontend-application/rule.mdx
+++ b/public/uploads/rules/do-you-know-where-to-host-your-frontend-application/rule.mdx
@@ -12,7 +12,7 @@ seoDescription: Discover the best way to host your frontend application with ASP
   10, balancing scalability, flexibility, and ease of deployment.
 title: Do you know where to host your Frontend application?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: do-you-know-where-to-host-your-frontend-application
 ---

--- a/public/uploads/rules/do-you-log-usage/rule.mdx
+++ b/public/uploads/rules/do-you-log-usage/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Track usage patterns and optimize functionality with Redgate's F
   layouts.
 title: Do you log usage?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-log-usage
 ---

--- a/public/uploads/rules/do-you-make-sure-your-website-doesnt-have-multiple-copies-of-the-same-image/rule.mdx
+++ b/public/uploads/rules/do-you-make-sure-your-website-doesnt-have-multiple-copies-of-the-same-image/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Optimize your website's performance by avoiding duplicate images
   storing them in a single, easily accessible location.
 title: Do you make sure your website doesn't have multiple copies of the same image?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-make-sure-your-website-doesnt-have-multiple-copies-of-the-same-image
 ---

--- a/public/uploads/rules/do-you-optimize-tinacms-project/rule.mdx
+++ b/public/uploads/rules/do-you-optimize-tinacms-project/rule.mdx
@@ -2,7 +2,7 @@
 type: rule
 title: Do you optimize your TinaCMS project for clarity, performance, and reliable builds?
 categories:
-  - category: categories/software-engineering/rules-to-better-tinacms.mdx
+  - category: categories/websites-and-cms/rules-to-better-tinacms.mdx
 seoDescription: Learn effective strategies to structure and optimize your
     TinaCMS project for clarity, performance, and successful builds.
 uri: do-you-optimize-tinacms-project

--- a/public/uploads/rules/do-you-perform-migration-procedures-with-an-approved-plan/rule.mdx
+++ b/public/uploads/rules/do-you-perform-migration-procedures-with-an-approved-plan/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Migrating to a new technology requires a carefully crafted plan 
 title: Do you perform migration procedures with an approved plan?
 categories:
   - category: categories/company-operations/rules-to-successful-projects.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: do-you-perform-migration-procedures-with-an-approved-plan
 ---

--- a/public/uploads/rules/do-you-prefix-your-images-appropriately/rule.mdx
+++ b/public/uploads/rules/do-you-prefix-your-images-appropriately/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Optimize your images by using descriptive names and prefixes lik
   engine visibility.
 title: Do you prefix your images appropriately?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-prefix-your-images-appropriately
 ---

--- a/public/uploads/rules/do-you-tell-your-designers-to-only-use-classes/rule.mdx
+++ b/public/uploads/rules/do-you-tell-your-designers-to-only-use-classes/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Sitefinity layouts are limited to assigning a class to a div, wi
   widths hardcoded and no customization options.
 title: Do you tell your designers to only use classes?
 categories:
-  - category: categories/software-engineering/rules-to-better-sitefinity.mdx
+  - category: categories/websites-and-cms/rules-to-better-sitefinity.mdx
 type: rule
 uri: do-you-tell-your-designers-to-only-use-classes
 ---

--- a/public/uploads/rules/do-you-use-image-sprites-to-reduce-http-requests/rule.mdx
+++ b/public/uploads/rules/do-you-use-image-sprites-to-reduce-http-requests/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Reduce HTTP requests and speed up page load times by using CSS i
   display only the needed portion.
 title: Do you use image sprites to reduce HTTP requests?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-use-image-sprites-to-reduce-http-requests
 ---

--- a/public/uploads/rules/do-you-use-image-styles-to-ensure-great-looking-content/rule.mdx
+++ b/public/uploads/rules/do-you-use-image-styles-to-ensure-great-looking-content/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Use consistent CSS styles to ensure great-looking images and enh
   user experience on your website.
 title: Do you use image styles to ensure great looking content?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-use-image-styles-to-ensure-great-looking-content
 ---

--- a/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: To keep your website fresh and engaging, add interactivity with 
   to make it come alive when users hover or click on elements.
 title: Do you use jQuery for making a site come alive?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-use-jquery-for-making-a-site-come-alive
 ---

--- a/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Improve page loading by providing instant details through jQuery
   saving users time and effort.
 title: Do you use jQuery Tooltips to save drilling through?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-use-jquery-tooltips-to-save-drilling-through
 ---

--- a/public/uploads/rules/do-you-use-msajax-for-live-data-binding-which-saves-round-trips/rule.mdx
+++ b/public/uploads/rules/do-you-use-msajax-for-live-data-binding-which-saves-round-trips/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Do you use MSAjax for live data binding which saves round trips 
   enhances user experience in ASP.NET AJAX applications.
 title: Do you use MSAjax for Live Data Binding which saves round trips?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: do-you-use-msajax-for-live-data-binding-which-saves-round-trips
 ---

--- a/public/uploads/rules/do-you-use-read-more-wordpress-tag-to-show-summary-only-on-a-blog-list/rule.mdx
+++ b/public/uploads/rules/do-you-use-read-more-wordpress-tag-to-show-summary-only-on-a-blog-list/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Do you use 'read more' WordPress tag to show summary only on a b
   list?
 title: Do you use 'read more' WordPress tag to show summary only on a blog list?
 categories:
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: do-you-use-read-more-wordpress-tag-to-show-summary-only-on-a-blog-list
 ---

--- a/public/uploads/rules/do-you-use-text-rather-than-images-where-appropriate/rule.mdx
+++ b/public/uploads/rules/do-you-use-text-rather-than-images-where-appropriate/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Optimize your web pages with text instead of images for faster l
   times, better search engine visibility, and improved mobile readability
 title: Do you use text rather than images where appropriate?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: do-you-use-text-rather-than-images-where-appropriate
 ---

--- a/public/uploads/rules/do-you-use-the-best-deployment-tool/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-best-deployment-tool/rule.mdx
@@ -25,7 +25,7 @@ title: Do you use the best deployment tool?
 categories:
   - category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
   - category: categories/project-delivery/rules-to-better-devops.mdx
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: do-you-use-the-best-deployment-tool
 ---

--- a/public/uploads/rules/do-your-developers-deploy-manually/rule.mdx
+++ b/public/uploads/rules/do-your-developers-deploy-manually/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Automated deployment process eliminates manual errors and ensure
   sites.
 title: Do your developers deploy manually?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: do-your-developers-deploy-manually
 ---

--- a/public/uploads/rules/exclude-width-and-height-properties-from-images/rule.mdx
+++ b/public/uploads/rules/exclude-width-and-height-properties-from-images/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Avoid using width and height attributes in image tags to optimiz
   content delivery and improve SEO performance.
 title: Do you avoid having width and height properties in image tags?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: exclude-width-and-height-properties-from-images
 ---

--- a/public/uploads/rules/favicon/rule.mdx
+++ b/public/uploads/rules/favicon/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Add a high-quality favicon to your website to give it a professi
 title: Do you add a favicon to your website?
 categories:
   - category: categories/marketing-and-video/rules-to-better-websites-branding-and-marketing.mdx
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: favicon
 ---

--- a/public/uploads/rules/fix-ugly-urls/rule.mdx
+++ b/public/uploads/rules/fix-ugly-urls/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Discover how to fix ugly URLs using IIS7 Rewrite for cleaner, SE
   links
 title: Do you use IIS7 Rewrite to fix ugly URLs?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: fix-ugly-urls
 ---

--- a/public/uploads/rules/generate-pdfs/rule.mdx
+++ b/public/uploads/rules/generate-pdfs/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Learn how to generate PDFs for download using various .NET libra
 type: rule
 title: Do you know how to generate PDFs for download?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 uri: generate-pdfs
 authors:
   - title: Alex Rothwell

--- a/public/uploads/rules/git-based-cms-solutions/rule.mdx
+++ b/public/uploads/rules/git-based-cms-solutions/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Unlock powerful workflows and scalability with Git-based CMS sol
   seeking flexible content management.
 title: Do you use Git-based Content Management Systems (CMS)?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: git-based-cms-solutions
 ---

--- a/public/uploads/rules/good-quality-images/rule.mdx
+++ b/public/uploads/rules/good-quality-images/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: High-quality images enhance user experience and improve website 
   with a minimum width of 800px for most visuals.
 title: Do you have good quality images?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: good-quality-images
 ---

--- a/public/uploads/rules/gravatar-for-profile-management/rule.mdx
+++ b/public/uploads/rules/gravatar-for-profile-management/rule.mdx
@@ -4,7 +4,7 @@ title: Do you implement Gravatar (or Cravatar for China) for profile management 
 uri: gravatar-for-profile-management
 categories:
   - category: categories/software-engineering/rules-to-better-internationalization.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/handling-diacritics/rule.mdx
+++ b/public/uploads/rules/handling-diacritics/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Multilingual search features require handling diacritics to ensu
   accurate matches and a seamless user experience.
 title: Do you know how to handle diacritics?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
 type: rule
 uri: handling-diacritics
 ---

--- a/public/uploads/rules/have-a-health-check-page-to-make-sure-your-website-is-healthy/rule.mdx
+++ b/public/uploads/rules/have-a-health-check-page-to-make-sure-your-website-is-healthy/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Ensure your website's health by having a Health Check page with 
 title: Do you have a Health Check page (from /zsValidate) to make sure your website
   is healthy?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: have-a-health-check-page-to-make-sure-your-website-is-healthy
 ---

--- a/public/uploads/rules/have-a-stylesheet-file/rule.mdx
+++ b/public/uploads/rules/have-a-stylesheet-file/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Streamline your website's design and maintenance with a single s
 title: Do you have a stylesheet file for all your formatting?
 categories:
   - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: have-a-stylesheet-file
 ---

--- a/public/uploads/rules/have-a-validation-page-for-your-web-server/rule.mdx
+++ b/public/uploads/rules/have-a-validation-page-for-your-web-server/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Ensure your website's health by validating dependencies with a '
   Check' page, verifying server, services, databases, and more.
 title: Do you have a Validation page (the /zsValidate) for your web server?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: have-a-validation-page-for-your-web-server
 ---

--- a/public/uploads/rules/have-an-uptime-report-for-your-website/rule.mdx
+++ b/public/uploads/rules/have-an-uptime-report-for-your-website/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Monitor website uptime and availability in real-time with a deta
   history of performance and downtime.
 title: Do you have uptime report for your website?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: have-an-uptime-report-for-your-website
 ---

--- a/public/uploads/rules/have-auto-generated-maintenance-pages/rule.mdx
+++ b/public/uploads/rules/have-auto-generated-maintenance-pages/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Do you have auto-generated maintenance pages on every project? Y
   with netTiers.
 title: Do you have auto-generated maintenance pages on every project ?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: have-auto-generated-maintenance-pages
 ---

--- a/public/uploads/rules/have-generic-exception-handler-in-your-global-asax/rule.mdx
+++ b/public/uploads/rules/have-generic-exception-handler-in-your-global-asax/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Handle exceptions in your ASP.NET application effectively with a
   exception handler in Global.asax, ensuring unhandled errors are logged and notified.
 title: Do you have generic exception handler in your Global.asax?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: have-generic-exception-handler-in-your-global-asax
 ---

--- a/public/uploads/rules/heading-to-anchor-targets/rule.mdx
+++ b/public/uploads/rules/heading-to-anchor-targets/rule.mdx
@@ -14,7 +14,7 @@ tips: ''
 title: Do you turn your headings into anchor links?
 categories:
   - category: categories/design/rules-to-better-websites-navigation.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: heading-to-anchor-targets
 created: 2025-09-26T17:11:48+02:00

--- a/public/uploads/rules/hide-visual-clutter-in-screenshots/rule.mdx
+++ b/public/uploads/rules/hide-visual-clutter-in-screenshots/rule.mdx
@@ -15,7 +15,7 @@ title: Do you hide visual clutter (toolbars, taskbar, bookmarks, inspector) befo
   taking screenshots?
 categories:
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: hide-visual-clutter-in-screenshots
 ---

--- a/public/uploads/rules/high-quality-images/rule.mdx
+++ b/public/uploads/rules/high-quality-images/rule.mdx
@@ -22,7 +22,7 @@ seoDescription: Use high-quality images that accurately represent your product t
 title: Do you use high quality images?
 categories:
   - category: categories/communication/rules-to-better-powerpoint-presentations.mdx
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: high-quality-images
 ---

--- a/public/uploads/rules/how-to-find-broken-links/rule.mdx
+++ b/public/uploads/rules/how-to-find-broken-links/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Discover how to find broken links on your website and improve us
   experience with these tips and tools.
 title: Do you know how to find broken links?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: how-to-find-broken-links
 ---

--- a/public/uploads/rules/how-to-generate-maintenance-pages/rule.mdx
+++ b/public/uploads/rules/how-to-generate-maintenance-pages/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Discover how to generate maintenance pages efficiently using top
   code generators like NetTiers, AspDB, BLinQ, and ASP.NET Dynamic Data.
 title: Do you know how to generate maintenance pages?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: how-to-generate-maintenance-pages
 ---

--- a/public/uploads/rules/html-unicode-hex-codes/rule.mdx
+++ b/public/uploads/rules/html-unicode-hex-codes/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Master the art of adding special characters to your HTML code wi
 type: rule
 title: Do you use Unicode Hex codes for special HTML characters?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 uri: html-unicode-hex-codes
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/httphandlers-sections-in-webconfig-must-contain-a-clear-element/rule.mdx
+++ b/public/uploads/rules/httphandlers-sections-in-webconfig-must-contain-a-clear-element/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: If web.config contains a `<httpHandlers>` or `<httpModules>` sec
 title: Do you know 'httpHandlers' or 'httpModules' sections in web.config must contain
   a 'remove' or 'clear' element?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: httphandlers-sections-in-webconfig-must-contain-a-clear-element
 ---

--- a/public/uploads/rules/image-formats/rule.mdx
+++ b/public/uploads/rules/image-formats/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn the advantages and disadvantages of SVGs, PNGs, and JPGs t
   optimize your graphics for the right format.
 title: Do you know which format to use for web graphics?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: image-formats
 ---

--- a/public/uploads/rules/images-should-be-hosted-internally/rule.mdx
+++ b/public/uploads/rules/images-should-be-hosted-internally/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you make sure your images are hosted internally?
 uri: images-should-be-hosted-internally
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/improve-performance-with-lazy-loading-of-media-assets/rule.mdx
+++ b/public/uploads/rules/improve-performance-with-lazy-loading-of-media-assets/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Improve web page performance by loading media assets lazily, red
   initial load size and saving bandwidth for readers.
 title: Do you improve web page performance with lazy loading of media assets?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: improve-performance-with-lazy-loading-of-media-assets
 ---

--- a/public/uploads/rules/keep-website-loading-time-acceptable/rule.mdx
+++ b/public/uploads/rules/keep-website-loading-time-acceptable/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: Website performance matters! Optimize your site's load speed usi
 title: Do you keep your website loading time acceptable?
 categories:
   - category: categories/software-engineering/rules-to-better-application-performance.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: keep-website-loading-time-acceptable
 ---

--- a/public/uploads/rules/keep-your-databinder-eval-clean/rule.mdx
+++ b/public/uploads/rules/keep-your-databinder-eval-clean/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Keep your "DataBinder.Eval" clean by avoiding inline processing 
   the form or use the ItemDataBound event for more complex logic.
 title: Do you keep your "DataBinder.Eval" clean?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: keep-your-databinder-eval-clean
 ---

--- a/public/uploads/rules/last-updated-by/rule.mdx
+++ b/public/uploads/rules/last-updated-by/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you include a “Last Updated by” on your website?
 uri: last-updated-by
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Aman Kumar
     url: 'https://www.ssw.com.au/people/aman-kumar'

--- a/public/uploads/rules/make-your-site-easy-to-maintain/rule.mdx
+++ b/public/uploads/rules/make-your-site-easy-to-maintain/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Make your site easy to maintain by providing an 'Edit' link on e
   page for database-driven pages. This allows for quick and easy updates when needed.
 title: Do you make your site easy to maintain?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: make-your-site-easy-to-maintain
 ---

--- a/public/uploads/rules/manage-bundle-size/rule.mdx
+++ b/public/uploads/rules/manage-bundle-size/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Manage bundle size effectively and improve your web app's perfor
   by identifying and eliminating unnecessary NPM packages.
 title: Do you know the best ways to manage your bundle size?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: manage-bundle-size
 ---

--- a/public/uploads/rules/mdx-vs-markdown/rule.mdx
+++ b/public/uploads/rules/mdx-vs-markdown/rule.mdx
@@ -10,7 +10,7 @@ seoDescription: ' Learn when to use MDX for custom components and advanced funct
   regardless of the framework, versus sticking with Markdown for simplicity.'
 title: Do you know when to use MDX over Markdown?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: mdx-vs-markdown
 created: 2024-12-12T21:30:47-03:00

--- a/public/uploads/rules/monitor-google-keywords/rule.mdx
+++ b/public/uploads/rules/monitor-google-keywords/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Monitor Google keywords effectively to boost your online presenc
   and stay ahead of the competition with tools like Ahrefs or Semrush.
 title: Do you monitor Google keywords?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: monitor-google-keywords
 ---

--- a/public/uploads/rules/monitor-packages-for-vulnerabilities/rule.mdx
+++ b/public/uploads/rules/monitor-packages-for-vulnerabilities/rule.mdx
@@ -24,7 +24,7 @@ seoDescription: Monitor packages for vulnerabilities and ensure your application
 title: Do you monitor your application for vulnerabilities?
 categories:
   - category: categories/software-engineering/rules-to-better-code.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: monitor-packages-for-vulnerabilities
 ---

--- a/public/uploads/rules/name-webpages-consistently-with-database-tables/rule.mdx
+++ b/public/uploads/rules/name-webpages-consistently-with-database-tables/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Consistent page naming aligns database-driven pages with their c
   data tables, enhancing user experience and search engine optimization.
 title: Do you name web pages to be consistent with database tables?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: name-webpages-consistently-with-database-tables
 ---

--- a/public/uploads/rules/npm-packages-version-symbols/rule.mdx
+++ b/public/uploads/rules/npm-packages-version-symbols/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Learn the meaning of symbols like ^, ~, and * in npm versioning.
   how to select dependency versions wisely for stable and predictable JavaScript projects.
 title: Do you know what the different symbols mean for npm version?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: npm-packages-version-symbols

--- a/public/uploads/rules/npm-packages-version-symbols/rule.mdx
+++ b/public/uploads/rules/npm-packages-version-symbols/rule.mdx
@@ -12,7 +12,7 @@ seoDescription: Learn the meaning of symbols like ^, ~, and * in npm versioning.
 title: Do you know what the different symbols mean for npm version?
 categories:
   - category: categories/software-engineering/rules-to-better-websites-deployment.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: npm-packages-version-symbols
 ---

--- a/public/uploads/rules/optimise-favicon/rule.mdx
+++ b/public/uploads/rules/optimise-favicon/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Optimise your website favicon to ensure a seamless user experien
   any further adjustments!)
 title: Do you optimise your website favicon?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: optimise-favicon
 ---

--- a/public/uploads/rules/optimize-web-performance-nextjs/rule.mdx
+++ b/public/uploads/rules/optimize-web-performance-nextjs/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you optimize web performance in Next.js?
 uri: optimize-web-performance-nextjs
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
   - category: categories/software-engineering/rules-to-better-nextjs.mdx
 authors:
   - title: Josh Berman

--- a/public/uploads/rules/optimize-web-performance-nextjs/rule.mdx
+++ b/public/uploads/rules/optimize-web-performance-nextjs/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you optimize web performance in Next.js?
 uri: optimize-web-performance-nextjs
+seoDescription: Best practices for optimizing web performance in Next.js — rendering strategies, bundle size, and data fetching patterns to keep apps fast.
 categories:
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
   - category: categories/software-engineering/rules-to-better-nextjs.mdx

--- a/public/uploads/rules/optimize-your-images/rule.mdx
+++ b/public/uploads/rules/optimize-your-images/rule.mdx
@@ -21,8 +21,8 @@ seoDescription: Optimize your images to reduce website loading time and improve 
   experience by compressing files without sacrificing quality.
 title: Do you optimize images for web?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: optimize-your-images
 ---

--- a/public/uploads/rules/packages-to-add-to-your-mvc-project/rule.mdx
+++ b/public/uploads/rules/packages-to-add-to-your-mvc-project/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: New MVC projects require specific packages to ensure efficiency 
   scalability.
 title: Do you know which packages to add to new MVC projects?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: packages-to-add-to-your-mvc-project
 ---

--- a/public/uploads/rules/packages-up-to-date/rule.mdx
+++ b/public/uploads/rules/packages-up-to-date/rule.mdx
@@ -32,7 +32,7 @@ seoDescription: Keep your npm and yarn packages up to date to ensure your applic
   security and functionality.
 title: Do you keep your npm and Yarn packages up to date?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: packages-up-to-date
 ---

--- a/public/uploads/rules/page-owner/rule.mdx
+++ b/public/uploads/rules/page-owner/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Designate a page owner to ensure accuracy and accountability for
 title: Do you have a page owner for each webpage?
 categories:
   - category: categories/project-delivery/rules-to-better-pull-requests.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: page-owner
 ---

--- a/public/uploads/rules/perform-security-and-system-checks/rule.mdx
+++ b/public/uploads/rules/perform-security-and-system-checks/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Maintain server stability and security by keeping software updat
   running only necessary services, and monitoring system logs.
 title: Do you perform security and system checks?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: perform-security-and-system-checks
 ---

--- a/public/uploads/rules/precompile-your-asp-net-1-1-and-2-0-and-later-sites/rule.mdx
+++ b/public/uploads/rules/precompile-your-asp-net-1-1-and-2-0-and-later-sites/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Improve website reliability by precompiling ASP.NET sites to cat
   errors before they affect users.
 title: Do you precompile your ASP.NET 1.1 and 2.0+ sites?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: precompile-your-asp-net-1-1-and-2-0-and-later-sites
 ---

--- a/public/uploads/rules/progressive-web-app/rule.mdx
+++ b/public/uploads/rules/progressive-web-app/rule.mdx
@@ -24,7 +24,7 @@ seoDescription: Do you have a PWA (Progressive Web App)? Your application should
 title: Do you have a PWA (Progressive Web App)?
 categories:
   - category: categories/software-engineering/rules-to-better-apps-mobile.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: progressive-web-app
 ---

--- a/public/uploads/rules/provide-fresh-content/rule.mdx
+++ b/public/uploads/rules/provide-fresh-content/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Freshly updated website pages drive customer interest by providi
   DNN, Orchard, Sitefinity, Sitecore, Umbraco, or WordPress.
 title: Do you provide fresh content via CMS?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: provide-fresh-content
 ---

--- a/public/uploads/rules/provide-modern-contact-options/rule.mdx
+++ b/public/uploads/rules/provide-modern-contact-options/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Upgrade your site's CX with modern contact options like chat, Vo
 title: Do you provide modern contact options?
 categories:
   - category: categories/infrastructure-and-networking/rules-to-better-zendesk.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: provide-modern-contact-options
 ---

--- a/public/uploads/rules/purge-server-caches/rule.mdx
+++ b/public/uploads/rules/purge-server-caches/rule.mdx
@@ -18,7 +18,7 @@ redirects:
 seoDescription: Purge cache to ensure immediate changes on your WordPress site.
 title: Do you purge cache?
 categories:
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: purge-server-caches
 ---

--- a/public/uploads/rules/readable-screenshots/rule.mdx
+++ b/public/uploads/rules/readable-screenshots/rule.mdx
@@ -20,7 +20,7 @@ title: Do you make sure your screenshots are readable?
 categories:
   - category: categories/communication/rules-to-better-email.mdx
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: readable-screenshots
 ---

--- a/public/uploads/rules/release-build-your-web-applications-before-you-deploy-them/rule.mdx
+++ b/public/uploads/rules/release-build-your-web-applications-before-you-deploy-them/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Release build your web applications before deployment to optimiz
   resource caching.
 title: Do you release build your web applications before you deploy them?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: release-build-your-web-applications-before-you-deploy-them
 ---

--- a/public/uploads/rules/remove-the-debug-attribute-in-webconfig-compilation-element/rule.mdx
+++ b/public/uploads/rules/remove-the-debug-attribute-in-webconfig-compilation-element/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Remove the debug attribute in Web.config compilation element to 
   page execution and improve performance.
 title: Do you remove the debug attribute in Web.config compilation element?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: remove-the-debug-attribute-in-webconfig-compilation-element
 ---

--- a/public/uploads/rules/run-load-tests-on-your-website/rule.mdx
+++ b/public/uploads/rules/run-load-tests-on-your-website/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Ensure your website's performance and scalability under high loa
   with load testing, avoiding errors and downtime.
 title: Do you run load tests on your website?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: run-load-tests-on-your-website
 ---

--- a/public/uploads/rules/scoped-css/rule.mdx
+++ b/public/uploads/rules/scoped-css/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Learn when and how to use scoped CSS in frameworks like Blazor, 
 type: rule
 title: Do you know when to use scoped CSS?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 uri: scoped-css
 authors:
   - title: Jack Reimers

--- a/public/uploads/rules/self-contained-images-and-content/rule.mdx
+++ b/public/uploads/rules/self-contained-images-and-content/rule.mdx
@@ -15,8 +15,8 @@ tips: ''
 title: Do you keep your images and content self-contained in your TinaCMS +  Next.js
   project?
 categories:
-  - category: categories/software-engineering/rules-to-better-tinacms.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-tinacms.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: self-contained-images-and-content
 created: 2025-07-03T13:48:09+10:00

--- a/public/uploads/rules/set-language-on-code-blocks/rule.mdx
+++ b/public/uploads/rules/set-language-on-code-blocks/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Enhance your markdown by adding syntax highlighting to code bloc
   for improved readability and easier debugging.
 title: Do you set the language on code blocks?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: set-language-on-code-blocks
 ---

--- a/public/uploads/rules/sitemap-xml-best-practices/rule.mdx
+++ b/public/uploads/rules/sitemap-xml-best-practices/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Learn how to structure a sitemap.xml that search engines and aud
 title: Do you have a crawler-friendly sitemap.xml?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: sitemap-xml-best-practices
 ---

--- a/public/uploads/rules/streamline-development-with-npm-and-task-runners/rule.mdx
+++ b/public/uploads/rules/streamline-development-with-npm-and-task-runners/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Streamline your .NET development process with NPM and task runne
   eliminating tedious tasks and improving collaboration.
 title: Do you streamline your development process with NPM and Task Runners?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: streamline-development-with-npm-and-task-runners
 ---

--- a/public/uploads/rules/structured-website/rule.mdx
+++ b/public/uploads/rules/structured-website/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Organize your website structure to keep it clean and efficient w
   shopping cart pages, client login, reports, maintenance, and validation checks.
 title: Do you have a structured website?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: structured-website
 ---

--- a/public/uploads/rules/the-best-sample-applications/rule.mdx
+++ b/public/uploads/rules/the-best-sample-applications/rule.mdx
@@ -26,7 +26,7 @@ categories:
   - category: categories/software-engineering/rules-to-better-angular.mdx
   - category: categories/software-engineering/rules-to-better-mvc.mdx
   - category: categories/software-engineering/rules-to-better-net-projects.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: the-best-sample-applications
 ---

--- a/public/uploads/rules/the-right-technology/rule.mdx
+++ b/public/uploads/rules/the-right-technology/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: .NET MVC provides a better alternative to ASP.NET Web Forms with
   support.
 title: Do you use .NET MVC over ASP.NET Web Forms?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: the-right-technology
 ---

--- a/public/uploads/rules/the-steps-to-do-after-adding-a-page/rule.mdx
+++ b/public/uploads/rules/the-steps-to-do-after-adding-a-page/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: After adding a website page, follow these steps to keep your con
   Repeat steps 2-3 until all green ticks.
 title: Do you know the steps to do after adding a website page?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: the-steps-to-do-after-adding-a-page
 ---

--- a/public/uploads/rules/uri-url-slug/rule.mdx
+++ b/public/uploads/rules/uri-url-slug/rule.mdx
@@ -3,7 +3,7 @@ title: 'Do you know the difference between a URI, URL, and slug?'
 uri: uri-url-slug
 categories:
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
+++ b/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Boost SEO by using 301 redirects to redirect renamed or moved pa
 title: Technical - Do you use "301" code to redirect renamed or moved pages?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
   - category: categories/software-engineering/rules-to-better-wordpress.mdx
 type: rule
 uri: use-301-redirect-on-renamed-or-moved-pages

--- a/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
+++ b/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
@@ -21,7 +21,7 @@ title: Technical - Do you use "301" code to redirect renamed or moved pages?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
   - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-wordpress.mdx
+  - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: use-301-redirect-on-renamed-or-moved-pages
 ---

--- a/public/uploads/rules/use-css-validation-service-to-check-your-css-file/rule.mdx
+++ b/public/uploads/rules/use-css-validation-service-to-check-your-css-file/rule.mdx
@@ -17,8 +17,8 @@ seoDescription: Check your CSS files against W3C recommendations and ensure a va
   and clean webpage with CSS Validation Service.
 title: Do you use CSS Validation Service to check your CSS file?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-css-validation-service-to-check-your-css-file
 ---

--- a/public/uploads/rules/use-dynamic-viewport-units/rule.mdx
+++ b/public/uploads/rules/use-dynamic-viewport-units/rule.mdx
@@ -12,7 +12,7 @@ seoDescription: Are you leveraging dynamic viewport units? They ensure your webs
 title: Do you use dynamic viewport units?
 categories:
   - category: categories/software-engineering/rules-to-better-apps-mobile.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-dynamic-viewport-units
 ---

--- a/public/uploads/rules/use-google-analytics/rule.mdx
+++ b/public/uploads/rules/use-google-analytics/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Install and review Google Analytics to see how people find and u
 title: Do you collect and analyze website data with Google Analytics?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-analytics-reports.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
   - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: use-google-analytics

--- a/public/uploads/rules/use-google-analytics/rule.mdx
+++ b/public/uploads/rules/use-google-analytics/rule.mdx
@@ -21,7 +21,7 @@ title: Do you collect and analyze website data with Google Analytics?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-analytics-reports.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
-  - category: categories/software-engineering/rules-to-better-websites-tuning-and-maintenance.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
 type: rule
 uri: use-google-analytics
 ---

--- a/public/uploads/rules/use-heading-tags-h1-h2-h3/rule.mdx
+++ b/public/uploads/rules/use-heading-tags-h1-h2-h3/rule.mdx
@@ -25,7 +25,7 @@ lastUpdated: 2025-12-18T00:59:32.741Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 ---
 
 You should understand the hierarchy and try to use the heading tags (\<H1>, \<H2> or \<H3>...) for titles and subtitles.

--- a/public/uploads/rules/use-jquery-instead-of-javascript/rule.mdx
+++ b/public/uploads/rules/use-jquery-instead-of-javascript/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Use jQuery's powerful and cross-browser compatible syntax to sim
 title: Do you use jQuery instead of JavaScript?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-jquery-instead-of-javascript
 ---

--- a/public/uploads/rules/use-link-auditor/rule.mdx
+++ b/public/uploads/rules/use-link-auditor/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Analyze your website's performance and identify bad links with S
   Link Auditor, a tool that offers comprehensive site analysis.
 title: Do you use Link Auditor to tell you about bad links?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-link-auditor
 ---

--- a/public/uploads/rules/use-markup-validation-service-to-check-your-html-code/rule.mdx
+++ b/public/uploads/rules/use-markup-validation-service-to-check-your-html-code/rule.mdx
@@ -16,8 +16,8 @@ redirects:
 seoDescription: Use Markup Validation Service to check your HTML and XHTML code.
 title: Do you use Markup Validation Service to check your HTML and XHTML code?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-markup-validation-service-to-check-your-html-code
 ---

--- a/public/uploads/rules/use-nextjs-caching-system/rule.mdx
+++ b/public/uploads/rules/use-nextjs-caching-system/rule.mdx
@@ -10,7 +10,7 @@ tips: ''
 title: Do you know how to use NextJS caching system?
 categories:
   - category: categories/software-engineering/rules-to-better-nextjs.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-nextjs-caching-system
 created: 2025-04-25T10:53:02+02:00

--- a/public/uploads/rules/use-open-graph/rule.mdx
+++ b/public/uploads/rules/use-open-graph/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Microsoft Azure | SSW Consulting - Sydney, Brisbane, Melbourne -
   how your links are shared with Open Graph protocol.
 title: Do you use Open Graph to control how your links are shared?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-open-graph
 ---

--- a/public/uploads/rules/use-right-site-search-for-your-website/rule.mdx
+++ b/public/uploads/rules/use-right-site-search-for-your-website/rule.mdx
@@ -12,7 +12,7 @@ seoDescription: Find the best search tool for your website! Learn about Algolia,
   the one that's right for you. It's important for happy users and easy browsing
 title: Do you use the right site search for your website?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-right-site-search-for-your-website
 ---

--- a/public/uploads/rules/use-server-side-comments/rule.mdx
+++ b/public/uploads/rules/use-server-side-comments/rule.mdx
@@ -17,8 +17,8 @@ seoDescription: Server-side commenting in ASP.NET allows efficient comment usage
   preserving page performance and reducing kilobytes.
 title: Do you use server side comments?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-server-side-comments
 ---

--- a/public/uploads/rules/use-sso-for-your-websites/rule.mdx
+++ b/public/uploads/rules/use-sso-for-your-websites/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Many companies benefit from Single Sign-On (SSO) technology, all
   users to log in once and stay authenticated across multiple web applications.
 title: Do you use SSO (Single sign-on) for your websites?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: use-sso-for-your-websites
 ---

--- a/public/uploads/rules/use-web-compiler/rule.mdx
+++ b/public/uploads/rules/use-web-compiler/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Use Visual Studio's Web Compiler extension to compile CSS files 
 title: Do you use Web Compiler extension?
 categories:
   - category: categories/project-delivery/rules-to-better-continuous-deployment-with-tfs.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-web-compiler
 ---

--- a/public/uploads/rules/use-windows-integrated-authentication/rule.mdx
+++ b/public/uploads/rules/use-windows-integrated-authentication/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Windows Integrated Authentication streamlines sign-ins by levera
   existing domain credentials, eliminating manual login requirements.
 title: Do you use Windows Integrated Authentication?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: use-windows-integrated-authentication
 ---

--- a/public/uploads/rules/using-markdown-to-store-your-content/rule.mdx
+++ b/public/uploads/rules/using-markdown-to-store-your-content/rule.mdx
@@ -28,7 +28,7 @@ seoDescription: Discover why storing content in Markdown offers a cleaner, more 
 title: Do you use Markdown to store your content?
 categories:
   - category: categories/software-engineering/rules-to-better-markdown.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: using-markdown-to-store-your-content
 ---

--- a/public/uploads/rules/web-ui-libraries/rule.mdx
+++ b/public/uploads/rules/web-ui-libraries/rule.mdx
@@ -21,7 +21,7 @@ title: Do you use the best Web UI libraries?
 categories:
   - category: categories/software-engineering/rules-to-better-architecture-and-code-review.mdx
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: web-ui-libraries
 ---

--- a/public/uploads/rules/when-anchor-should-run-at-server/rule.mdx
+++ b/public/uploads/rules/when-anchor-should-run-at-server/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Anchor tags should run at server only when needed to change targ
   at runtime, avoiding unnecessary overhead.
 title: Do you know when anchor should "run at server"?
 categories:
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
 type: rule
 uri: when-anchor-should-run-at-server
 ---

--- a/public/uploads/rules/where-to-find-nice-icons/rule.mdx
+++ b/public/uploads/rules/where-to-find-nice-icons/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Discover a wide range of high-quality icons from reputable sourc
   such as Icon Finder, Metro Studio, IcoMoon, FontAwesome, and Glyphicons.
 title: Do you know where you can find some nice icons?
 categories:
-  - category: categories/software-engineering/rules-to-better-websites-graphics.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx
 type: rule
 uri: where-to-find-nice-icons
 ---

--- a/public/uploads/rules/why-choose-dot-net-core/rule.mdx
+++ b/public/uploads/rules/why-choose-dot-net-core/rule.mdx
@@ -18,8 +18,8 @@ seoDescription: Develop a cross-platform .NET Core application that runs on macO
 title: Do you know why you choose .NET Core?
 categories:
   - category: categories/software-engineering/rules-to-better-net-core.mdx
-  - category: categories/software-engineering/rules-to-better-website-development-asp-net.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: why-choose-dot-net-core
 ---

--- a/public/uploads/rules/why-nextjs-is-great/rule.mdx
+++ b/public/uploads/rules/why-nextjs-is-great/rule.mdx
@@ -4,7 +4,7 @@ title: Do you know why Next.js is great?
 uri: why-nextjs-is-great
 categories:
   - category: categories/software-engineering/rules-to-better-nextjs.mdx
-  - category: categories/software-engineering/rules-to-better-websites-development.mdx
+  - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 authors:
   - title: Piers Sinclair
     url: 'https://www.ssw.com.au/people/piers-sinclair'


### PR DESCRIPTION
## Summary

[PR #12554](https://github.com/SSWConsulting/SSW.Rules.Content/pull/12554) (2026-04-30) moved 8 categories from `categories/software-engineering/` to `categories/websites-and-cms/` via `git mv`, but the `categories:` arrays inside ~150 `public/uploads/rules/<slug>/rule.mdx` files were not updated. Tina's GraphQL resolver could no longer follow those references, surfacing as `Unable to find record categories/software-engineering/rules-to-better-*.mdx` errors.

This caused:
- `https://www.ssw.com.au/rules/` returning **HTTP 500** at runtime (homepage's `fetchActivityLatestRules` in `app/(home)/page.tsx` had no fallback)
- The same errors logged repeatedly during static generation in the SSW.Rules production deploy

This PR rewrites every stale reference under `public/uploads/rules/` to point at the new `websites-and-cms/` paths.

### Categories addressed (all 8 from PR #12554)

| Category | Rule files updated |
|---|---|
| `rules-to-better-tinacms` | (commit 1) |
| `rules-to-better-website-development-asp-net` | (commit 1) |
| `rules-to-better-websites-development` | (commit 1) |
| `rules-to-better-websites-graphics` | 22 |
| `rules-to-better-websites-tuning-and-maintenance` | 10 |
| `rules-to-better-wordpress` | 7 |
| `rules-to-better-websites-deployment` | 7 |
| `rules-to-better-sitefinity` | 5 |

After this PR, `grep -rE "categories/software-engineering/(rules-to-better-tinacms|rules-to-better-website-development-asp-net|rules-to-better-websites-development|rules-to-better-websites-graphics|rules-to-better-websites-tuning-and-maintenance|rules-to-better-wordpress|rules-to-better-websites-deployment|rules-to-better-sitefinity)\.mdx" public/uploads/rules` returns 0 matches.


## Follow-up (separate PR, in `SSW.Rules`)

The homepage 500 only happened because `app/(home)/page.tsx` doesn't catch errors from `fetchActivityLatestRules` / `fetchRuleCount`. Adding fallbacks there (matching the existing `.catch(() => null)` on `fetchDiscussionData`) is recommended so a single bad reference can never take the whole homepage down again.
