### PR TITLE
public/uploads/rules/easy to-view-screen-recordings/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/easy-to-view-screen-recordings/rule.mdx
+++ b/public/uploads/rules/easy-to-view-screen-recordings/rule.mdx
@@ -1,59 +1,54 @@
 ---
-archivedreason: null
-authors:
-- title: Steve Leigh
-  url: https://www.ssw.com.au/people/steve-leigh
-created: 2016-05-02 18:41:31+00:00
-createdBy: Tiago Araujo
-createdByEmail: TiagoAraujo@ssw.com.au
-guid: c5abc895-cab3-4c9f-80fc-475f9c1202de
-isArchived: false
-lastUpdated: 2020-06-29 01:18:43+00:00
-lastUpdatedBy: Ulysses Maclaren
-lastUpdatedByEmail: ulyssesmaclaren@ssw.com.au
-redirects:
-- do-you-make-sure-your-screen-recordings-are-easy-to-view
-related:
-- rule: public/uploads/rules/done-video/rule.mdx
-- rule: public/uploads/rules/enable-presentation-mode-in-visual-studio/rule.mdx
-seoDescription: Easy screen recordings start with a clean slate - optimize your browser
-  settings to ensure a professional and easy-to-view presentation.
+type: rule
 title: Screen Recordings - Do you make sure your browser is easy to view?
+uri: easy-to-view-screen-recordings
 categories:
   - category: categories/communication/rules-to-better-presentations.mdx
   - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
-type: rule
-uri: easy-to-view-screen-recordings
+authors:
+  - title: Steve Leigh
+    url: 'https://www.ssw.com.au/people/steve-leigh'
+related:
+  - rule: public/uploads/rules/done-video/rule.mdx
+  - rule: public/uploads/rules/enable-presentation-mode-in-visual-studio/rule.mdx
+redirects:
+  - do-you-make-sure-your-screen-recordings-are-easy-to-view
+guid: c5abc895-cab3-4c9f-80fc-475f9c1202de
+seoDescription: Easy screen recordings start with a clean slate - optimize your browser settings to ensure a professional and easy-to-view presentation.
+created: 2016-05-02T18:41:31.000Z
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-09T10:37:26.650Z
+lastUpdatedBy: 'LydiaCheng [SSW]'
+lastUpdatedByEmail: lydiacheng@ssw.com.au
+isArchived: false
+archivedreason: null
 ---
 
 Most developers like to set up their screen efficiently – often that means small fonts, visible bookmark bars and a huge amount of browser tabs and taskbar items. While this is great for efficiency, it is not very good for recordings or presentations, and the clutter should be removed.
 
 <endIntro />
 
-Before recording your screen reduce visual noise by:
+1. **Before recording **
 
 * **Removing unnecessary tabs** - Open the tab in its own window
 * **Avoiding small fonts** - Zoom in to 125% by holding Ctrl and scrolling up on the mouse wheel. If you're using a 4K or large monitor, consider zooming further or increasing your display scale to 175% or 200% instead of the recommended 150%
 * **Hiding the bookmark bar**
-
   * Windows shortcut: Ctrl + Shift + b
   * Mac shortcut: Cmd + Shift + b
 
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="bad"
-  figure="This video will be cluttered and unprofessional"
-  src="/uploads/rules/easy-to-view-screen-recordings/screen-recording-bad.png"
-/>
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="bad" figure="This video will be cluttered and unprofessional" src="/uploads/rules/easy-to-view-screen-recordings/screen-recording-bad.png" />
 
+<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="good" figure="This is easy to read, and doesn’t look cluttered" src="/uploads/rules/easy-to-view-screen-recordings/screen-recording-good.png" />
 
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="good"
-  figure="This is easy to read, and doesn’t look cluttered"
-  src="/uploads/rules/easy-to-view-screen-recordings/screen-recording-good.png"
-/>
+When demonstrating specific UI elements, code snippets, or small checkboxes, keeping the 100% full screen makes it hard for viewers to see the details, especially on mobile devices. You should guide the viewer's focus using one of the following two methods:
+
+**2. During recording**
+
+*
+  Zoom in on a section of interest, follow the established guide on using tools like ZoomIt or built-in OS features to spotlight your cursor - [rules/screen-recording-spotlight](https://www.ssw.com.au/rules/screen-recording-spotlight).
+* This saves massive post-production time.
+
+**3. After recording**
+
+* If the raw recording is pinned at full screen, the editor must manually create focal points in the timeline.


### PR DESCRIPTION
**Summary**
Updated the Easy to view screen recordings rule by completely rewriting and restructuring the content into a 3-step chronological workflow (Before, During, After).

**The Problem**
The old rule had unstructured points that were hard to follow for both presenters and editors, making it easy to forget critical adjustments like resolution scaling or post-production zooming. This often led to unreadable recordings.

**The Solution**
Reorganized and rewrote the guide into a logical, time-based workflow:

- Step 1 (Before Recording - Setup): Clear pre-record checklists including setting the resolution to 1080p, scaling UI up to 125% or 150%, and cleaning up toolbars/background noise.
- 
- Step 2 (During Recording - Focus): Instructions for presenters to live-zoom or track the cursor, referencing the Screen Recording Spotlight rule for tools like ZoomIt.
- 
- Step 3 (After Recording - Post-Production): Actionable guidance for editors to punch in on sections of interest using manual keyframe scaling (150% to 200%) in editing tools.