### PR TITLE
public/uploads/rules/stick to-the-agenda-and-complete-the-meetings-goal/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: 'During a meeting, sticking to the agenda and completing the goa
 created: 2021-07-29T17:55:26.790Z
 createdBy: 'Tiago Araújo [SSW]'
 createdByEmail: tiagov8@gmail.com
-lastUpdated: 2026-06-04T23:11:05.207Z
+lastUpdated: 2026-06-05T00:02:31.626Z
 lastUpdatedBy: 'Adam Cogan [SSW]'
 lastUpdatedByEmail: AdamCogan@ssw.com.au
 isArchived: false
@@ -42,7 +42,7 @@ Capture side issues separately instead of letting them take over the meeting. St
 * Put important or mentally demanding items near the start, while people are fresh
 * Refer to the agenda from time-to-time. Early topics should build alignment, then handle difficult topics, and try to end on something that brings the group together
 * Keep urgent but low-value topics timeboxed
-* Add a break if the meeting is longer than an hour or two
+* For long meetings, add a break at each hour mark 
 * End with a [quick Retro](https://www.ssw.com.au/rules/do-a-retrospective) to check whether the meeting stayed on track and what could be improved next time
 
 A good meeting should stay aligned with the agenda, respect everyone’s time, and end with clear outcomes.

--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -18,14 +18,14 @@ seoDescription: 'During a meeting, sticking to the agenda and completing the goa
 created: 2021-07-29T17:55:26.790Z
 createdBy: 'Tiago Araújo [SSW]'
 createdByEmail: tiagov8@gmail.com
-lastUpdated: 2026-06-04T22:58:04.970Z
-lastUpdatedBy: Tiago Araujo
-lastUpdatedByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-04T23:05:05.585Z
+lastUpdatedBy: 'Adam Cogan [SSW]'
+lastUpdatedByEmail: AdamCogan@ssw.com.au
 isArchived: false
 archivedreason: null
 ---
 
-Any good meeting has a clear goal and follow [an agenda](/share-the-agenda).
+Any good meeting has a clear goal and follows [an agenda](/share-the-agenda).
 
 <endIntro />
 

--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -1,51 +1,47 @@
 ---
-archivedreason: null
-authors:
-- title: Ulysses Maclaren
-  url: https://www.ssw.com.au/people/ulysses-maclaren
-- title: Adam Cogan
-  url: https://www.ssw.com.au/people/adam-cogan
-created: 2021-07-29 17:55:26.790000+00:00
-createdBy: Tiago Araújo [SSW]
-createdByEmail: tiagov8@gmail.com
-guid: 02d4ed58-d19d-4895-ba49-55dae5a11f5b
-isArchived: false
-lastUpdated: 2021-07-29 17:55:26.790000+00:00
-lastUpdatedBy: Tiago Araújo [SSW]
-lastUpdatedByEmail: tiagov8@gmail.com
-seoDescription: During a meeting, sticking to the agenda and completing the goal requires
-  careful planning, prioritization, and time management.
-title: Do you stick to the agenda and complete the meeting's goal?
+type: rule
+title: Do you stick to the agenda and achieve the meeting goal?
+uri: stick-to-the-agenda-and-complete-the-meetings-goal
 categories:
   - category: categories/communication/rules-to-better-meetings.mdx
-type: rule
-uri: stick-to-the-agenda-and-complete-the-meetings-goal
+authors:
+  - title: Ulysses Maclaren
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+  - title: Adam Cogan
+    url: 'https://www.ssw.com.au/people/adam-cogan'
+related:
+  - rule: public/uploads/rules/great-meetings/rule.mdx
+  - rule: public/uploads/rules/share-the-agenda/rule.mdx
+  - rule: public/uploads/rules/make-sure-the-meeting-needs-to-exist/rule.mdx
+guid: 02d4ed58-d19d-4895-ba49-55dae5a11f5b
+seoDescription: 'During a meeting, sticking to the agenda and completing the goal requires careful planning, prioritization, and time management.'
+created: 2021-07-29T17:55:26.790Z
+createdBy: 'Tiago Araújo [SSW]'
+createdByEmail: tiagov8@gmail.com
+lastUpdated: 2026-06-03T22:31:54.565Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
+isArchived: false
+archivedreason: null
 ---
 
-Any good meeting has a clear goal, and an agenda that breaks that goal up into items that are “For information,” “For discussion,” or “For decision”.
+Any good meeting has a clear goal and follow [an agenda](/share-the-agenda). 
 
 <endIntro />
 
-A few other ways to make the most of the attendees' time would be:
+Capture side issues separately instead of letting them take over the meeting. Start by agreeing how side issues will be handled, for example:
 
-- The early part of a meeting tends to be more lively and creative than the end of it, so if an item needs mental energy, bright ideas, and clear heads, put it high up on the list
-- Start with the low hanging fruit so you get some decisions made
-- Keep the important topics closer to the front, than the end
-- Some items unite the meeting while others divide the members. The leader may want to start with unity before entering into division, or they may prefer the other way around. The point is to be aware of the choice and to make it consciously. It is always a good idea to end the meeting on a unifying item
-- Don't get side-tracked for too long by urgent, but not important, items. Keep non-important topics timeboxed
-- If your meeting is more than an hour or two, consider adding a break
-- To improve future meetings, at the end of the meeting, do [a quick debrief (aka Retro)](/do-a-retrospective) to see how long the meeting took, if anything was covered that didn't need to be, etc.
+> “Who will be the scribe so we can capture side issues? Let’s aim to stay on track and avoid rat holes.”
 
+<imageEmbed alt="Image" size="small" showBorder={true} figurePrefix="none" figure="Rat holes are where meeting goals go to disappear" src="/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rathole.jpeg" />
 
-<boxEmbed
-  style="greybox"
-  body={<>
-    ⭐ **Tip:** A meeting is better without going down rat holes... Start a meeting with:
-_“Who will be the scribe so we can take notes of side issues? Let’s aim to keep on track and avoid rat holes”_
+## Keep the meeting effective
 
-![Figure: Don't go down rat holes](/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rathole.jpeg)
+* Put important or mentally demanding items near the start, while people are fresh
+* Start with a few quick wins to build momentum and get decisions made
+* Order the agenda intentionally. Start with topics that build alignment, handle difficult topics carefully, and try to end on something that brings the group together
+* Keep urgent but low-value topics timeboxed
+* Add a break if the meeting is longer than an hour or two
+* End with a [quick debrief or Retro](https://www.ssw.com.au/rules/do-a-retrospective) to check whether the meeting stayed on track and what could be improved next time
 
-  </>}
-  figurePrefix="none"
-  figure=""
-/>
+A good meeting should stay aligned with the agenda, respect everyone’s time, and end with clear outcomes.

--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: 'During a meeting, sticking to the agenda and completing the goa
 created: 2021-07-29T17:55:26.790Z
 createdBy: 'Tiago Araújo [SSW]'
 createdByEmail: tiagov8@gmail.com
-lastUpdated: 2026-06-04T23:07:27.214Z
+lastUpdated: 2026-06-04T23:11:05.207Z
 lastUpdatedBy: 'Adam Cogan [SSW]'
 lastUpdatedByEmail: AdamCogan@ssw.com.au
 isArchived: false
@@ -31,17 +31,18 @@ Any good meeting has a clear goal and follows [an agenda](/share-the-agenda).
 
 Capture side issues separately instead of letting them take over the meeting. Start by agreeing side issues will be [moved to the parking lot or handled by a scribe](https://www.ssw.com.au/rules/creating-action-items).
 
+> Start the meeting with a question:\
 > “Who will be the scribe so we can capture side issues? Let’s aim to stay on track and avoid rat holes.”
 
 <imageEmbed alt="Image" size="small" showBorder={true} figurePrefix="none" figure="Rat holes are where meeting goals go to disappear" src="/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rathole.jpeg" />
 
 ## Keep the meeting effective
 
+* Start with a couple of easy quick wins to build momentum and get decisions made
 * Put important or mentally demanding items near the start, while people are fresh
-* Start with a few quick wins to build momentum and get decisions made
-* Order the agenda intentionally. Start with topics that build alignment, handle difficult topics carefully, and try to end on something that brings the group together
+* Refer to the agenda from time-to-time. Early topics should build alignment, then handle difficult topics, and try to end on something that brings the group together
 * Keep urgent but low-value topics timeboxed
 * Add a break if the meeting is longer than an hour or two
-* End with a [quick debrief or Retro](https://www.ssw.com.au/rules/do-a-retrospective) to check whether the meeting stayed on track and what could be improved next time
+* End with a [quick Retro](https://www.ssw.com.au/rules/do-a-retrospective) to check whether the meeting stayed on track and what could be improved next time
 
 A good meeting should stay aligned with the agenda, respect everyone’s time, and end with clear outcomes.

--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: 'During a meeting, sticking to the agenda and completing the goa
 created: 2021-07-29T17:55:26.790Z
 createdBy: 'Tiago Araújo [SSW]'
 createdByEmail: tiagov8@gmail.com
-lastUpdated: 2026-06-04T23:05:05.585Z
+lastUpdated: 2026-06-04T23:07:27.214Z
 lastUpdatedBy: 'Adam Cogan [SSW]'
 lastUpdatedByEmail: AdamCogan@ssw.com.au
 isArchived: false
@@ -29,7 +29,7 @@ Any good meeting has a clear goal and follows [an agenda](/share-the-agenda).
 
 <endIntro />
 
-Capture side issues separately instead of letting them take over the meeting. Start by agreeing side issues will be [handled by a scribe](https://www.ssw.com.au/rules/creating-action-items).
+Capture side issues separately instead of letting them take over the meeting. Start by agreeing side issues will be [moved to the parking lot or handled by a scribe](https://www.ssw.com.au/rules/creating-action-items).
 
 > “Who will be the scribe so we can capture side issues? Let’s aim to stay on track and avoid rat holes.”
 

--- a/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+++ b/public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
@@ -18,18 +18,18 @@ seoDescription: 'During a meeting, sticking to the agenda and completing the goa
 created: 2021-07-29T17:55:26.790Z
 createdBy: 'Tiago Araújo [SSW]'
 createdByEmail: tiagov8@gmail.com
-lastUpdated: 2026-06-03T22:31:54.565Z
+lastUpdated: 2026-06-04T22:58:04.970Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 isArchived: false
 archivedreason: null
 ---
 
-Any good meeting has a clear goal and follow [an agenda](/share-the-agenda). 
+Any good meeting has a clear goal and follow [an agenda](/share-the-agenda).
 
 <endIntro />
 
-Capture side issues separately instead of letting them take over the meeting. Start by agreeing how side issues will be handled, for example:
+Capture side issues separately instead of letting them take over the meeting. Start by agreeing side issues will be [handled by a scribe](https://www.ssw.com.au/rules/creating-action-items).
 
 > “Who will be the scribe so we can capture side issues? Let’s aim to stay on track and avoid rat holes.”
 


### PR DESCRIPTION
cc @Levijj22 @uly1 @cameronshawssw 

as per @adamcogan 's email: **Re: Cameron at SSW**

Tiago was asked to review and mark this rule /10

6/10

- No reason for the tagging “for info/discussion/decision” + the tip to be separated from the other instructions
- List items are repetitive
- Tip box is using an inconsistent star in a grey box instead of the tip box
- Unnecessarily huge image 