### PR TITLE
public/uploads/rules/easy to-view-screen-recordings/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/easy-to-view-screen-recordings/rule.mdx
+++ b/public/uploads/rules/easy-to-view-screen-recordings/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Easy screen recordings start with a clean slate - optimize your 
 created: 2016-05-02T18:41:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-09T10:37:26.650Z
+lastUpdated: 2026-06-10T08:01:52.809Z
 lastUpdatedBy: 'LydiaCheng [SSW]'
 lastUpdatedByEmail: lydiacheng@ssw.com.au
 isArchived: false
@@ -29,7 +29,7 @@ Most developers like to set up their screen efficiently – often that means sma
 
 <endIntro />
 
-1. **Before recording **
+1. **Before recording**
 
 * **Removing unnecessary tabs** - Open the tab in its own window
 * **Avoiding small fonts** - Zoom in to 125% by holding Ctrl and scrolling up on the mouse wheel. If you're using a 4K or large monitor, consider zooming further or increasing your display scale to 175% or 200% instead of the recommended 150%
@@ -45,8 +45,7 @@ When demonstrating specific UI elements, code snippets, or small checkboxes, kee
 
 **2. During recording**
 
-*
-  Zoom in on a section of interest, follow the established guide on using tools like ZoomIt or built-in OS features to spotlight your cursor - [rules/screen-recording-spotlight](https://www.ssw.com.au/rules/screen-recording-spotlight).
+* Zoom in on a section of interest, follow the established guide on using tools like ZoomIt or built-in OS features to spotlight your cursor - [rules/screen-recording-spotlight](https://www.ssw.com.au/rules/screen-recording-spotlight).
 * This saves massive post-production time.
 
 **3. After recording**


### PR DESCRIPTION
**Summary**
Updated the Easy to view screen recordings rule by completely rewriting and restructuring the content into a 3-step chronological workflow (Before, During, After).

**The Problem**
The old rule had unstructured points that were hard to follow for both presenters and editors, making it easy to forget critical adjustments like resolution scaling or post-production zooming. This often led to unreadable recordings.

**The Solution**
Reorganized and rewrote the guide into a logical, time-based workflow:

- Step 1 (Before Recording - Setup): Clear pre-record checklists including setting the resolution to 1080p, scaling UI up to 125% or 150%, and cleaning up toolbars/background noise.

- Step 2 (During Recording - Focus): Instructions for presenters to live-zoom or track the cursor, referencing the Screen Recording Spotlight rule for tools like ZoomIt.

- Step 3 (After Recording - Post-Production): Actionable guidance for editors to punch in on sections of interest using manual keyframe scaling (150% to 200%) in editing tools.