### PR TITLE
Add Test Please reply examples (pass, pass with changes, fail)

### DIFF
--- a/public/uploads/rules/conduct-a-test-please/rule.mdx
+++ b/public/uploads/rules/conduct-a-test-please/rule.mdx
@@ -103,15 +103,15 @@ The reply is the official sign-off that lets the developer deploy. There are 3 p
 
 **✅ Test Passed**
 
-No critical bugs found - you are ready to deploy {{ PRODUCT }} {{ VERSION }} to production.
+No critical bugs found - you are ready to deploy &#123;&#123; PRODUCT &#125;&#125; &#123;&#123; VERSION &#125;&#125; to production.
 
 Tested:
 
-* {{ FEATURE }}
-* {{ FEATURE }}
+* &#123;&#123; FEATURE &#125;&#125;
+* &#123;&#123; FEATURE &#125;&#125;
 
 Regards,\
-{{ Client }}
+&#123;&#123; Client &#125;&#125;
 
   </>}
   figurePrefix="good"
@@ -131,11 +131,11 @@ Once these bugs are fixed we are ready to go live.
 
 PBIs:
 
-* {{ GITHUB ISSUE LINK }}
-* {{ GITHUB ISSUE LINK }}
+* &#123;&#123; GITHUB ISSUE LINK &#125;&#125;
+* &#123;&#123; GITHUB ISSUE LINK &#125;&#125;
 
 Regards,\
-{{ Client }}
+&#123;&#123; Client &#125;&#125;
 
   </>}
   figurePrefix="ok"

--- a/public/uploads/rules/conduct-a-test-please/rule.mdx
+++ b/public/uploads/rules/conduct-a-test-please/rule.mdx
@@ -90,6 +90,58 @@ If you created a video, you should conduct a ["Test Please" for videos](/test-pl
 
 If you are doing anything else (e.g. creating a new blog post, updating a Word document, or preparing a PowerPoint presentation), you should still get a 2nd set of eyes to check the work and document it somewhere. You can do that via a PBI (ideally) or email (if there is no backlog).
 
+## Replying to a "Test Please"
+
+The reply is the official sign-off that lets the developer deploy. There are 3 possible outcomes:
+
+
+<boxEmbed
+  style="greybox"
+  body={<>
+
+### Hi Brady
+
+**✅ Test Passed**
+
+No critical bugs found - you are ready to deploy {{ PRODUCT }} {{ VERSION }} to production.
+
+Tested:
+
+* {{ FEATURE }}
+* {{ FEATURE }}
+
+Regards,\
+{{ Client }}
+
+  </>}
+  figurePrefix="good"
+  figure="Good example - A clean pass gives the developer the green light to deploy"
+/>
+
+
+<boxEmbed
+  style="greybox"
+  body={<>
+
+### Hi Brady
+
+**⚠️ Test Passed with changes**
+
+Once these bugs are fixed we are ready to go live.
+
+PBIs:
+
+* {{ GITHUB ISSUE LINK }}
+* {{ GITHUB ISSUE LINK }}
+
+Regards,\
+{{ Client }}
+
+  </>}
+  figurePrefix="ok"
+  figure="OK example - A conditional pass - small bugs are tracked as PBIs and must be fixed before deploy"
+/>
+
 
 <boxEmbed
   style="greybox"
@@ -105,7 +157,7 @@ If you are doing anything else (e.g. creating a new blog post, updating a Word d
 
   </>}
   figurePrefix="good"
-  figure="Sometimes it's good to soften the blow with some humour when you have to fail a &quot;test please&quot; email"
+  figure="Good example - Sometimes it's good to soften the blow with some humour when you have to fail a &quot;test please&quot; email"
 />
 
 

--- a/public/uploads/rules/conduct-a-test-please/rule.mdx
+++ b/public/uploads/rules/conduct-a-test-please/rule.mdx
@@ -48,8 +48,8 @@ uri: conduct-a-test-please
 
 <imageEmbed
   alt="Image"
-  size="large"
-  showBorder={false}
+  size="medium"
+  showBorder={true}
   figurePrefix="none"
   figure="Do you want users to have a good first impression?"
   src="/uploads/rules/conduct-a-test-please/good-first-impressions.png"
@@ -71,12 +71,12 @@ uri: conduct-a-test-please
 
 ## Coding
 
-If you are writing code, your Pull Request (PR) review is your "Test Please"
+If you are writing code, the Pull Request (PR) review is your "Test Please".
 
 **Tips:**
 
 * You should do an [over the shoulder PR review](/over-the-shoulder)
-* Embrace proactive testing – If you anticipate potential feedback on the User eXperience (UX) after your code is merged and deployed, ensure it is tested by a team member in the development environment. This will save tears when it reaches production
+* Embrace proactive testing – If you anticipate potential feedback on the User Experience (UX) after your code is merged and deployed, ensure it is tested by a team member in the development environment. This will save tears when it reaches production
 
 ## Emails
 
@@ -103,15 +103,15 @@ The reply is the official sign-off that lets the developer deploy. There are 3 p
 
 **✅ Test Passed**
 
-No critical bugs found - you are ready to deploy &#123;&#123; PRODUCT &#125;&#125; &#123;&#123; VERSION &#125;&#125; to production.
+No critical bugs found - you are ready to deploy MyApp v1.11 to production.
 
 Tested:
 
-* &#123;&#123; FEATURE &#125;&#125;
-* &#123;&#123; FEATURE &#125;&#125;
+* User login flow
+* Reports dashboard
 
 Regards,\
-&#123;&#123; Client &#125;&#125;
+Gary
 
   </>}
   figurePrefix="good"
@@ -131,15 +131,15 @@ Once these bugs are fixed we are ready to go live.
 
 PBIs:
 
-* &#123;&#123; GITHUB ISSUE LINK &#125;&#125;
-* &#123;&#123; GITHUB ISSUE LINK &#125;&#125;
+* [#1234 - Date picker doesn't accept manual input](https://github.com/myorg/myrepo/issues/1234)
+* [#1237 - Export button label is truncated](https://github.com/myorg/myrepo/issues/1237)
 
 Regards,\
-&#123;&#123; Client &#125;&#125;
+Gary
 
   </>}
-  figurePrefix="ok"
-  figure="OK example - A conditional pass - small bugs are tracked as PBIs and must be fixed before deploy"
+  figurePrefix="good"
+  figure="Good example - A conditional pass - small bugs are tracked as PBIs and must be fixed before deploy"
 />
 
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

About to deploy to prod and realised there's no official "looks good to deploy" reply example in the rule. The existing **[Do you conduct a Test Please?](https://www.ssw.com.au/rules/conduct-a-test-please)** rule has a "Test failed" example but no matching "Test passed" example — leaving developers without a clear template to send to clients.

> 2. What was changed?

Added a new **"Replying to a Test Please"** section to `conduct-a-test-please` with 3 side-by-side reply examples covering every outcome:

* ✅ **Test Passed** — clean pass, ready to deploy (`figurePrefix="good"`)
* ⚠️ **Test Passed with changes** — conditional pass, bugs tracked as PBIs (`figurePrefix="ok"`)
* ❌ **Test failed** — existing example, retained (`figurePrefix="good"`)

> 3. I paired or mob programmed with: 

Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)