### PR TITLE
Add rule: Do you avoid editing an already-exported video?

### DIFF
--- a/categories/marketing-and-video/rules-to-better-video-post-production.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-post-production.mdx
@@ -31,6 +31,7 @@ index:
   - rule: public/uploads/rules/post-production-do-you-know-how-to-promote-videos/rule.mdx
   - rule: public/uploads/rules/post-production-do-you-know-how-to-structure-your-files/rule.mdx
   - rule: public/uploads/rules/share-source-files-with-video-editor/rule.mdx
+  - rule: public/uploads/rules/avoid-editing-exported-videos/rule.mdx
   - rule: public/uploads/rules/post-production-do-you-know-how-to-transfer-avchd-footage-to-your-computer/rule.mdx
   - rule: public/uploads/rules/production-do-you-add-a-call-to-action/rule.mdx
   - rule: public/uploads/rules/copy-views-and-comments-before-deleting-a-video-version/rule.mdx

--- a/categories/marketing-and-video/rules-to-better-video-recording.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -6,6 +6,7 @@ guid: 60485409-d17d-4be3-b2a0-1ab5cdd4d82d
 index:
   - rule: public/uploads/rules/done-video/rule.mdx
   - rule: public/uploads/rules/making-a-great-done-video/rule.mdx
+  - rule: public/uploads/rules/avoid-editing-exported-videos/rule.mdx
   - rule: public/uploads/rules/production-do-you-know-how-to-conduct-an-interview/rule.mdx
   - rule: public/uploads/rules/production-do-you-know-how-to-record-live-video-interviews-on-location/rule.mdx
   - rule: public/uploads/rules/production-do-you-know-how-to-start-recording-with-camtasia/rule.mdx

--- a/public/uploads/rules/avoid-editing-exported-videos/rule.mdx
+++ b/public/uploads/rules/avoid-editing-exported-videos/rule.mdx
@@ -2,25 +2,30 @@
 type: rule
 title: Do you avoid editing an already-exported video?
 uri: avoid-editing-exported-videos
-seoDescription: Editing a finished, exported video re-compresses it and degrades quality. Go back to the original project and source files, or hand the edit to your video team.
-guid: 634fb18b-3471-4d1c-9e0a-8c7d7d006be9
-created: 2026-06-17T00:00:00.000Z
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-post-production.mdx
+  - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
 authors:
   - title: Isaac Lombard
-    url: https://www.ssw.com.au/people/isaac-lombard
+    url: 'https://www.ssw.com.au/people/isaac-lombard'
 related:
   - rule: public/uploads/rules/share-source-files-with-video-editor/rule.mdx
   - rule: public/uploads/rules/post-production-high-quality/rule.mdx
   - rule: public/uploads/rules/the-editors-aim-is-to-be-a-coach-not-just-a-video-editor/rule.mdx
   - rule: public/uploads/rules/done-video/rule.mdx
-categories:
-  - category: categories/marketing-and-video/rules-to-better-video-post-production.mdx
-  - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
+guid: 634fb18b-3471-4d1c-9e0a-8c7d7d006be9
+seoDescription: 'Editing a finished, exported video re-compresses it and degrades quality. Go back to the original project and source files, or hand the edit to your video team.'
+created: 2026-06-17T00:00:00.000Z
+createdBy: Isaac Lombard
+createdByEmail: isaaclombard@ssw.com.au
+lastUpdated: 2026-06-17T05:56:33.952Z
+lastUpdatedBy: Isaac Lombard
+lastUpdatedByEmail: isaaclombard@ssw.com.au
 ---
 
-An exported video is a flattened, compressed file. Once it's rendered out, the timeline, the layers, and the original quality are gone - all that's left is a baked copy. So when a small change comes in (a trim, a new title, a re-cut), it's tempting to just open that finished file, make the edit, and export it again.
+An exported video is a flattened, compressed file. Once it's rendered out, the timeline, the layers, and the original quality are gone - all that's left is a baked copy. So when a small change comes in, it's tempting to just open that finished file, make the edit, and export it again.
 
-The problem is that every export compresses the video on top of compression that's already there. Do that a couple of times and the picture goes soft, the audio gets muddy, and you ship something noticeably worse than the original - often without anyone noticing until it's flagged later.
+The problem is that every export compresses the video on top of compression that's already there. This is a slippery slope that can result in a low quality video.
 
 <endIntro />
 
@@ -28,7 +33,10 @@ The problem is that every export compresses the video on top of compression that
 
 Video codecs like H.264 are lossy - they throw away detail to keep file sizes small. That's fine the first time, because you're exporting from high-quality footage. But a finished export is a poor source: re-editing and re-exporting it means compressing an image that was already compressed, and the loss stacks up with each pass. It's the same reason a photocopy of a photocopy looks rough.
 
-The trap is that consumer tools make this easy. You can drag a finished `.mp4` into iMovie, chop out a few seconds, and export - and on your own screen the result looks fine. But you've just done another lossy pass without the export settings a video editor would normally use to protect quality. The hack ships, nobody notices straight away, and weeks later it gets picked up as a low-quality video that has to be redone properly anyway.
+The trap is that consumer tools make this easy. You can drag a finished `.mp4` into iMovie, chop out a few seconds, and export - and on your own screen the result looks fine. But you've just done another lossy pass without the export settings a video editor would normally use to protect quality. 
+
+
+The hack ships, nobody notices straight away, and weeks later it gets picked up as a low-quality video that has to be redone properly anyway.
 
 <boxEmbed
   style="greybox"

--- a/public/uploads/rules/avoid-editing-exported-videos/rule.mdx
+++ b/public/uploads/rules/avoid-editing-exported-videos/rule.mdx
@@ -1,0 +1,68 @@
+---
+type: rule
+title: Do you avoid editing an already-exported video?
+uri: avoid-editing-exported-videos
+seoDescription: Editing a finished, exported video re-compresses it and degrades quality. Go back to the original project and source files, or hand the edit to your video team.
+guid: 634fb18b-3471-4d1c-9e0a-8c7d7d006be9
+created: 2026-06-17T00:00:00.000Z
+authors:
+  - title: Isaac Lombard
+    url: https://www.ssw.com.au/people/isaac-lombard
+related:
+  - rule: public/uploads/rules/share-source-files-with-video-editor/rule.mdx
+  - rule: public/uploads/rules/post-production-high-quality/rule.mdx
+  - rule: public/uploads/rules/the-editors-aim-is-to-be-a-coach-not-just-a-video-editor/rule.mdx
+  - rule: public/uploads/rules/done-video/rule.mdx
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-post-production.mdx
+  - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
+---
+
+An exported video is a flattened, compressed file. Once it's rendered out, the timeline, the layers, and the original quality are gone - all that's left is a baked copy. So when a small change comes in (a trim, a new title, a re-cut), it's tempting to just open that finished file, make the edit, and export it again.
+
+The problem is that every export compresses the video on top of compression that's already there. Do that a couple of times and the picture goes soft, the audio gets muddy, and you ship something noticeably worse than the original - often without anyone noticing until it's flagged later.
+
+<endIntro />
+
+## Why re-exporting hurts
+
+Video codecs like H.264 are lossy - they throw away detail to keep file sizes small. That's fine the first time, because you're exporting from high-quality footage. But a finished export is a poor source: re-editing and re-exporting it means compressing an image that was already compressed, and the loss stacks up with each pass. It's the same reason a photocopy of a photocopy looks rough.
+
+The trap is that consumer tools make this easy. You can drag a finished `.mp4` into iMovie, chop out a few seconds, and export - and on your own screen the result looks fine. But you've just done another lossy pass without the export settings a video editor would normally use to protect quality. The hack ships, nobody notices straight away, and weeks later it gets picked up as a low-quality video that has to be redone properly anyway.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    A change comes in for a finished video, so you open the exported .mp4 in iMovie, trim it, and export again. The video is re-compressed and ships softer than the original.
+  </>}
+  figurePrefix="bad"
+  figure="Editing the flattened export and re-compressing it"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    A change comes in for a finished video, so you open the original project file and source media, make the change, and export once. The quality stays intact.
+  </>}
+  figurePrefix="good"
+  figure="Going back to the source files for the edit"
+/>
+
+## Go back to the source
+
+When a change is needed, go back to the project file (e.g. `.prproj`, `.fcpxml`, `.tscproj`, or your Clipchamp project) and the original media, make the edit there, and export once. The source files hold the full-quality footage and your edit history, so the change costs you nothing in quality.
+
+If you don't have the source files, get them from whoever recorded or edited the video - don't work around their absence by editing the export. See [Do you share source files with your video editor?](/share-source-files-with-video-editor)
+
+## When to hand it to the video team
+
+Doing a quick, self-contained change yourself is fine when you made the video and still have the project for it. Hand it to the video team when:
+
+* You don't have the source files
+* The video is public or client-facing
+* The change is more than a quick trim - re-cuts, titles, colour, or audio fixes
+* You'd be reaching for a consumer tool and a "good enough" export to get it done
+
+They have the source footage, the right tools, and the export settings to keep it sharp. A few minutes of their time beats shipping a soft video that gets redone later.
+
+For the export settings that keep quality high in the first place, see [Do you export your videos in high quality?](/post-production-high-quality)


### PR DESCRIPTION
New rule on preserving video quality, written from a real incident: a self-serve edit pushed through iMovie (re-exporting a finished file) shipped at low quality and wasn't picked up for a while.

Rather than a broad "preserve video quality" rule (which would overlap [Do you export your videos in high quality?](https://www.ssw.com.au/rules/post-production-high-quality) and [Do you share source files with your video editor?](https://www.ssw.com.au/rules/share-source-files-with-video-editor)), this takes a tighter, non-duplicative angle: don't re-edit/re-export a flattened file - the generational loss is the root cause - go back to the source, or hand it to the video team.

- New rule: `public/uploads/rules/avoid-editing-exported-videos/rule.mdx`
- Added to **Post-Production** and **Recording and Production** category indexes
- Cross-linked to the source-files, high-quality export, editor-as-coach, and done-video rules

Frontmatter validation and markdownlint both pass.