### PR TITLE
📝 Add Lucidchart and Excalidraw to architecture diagram alternatives

### DIFF
--- a/public/uploads/rules/architecture-diagram/rule.mdx
+++ b/public/uploads/rules/architecture-diagram/rule.mdx
@@ -282,6 +282,14 @@ Another popular tool is [Eraser](https://app.eraser.io/) which provide many indu
 
 If you really want to geek out and use markdown, you can try [Mermaid](https://mermaid.live) to build simple diagrams.
 
+#### Lucidchart
+
+[Lucidchart](https://www.lucid.app/) is a popular cloud-based diagramming tool with a large library of templates and shape libraries for AWS, Azure, and GCP architecture icons. It's a strong choice if your team is already in the Lucid ecosystem (e.g. using Lucidspark for whiteboarding).
+
+#### Excalidraw
+
+[Excalidraw](https://excalidraw.com/) is a free, open-source tool with a distinctive hand-drawn aesthetic. It's great for quick sketches and live collaboration when you want a diagram to feel approachable rather than formal, and the [excalidraw-libraries](https://libraries.excalidraw.com/) include cloud architecture icon packs.
+
 ## Tip 9: Exporting diagrams
 
 To export your diagram, go to **File | Export as | PNG**.


### PR DESCRIPTION
## TL;DR

The [Do you have an architecture diagram?](https://www.ssw.com.au/rules/architecture-diagram/) rule lists Eraser, Miro, and Mermaid as alternatives to draw.io but omits two of the most widely used diagramming tools. Adds Lucidchart and Excalidraw entries to the existing "Alternatives to draw.io" subsection.

## How

Appended two short entries (matching the style of the existing Eraser/Miro/Mermaid entries) under Tip 8's "Alternatives to draw.io" subsection:

- **Lucidchart** - cloud-based, has AWS/Azure/GCP icon libraries, good for teams already in the Lucid ecosystem
- **Excalidraw** - free, open-source, hand-drawn aesthetic, with cloud architecture icon packs via excalidraw-libraries

## Reviewer notes

- **Placement.** Added to the existing "Alternatives to draw.io" subsection rather than a new section at the end; this keeps all alternatives in one place.
- **No frontmatter changes.** Content-only edit; `lastUpdated` will be set by the existing automation.