### PR TITLE
Review and update of unplanned outage rule

### DIFF
--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
+    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
     
     Thank you,
     SysAdmins

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Unplanned outage process for SysAdmins to ensure minimal disrupt
 created: 2021-01-07T13:16:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-16T02:40:29.769Z
+lastUpdated: 2026-06-16T02:42:54.663Z
 lastUpdatedBy: Rob Thomlinson
 lastUpdatedByEmail: RobThomlinson@ssw.com.au
 isArchived: false
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="SysAdmins – Outage Notice"
+  subject="Outage Notice - {{Outage info}} - {{Date}}"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
+    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
     
     Thank you,
     SysAdmins

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Unplanned outage process for SysAdmins to ensure minimal disrupt
 created: 2021-01-07T13:16:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-16T02:26:09.811Z
+lastUpdated: 2026-06-16T02:38:35.492Z
 lastUpdatedBy: Rob Thomlinson
 lastUpdatedByEmail: RobThomlinson@ssw.com.au
 isArchived: false
@@ -42,7 +42,7 @@ During your course of being a SysAdmin, you will come across many unplanned outa
 
 Below is a process for these types of outages. Some amount of common sense is required here, an outage would be if services that would affect BAU work are disrupted and/or some hardware has failed.
 
-Hardware Outage:
+Example Hardware Outages:
 
 * Firewall
 * Switch
@@ -50,17 +50,17 @@ Hardware Outage:
 * SAN Storage
 * UPS
 
-Service Outage:
+Example Service Outages:
 
 * Active Directory Domain Services
 * O365 Services; Teams, SharePoint, Exchange, OneDrive
 * File Servers
-* SQL Servers
 * IIS Servers
+* Internet
 
 ### Determining what services are disrupted
 
-Many services can be used for device monitoring e.g. WhatsUp Gold, Solarwinds, SCOM. You would do the following in any of them:
+Many services can be used for device monitoring e.g. WhatsUp Gold, LogicMonitor, Zabbix. You would do the following in any of them:
 
 1. Login to monitoring service
 2. Check to see what services are down
@@ -101,6 +101,8 @@ If from the previous discussion you have determined that an email needs to be se
     * ZZZ
     
     We are working on restoring these services and will keep you updated.
+    
+    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
     
     Thank you,
     SysAdmins

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Outage Notice - {{Outage info}} - {{Date}}"
+  subject="Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
+    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
     
     Thank you,
     SysAdmins

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Unplanned outage process for SysAdmins to ensure minimal disrupt
 created: 2021-01-07T13:16:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-16T02:38:35.492Z
+lastUpdated: 2026-06-16T02:40:29.769Z
 lastUpdatedBy: Rob Thomlinson
 lastUpdatedByEmail: RobThomlinson@ssw.com.au
 isArchived: false
@@ -86,9 +86,9 @@ If from the previous discussion you have determined that an email needs to be se
 
 <emailEmbed
   from=""
-  to="SSWAll"
+  to=""
   cc=""
-  bcc=""
+  bcc="SSWAll"
   subject="SysAdmins – Outage Notice"
   shouldDisplayBody={true}
   body={<>
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
+    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
     
     Thank you,
     SysAdmins

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Unplanned outage process for SysAdmins to ensure minimal disrupt
 created: 2021-01-07T13:16:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-16T02:46:34.238Z
+lastUpdated: 2026-06-16T02:59:34.914Z
 lastUpdatedBy: Rob Thomlinson
 lastUpdatedByEmail: RobThomlinson@ssw.com.au
 isArchived: false
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
+  subject="Outage Notice - {{Outage info}} - {{Date}}"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
+    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
     
     Thank you,
     SysAdmins
@@ -118,7 +118,7 @@ A separate email needs to be sent to SysAdmins outlining what was discussed on t
   to="SysAdmins"
   cc=""
   bcc=""
-  subject="SysAdmins - Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
+  subject="SysAdmins - Outage Notice - {{Outage info}} - {{Date}}"
   shouldDisplayBody={true}
   body={<>
     ## Hi Team
@@ -160,4 +160,47 @@ If you have completed your tasks but the issue has not resolved, please try to m
 
 ### Next steps resolved the issue
 
-If your actions have resolved the issue, please notify ALL of the services being restored and update your 'To Myself' email.
+If your actions have resolved the issue update your 'To Myself' email. Perform a root cause analysis and reply to the original outage notice email of the services being restored.
+
+<emailEmbed
+  from=""
+  to=""
+  cc=""
+  bcc="SSWAll"
+  subject="Re: Outage Notice - {{Outage info}} - {{Date}}"
+  shouldDisplayBody={true}
+  body={<>
+    ## Hi All,
+    
+    Please find below the details regarding the recent {{outage and affected service}}
+    
+    ##### Summary:
+    
+    {{High level summary of the outage}}
+    
+    ##### Incident Timeline:
+    
+    07:10 - xxx
+    
+    07:14 - yyy
+    
+    07:40 - zzz
+    
+    ##### Root Cause:
+    
+    {{Detailed explanation of the outage}}
+    
+    ##### Next Steps:
+    
+    To ensure this doesn't happen again we are implementing the following fixes.
+    {{Link to Ticket}}
+    
+    1. xxx
+    2. yyy
+    3. zzz
+    
+    Thank you, SysAdmin
+  </>}
+  figurePrefix="none"
+  figure=""
+/>

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Outage Notice - {{Outage info}} - {{Date}}"
+  subject="Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
+    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
     
     Thank you,
     SysAdmins
@@ -118,7 +118,7 @@ A separate email needs to be sent to SysAdmins outlining what was discussed on t
   to="SysAdmins"
   cc=""
   bcc=""
-  subject="SysAdmins - Outage Notice - {{Outage info}} - {{Date}}"
+  subject="SysAdmins - Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi Team

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Unplanned outage process for SysAdmins to ensure minimal disrupt
 created: 2021-01-07T13:16:31.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-16T02:42:54.663Z
+lastUpdated: 2026-06-16T02:46:34.238Z
 lastUpdatedBy: Rob Thomlinson
 lastUpdatedByEmail: RobThomlinson@ssw.com.au
 isArchived: false
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
+  subject="Outage Notice - {{Outage info}} - {{Date}}"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
+    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
     
     Thank you,
     SysAdmins
@@ -118,7 +118,7 @@ A separate email needs to be sent to SysAdmins outlining what was discussed on t
   to="SysAdmins"
   cc=""
   bcc=""
-  subject="SysAdmins – Outage Notice"
+  subject="SysAdmins - Outage Notice - {{Outage info}} - {{Date}}"
   shouldDisplayBody={true}
   body={<>
     ## Hi Team

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -1,36 +1,35 @@
 ---
-archivedreason: null
-authors:
-- title: Steven Andrews
-  url: https://www.ssw.com.au/people/steven-andrews
-- img: https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/Kaique-Biancatti/Images/Kaique-Biancatti-Square.jpg
-  title: Kiki Biancatti
-  url: https://www.ssw.com.au/people/kaique-biancatti
-created: 2021-01-07 13:16:31+00:00
-createdBy: Tiago Araujo
-createdByEmail: TiagoAraujo@ssw.com.au
-guid: d96278bc-f927-4079-ba6c-c0b3c9a49b0d
-isArchived: false
-lastUpdated: 2021-07-02 22:50:41.434000+00:00
-lastUpdatedBy: Tiago Araújo [SSW]
-lastUpdatedByEmail: tiagov8@gmail.com
-redirects:
-- do-you-have-an-unplanned-outage-process
-related:
-- rule: public/uploads/rules/planned-outage-process/rule.mdx
-seoDescription: Unplanned outage process for SysAdmins to ensure minimal disruption
-  to business operations while resolving hardware and service outages.
+type: rule
 title: Outage - Do you have an unplanned outage process?
+uri: unplanned-outage-process
 categories:
   - category: categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
-type: rule
-uri: unplanned-outage-process
+authors:
+  - title: Steven Andrews
+    url: 'https://www.ssw.com.au/people/steven-andrews'
+  - title: Kiki Biancatti
+    url: 'https://www.ssw.com.au/people/kaique-biancatti'
+  - title: Rob Thomlinson
+    url: 'https://www.ssw.com.au/people/Rob-Thomlinson'
+related:
+  - rule: public/uploads/rules/planned-outage-process/rule.mdx
+redirects:
+  - do-you-have-an-unplanned-outage-process
+guid: d96278bc-f927-4079-ba6c-c0b3c9a49b0d
+seoDescription: Unplanned outage process for SysAdmins to ensure minimal disruption to business operations while resolving hardware and service outages.
+created: 2021-01-07T13:16:31.000Z
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-16T02:26:09.811Z
+lastUpdatedBy: Rob Thomlinson
+lastUpdatedByEmail: RobThomlinson@ssw.com.au
+isArchived: false
+archivedreason: null
 ---
 
 During your course of being a SysAdmin, you will come across many unplanned outages. Some of them will impact BAU (Business as usual) and others will just be minor service outages. Do you know what to do in the event of these outages?
 
 <endIntro />
-
 
 <boxEmbed
   style="info"
@@ -41,24 +40,23 @@ During your course of being a SysAdmin, you will come across many unplanned outa
   figure=""
 />
 
-
 Below is a process for these types of outages. Some amount of common sense is required here, an outage would be if services that would affect BAU work are disrupted and/or some hardware has failed.
 
 Hardware Outage:
 
-- Firewall
-- Switch
-- Blade Servers
-- SAN Storage
-- UPS
+* Firewall
+* Switch
+* Blade Servers
+* SAN Storage
+* UPS
 
 Service Outage:
 
-- Active Directory Domain Services
-- O365 Services; Teams, SharePoint, Exchange, OneDrive
-- File Servers
-- SQL Servers
-- IIS Servers
+* Active Directory Domain Services
+* O365 Services; Teams, SharePoint, Exchange, OneDrive
+* File Servers
+* SQL Servers
+* IIS Servers
 
 ### Determining what services are disrupted
 
@@ -95,17 +93,17 @@ If from the previous discussion you have determined that an email needs to be se
   shouldDisplayBody={true}
   body={<>
     ## Hi All
-
-We are experiencing an outage and the following services have been affected:
-
-- XXX
-- YYY
-- ZZZ
-
-We are working on restoring these services and will keep you updated.
-
-Thank you,
-SysAdmins
+    
+    We are experiencing an outage and the following services have been affected:
+    
+    * XXX
+    * YYY
+    * ZZZ
+    
+    We are working on restoring these services and will keep you updated.
+    
+    Thank you,
+    SysAdmins
   </>}
   figurePrefix="none"
   figure=""
@@ -122,33 +120,33 @@ A separate email needs to be sent to SysAdmins outlining what was discussed on t
   shouldDisplayBody={true}
   body={<>
     ## Hi Team
-
-As per our conversation,
-
-The following services are disrupted:
-
-- XXX
-- YYY
-- ZZZ
-
-The impact of these services disrupted are:
-
-- XXX
-- YYY
-- ZZZ
-
-We have decided that an email to ALL is/is not required.
-
-## To myself
-
-The next steps to resolving this are:
-
-1. XXX
-2. YYY
-3. ZZZ
-
-Thank you,
-SysAdmin
+    
+    As per our conversation,
+    
+    The following services are disrupted:
+    
+    * XXX
+    * YYY
+    * ZZZ
+    
+    The impact of these services disrupted are:
+    
+    * XXX
+    * YYY
+    * ZZZ
+    
+    We have decided that an email to ALL is/is not required.
+    
+    ## To myself
+    
+    The next steps to resolving this are:
+    
+    1. XXX
+    2. YYY
+    3. ZZZ
+    
+    Thank you,
+    SysAdmin
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -89,7 +89,7 @@ If from the previous discussion you have determined that an email needs to be se
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Outage Notice - {{Outage info}} - {{Date}}"
+  subject="Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi All
@@ -102,7 +102,7 @@ If from the previous discussion you have determined that an email needs to be se
     
     We are working on restoring these services and will keep you updated.
     
-    Note: \<This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)>
+    Note: &lt;This is as per rule Outage – [Do you have an unplanned outage process?](https://www.ssw.com.au/rules/unplanned-outage-process)&gt;
     
     Thank you,
     SysAdmins
@@ -118,7 +118,7 @@ A separate email needs to be sent to SysAdmins outlining what was discussed on t
   to="SysAdmins"
   cc=""
   bcc=""
-  subject="SysAdmins - Outage Notice - {{Outage info}} - {{Date}}"
+  subject="SysAdmins - Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi Team
@@ -167,16 +167,16 @@ If your actions have resolved the issue update your 'To Myself' email. Perform a
   to=""
   cc=""
   bcc="SSWAll"
-  subject="Re: Outage Notice - {{Outage info}} - {{Date}}"
+  subject="Re: Outage Notice - &#123;&#123;Outage info&#125;&#125; - &#123;&#123;Date&#125;&#125;"
   shouldDisplayBody={true}
   body={<>
     ## Hi All,
     
-    Please find below the details regarding the recent {{outage and affected service}}
+    Please find below the details regarding the recent &#123;&#123;outage and affected service&#125;&#125;
     
     ##### Summary:
     
-    {{High level summary of the outage}}
+    &#123;&#123;High level summary of the outage&#125;&#125;
     
     ##### Incident Timeline:
     
@@ -188,12 +188,12 @@ If your actions have resolved the issue update your 'To Myself' email. Perform a
     
     ##### Root Cause:
     
-    {{Detailed explanation of the outage}}
+    &#123;&#123;Detailed explanation of the outage&#125;&#125;
     
     ##### Next Steps:
     
     To ensure this doesn't happen again we are implementing the following fixes.
-    {{Link to Ticket}}
+    &#123;&#123;Link to Ticket&#125;&#125;
     
     1. xxx
     2. yyy


### PR DESCRIPTION
This pull request updates and improves the documentation for the unplanned outage process rule, making the instructions clearer and the notification templates more actionable and standardized. The changes focus on clarifying outage examples, updating monitoring tool references, and enhancing the communication templates for both internal and company-wide notifications.

**Content and structure improvements:**

* Updated front matter in `rule.mdx` to include additional metadata, improved author formatting, related rule references, SEO description, and accurate timestamps.
* Clarified and reformatted examples of hardware and service outages, and updated monitoring tool references to include more current options (e.g., LogicMonitor, Zabbix).

**Notification template enhancements:**

* Improved the "Outage Notice" email template to use bullet points for affected services, added a note referencing the rule, and updated recipient fields for clearer communication.
* Updated the SysAdmins notification template to use bullet points for clarity and standardized the subject line format. [[1]](diffhunk://#diff-bd4e1b946bedcc25a7ddb7396f839c11915eddbb9e7a6103de908bc7e1dc598aL121-R121) [[2]](diffhunk://#diff-bd4e1b946bedcc25a7ddb7396f839c11915eddbb9e7a6103de908bc7e1dc598aL130-R138)
* Added a new post-resolution email template for company-wide notification, including sections for summary, incident timeline, root cause, and next steps, to ensure thorough communication and follow-up after resolution.