### PR TITLE
fix: capitalise 'Multiple' in write-agents-md heading

### DIFF
--- a/public/uploads/rules/write-agents-md/rule.mdx
+++ b/public/uploads/rules/write-agents-md/rule.mdx
@@ -81,7 +81,7 @@ For more details, you can view the [full AGENTS.md file on GitHub](https://githu
 
 As your project grows, so will your AGENTS.md. Read on to learn how to tackle the scaling problem.
 
-## Even better: multiple AGENTS.md
+## Even better: Multiple AGENTS.md
 
 You might be thinking: “Wait.. I have a massive monorepo. There's no way it's efficient to capture all that information in one file, and feed it into the AI in one go…”
 


### PR DESCRIPTION
## Summary
- Changes \`Even better: multiple AGENTS.md\` to \`Even better: Multiple AGENTS.md\` (sentence case for heading)

## Test plan
- [ ] Verify heading capitalisation on https://www.ssw.com.au/rules/write-agents-md

🤖 Generated with [Claude Code](https://claude.com/claude-code)