### PR TITLE
Add rule: Do you know how to share files with China?

### DIFF
--- a/categories/marketing-and-video/rules-to-better-video-recording.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -31,6 +31,7 @@ index:
   - rule: public/uploads/rules/screen-recording-spotlight/rule.mdx
   - rule: public/uploads/rules/production-do-you-set-up-the-speaker-prior-to-recording/rule.mdx
   - rule: public/uploads/rules/easy-recording-space/rule.mdx
+  - rule: public/uploads/rules/share-files-with-china/rule.mdx
 created: 2021-05-17T02:16:52.000Z
 createdBy: 'Jayden Alchin [SSW]'
 createdByEmail: 75593567+jaydenalchin@users.noreply.github.com

--- a/public/uploads/rules/share-files-with-china/rule.mdx
+++ b/public/uploads/rules/share-files-with-china/rule.mdx
@@ -1,0 +1,72 @@
+---
+type: rule
+title: Do you know how to share files with China?
+uri: share-files-with-china
+authors:
+  - title: Ulysses Maclaren
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+guid: e7d783d9-dcb0-4f33-a44c-f850257900c2
+seoDescription: >-
+  Sharing large files with team members in mainland China? OneDrive and
+  SharePoint downloads often fail or crawl, while Google Drive handles big
+  transfers reliably.
+created: 2026-06-16T00:00:00.000Z
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
+related:
+  - rule: public/uploads/rules/wechat-for-business/rule.mdx
+  - rule: public/uploads/rules/easy-recording-space/rule.mdx
+  - rule: public/uploads/rules/making-a-great-done-video/rule.mdx
+---
+
+When you need to get a large file to or from a team member in mainland China - for example, sending raw video footage to the TV team for editing - the tools that work everywhere else often let you down.
+
+Large files on OneDrive and SharePoint frequently time out, fail, or crawl to a halt for people in China, leaving everyone stuck re-trying the same broken download.
+
+<endIntro />
+
+## Why OneDrive and SharePoint struggle
+
+Microsoft 365 services are reachable from mainland China, but the connection is slow and unreliable for big transfers. A small document might be fine, but a multi-gigabyte video will often stall partway through and never finish.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Sending a 2 GB video over SharePoint and telling your China-based colleague to "just download it" - then watching them fail repeatedly over several days.
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - Large files on OneDrive/SharePoint often fail to download in China"
+/>
+
+## Use Google Drive instead
+
+Google Drive handles large file transfers to and from China far more reliably. Share a folder that both sides can access, and the file comes through without the repeated failures.
+
+<boxEmbed
+  style="good"
+  body={<>
+    Upload the file to a shared Google Drive folder the recipient already has access to, then send them the link.
+  </>}
+  figurePrefix="good"
+  figure="Good example - Google Drive handles large file transfers to and from China reliably"
+/>
+
+<boxEmbed
+  style="china"
+  body={<>
+    Access to Google services from mainland China usually depends on a working VPN, so confirm the person on the China side can reach Google Drive before relying on it.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+## Example - Sharing a video recorded on your phone
+
+A common scenario is capturing footage on a phone and getting it to the TV team:
+
+1. **Record** the video on your iPhone
+2. **Install** the Google Drive app from the App Store
+3. **Upload** the file to a shared Drive folder the TV team can access
+4. **Notify** the team so they can pick it up and start editing
+
+This avoids the back-and-forth of failed OneDrive and SharePoint downloads, and gets your footage into the right hands the first time.


### PR DESCRIPTION
@
## Rule
Adds a new rule to **Rules to Better Video Recording**: *Do you know how to share files with China?*

## Why
Team members in mainland China often struggle to download large files from OneDrive/SharePoint - transfers time out, fail, or crawl. Google Drive (over a VPN) handles big files reliably. The rule includes the common iPhone footage → Google Drive app → TV team workflow.

## Changes
- New rule: `public/uploads/rules/share-files-with-china/rule.mdx`
- Registered in category index `categories/marketing-and-video/rules-to-better-video-recording.mdx`

Frontmatter validator and markdownlint both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@