### PR TITLE
Move user authentication terms rule to dedicated category

### DIFF
--- a/categories/communication/rules-to-better-technical-documentation.mdx
+++ b/categories/communication/rules-to-better-technical-documentation.mdx
@@ -33,7 +33,6 @@ index:
   - rule: public/uploads/rules/commas-and-full-stops-always-should-have-1-space-after-them/rule.mdx
   - rule: public/uploads/rules/dashes/rule.mdx
   - rule: public/uploads/rules/use-lowercase-after-a-dash/rule.mdx
-  - rule: public/uploads/rules/user-authentication-terms/rule.mdx
   - rule: public/uploads/rules/use-will-not-should/rule.mdx
   - rule: public/uploads/rules/use-try-again-instead-of-retry/rule.mdx
   - rule: public/uploads/rules/use-bad-and-good-examples/rule.mdx

--- a/categories/design/rules-to-better-interfaces-forms.mdx
+++ b/categories/design/rules-to-better-interfaces-forms.mdx
@@ -14,7 +14,6 @@ index:
   - rule: public/uploads/rules/required-fields-validation/rule.mdx
   - rule: public/uploads/rules/use-adaptive-placeholders-on-your-forms/rule.mdx
   - rule: public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
-  - rule: public/uploads/rules/user-authentication-terms/rule.mdx
   - rule: public/uploads/rules/do-you-have-a-label-tag-for-the-fields-associated-with-your-input/rule.mdx
   - rule: public/uploads/rules/forms-do-you-include-the-number-of-results-in-comboboxes/rule.mdx
   - rule: public/uploads/rules/create-a-combo-box-that-has-a-custom-template/rule.mdx

--- a/categories/design/rules-to-better-user-authentication.mdx
+++ b/categories/design/rules-to-better-user-authentication.mdx
@@ -5,6 +5,7 @@ uri: rules-to-better-user-authentication
 guid: 4424a1af-acc8-4a79-ba75-e335783bb219
 seoDescription: Best practices for user authentication UX, including sign-in screens, password management, session handling, and logout flows.
 index:
+  - rule: public/uploads/rules/user-authentication-terms/rule.mdx
   - rule: public/uploads/rules/authentication-do-you-have-a-user-friendly-registration-and-sign-in-screen/rule.mdx
   - rule: public/uploads/rules/authentication-do-you-use-email-address-instead-of-user-name/rule.mdx
   - rule: public/uploads/rules/forgot-password/rule.mdx

--- a/public/uploads/rules/user-authentication-terms/rule.mdx
+++ b/public/uploads/rules/user-authentication-terms/rule.mdx
@@ -18,8 +18,7 @@ seoDescription: Use intuitive user authentication terms to enhance your applicat
   user experience with sign-in and registration options.
 title: Do you use right terms for user authentication?
 categories:
-  - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/design/rules-to-better-interfaces-forms.mdx
+  - category: categories/design/rules-to-better-user-authentication.mdx
 type: rule
 uri: user-authentication-terms
 ---


### PR DESCRIPTION
> 1. What triggered this change?

Reorganization of rule categories to better reflect content structure and improve discoverability.

> 2. What was changed?

- Moved the "user-authentication-terms" rule from two categories (technical documentation and interface forms) to a dedicated "rules-to-better-user-authentication" category
- Updated the rule's frontmatter to reference only the new user authentication category
- Removed the rule reference from `categories/communication/rules-to-better-technical-documentation.mdx`
- Removed the rule reference from `categories/design/rules-to-better-interfaces-forms.mdx`
- Added the rule reference to `categories/design/rules-to-better-user-authentication.mdx`

This change consolidates user authentication-related rules into a single, focused category for better organization and user experience.

> 3. I paired or mob programmed with:

ClaudeCode

https://claude.ai/code/session_01YTS4zqP75FYhd4ykZyUMcQ