### PR TITLE
Fix: valid boxEmbed style in share-files-with-china rule

### DIFF
--- a/public/uploads/rules/share-files-with-china/rule.mdx
+++ b/public/uploads/rules/share-files-with-china/rule.mdx
@@ -43,7 +43,7 @@ Microsoft 365 services are reachable from mainland China, but the connection is 
 Google Drive handles large file transfers to and from China far more reliably. Share a folder that both sides can access, and the file comes through without the repeated failures.
 
 <boxEmbed
-  style="good"
+  style="greybox"
   body={<>
     Upload the file to a shared Google Drive folder the recipient already has access to, then send them the link.
   </>}


### PR DESCRIPTION
@
Fixes an invalid `style="good"` on a `boxEmbed` in the new *share files with China* rule. `good` is not a valid box style (it was the only occurrence in the entire repo); the good-example label already comes from `figurePrefix="good"`, so the box now uses `greybox` like every other example box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@