### PR TITLE
public/uploads/rules/getting a busy person into the meeting/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/getting-a-busy-person-into-the-meeting/rule.mdx
+++ b/public/uploads/rules/getting-a-busy-person-into-the-meeting/rule.mdx
@@ -1,65 +1,59 @@
 ---
-authors:
-- title: Chris Schultz
-  url: https://www.ssw.com.au/people/chris-schultz
-- title: Levi Jackson
-  url: https://www.ssw.com.au/people/levi-jackson
-created: 2021-12-16 23:49:23.696000+00:00
-guid: 2c6e0175-0723-4f3b-81c8-33260f625a46
-redirects: []
-related:
-- rule: public/uploads/rules/what-happens-at-a-sprint-review-meeting/rule.mdx
-- rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
-seoDescription: Getting a busy person into an online meeting requires a proactive
-  approach, including pinging them on Teams and persistently adding them to the call
-  if they're missing.
-title: Ceremony - Do you know how to get a busy person into the meeting?
+type: rule
+title: Do you make important meetings feel like a ceremony so busy people attend?
+uri: getting-a-busy-person-into-the-meeting
 categories:
   - category: categories/communication/rules-to-better-meetings.mdx
-type: rule
-uri: getting-a-busy-person-into-the-meeting
+authors:
+  - title: Chris Schultz
+    url: 'https://www.ssw.com.au/people/chris-schultz'
+  - title: Levi Jackson
+    url: 'https://www.ssw.com.au/people/levi-jackson'
+related:
+  - rule: public/uploads/rules/what-happens-at-a-sprint-review-meeting/rule.mdx
+  - rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
+redirects: []
+guid: 2c6e0175-0723-4f3b-81c8-33260f625a46
+seoDescription: 'Getting a busy person into an online meeting requires a proactive approach, including pinging them on Teams and persistently adding them to the call if they''re missing.'
+created: 2021-12-16T23:49:23.696Z
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-23T00:53:22.585Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
 
 It can be difficult to get everybody into a meeting, especially these days when many meetings are online. It is important that time is not wasted in these situations, so it's good to be proactive and have a plan for when the decision maker is busy.
 
 <endIntro />
 
-### Make it a ceremony
+## Send an SMS the day before
+
+For important meetings, send a short SMS the day before to remind key attendees and make the meeting feel important.
+
+This works especially well for busy people because SMS is harder to miss than email or calendar notifications.
+
+> Hi Bob, quick reminder about tomorrow’s meeting at 10 am. We’re keen to get your input on the final decision. Thanks!
+
+Keep it short, personal, and clear about why their attendance matters.
+
+## Make it a ceremony
 
 You have already [shared the agenda](/share-the-agenda), so pick out the best item and ping the decision maker on teams before the meeting:
 
 > "We're meeting in 30 minutes, I'm excited to be talking about xxx"
 
-### Be persistent
+## Be persistent
 
-
-<boxEmbed
-  style="greybox"
-  body={<>
-    If the meeting has started and someone is missing, then add them to the call. Ping them if they dont answer.
-If a decision maker is missing from the call and you don't get a response, tell them _"I will call you towards the end of the meeting for a summary"_, as per [Do you know how to loop someone in at the end of a meeting?](/loop-someone-in)
-  </>}
-  figurePrefix="none"
-  figure=""
-/>
-
+If the meeting has started and someone is missing, then add them to the call. Ping them if they don't answer.
+If a decision maker is missing from the call and you don't get a response, tell them *"I will call you towards the end of the meeting for a summary"*, as per [how to loop someone in at the end of a meeting](/loop-someone-in).
 
 Once you have done the above, you can start the meeting without the decision-maker. You may choose to start with the less important items in the agenda, or the ones that won't require a final decision ("For information" items) that can be easily summarised at the end of the meeting.
 
-### I’m here, where is everyone else?
+### “Where is everyone else?”
 
-If you join a meeting and the other attendees haven't joined yet, use the ”Request to Join” button in teams.
-
-Teams | Participants | Request to Join
+If you join a meeting and the other attendees haven't joined yet, use the ”Request to Join” button in Microsoft Teams.
 
 This will remind the team that the meeting has started just in case they missed the calendar reminder.
 
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure="In Microsoft Teams, add someone to the call by Show Participants | Request to join"
-  src="/uploads/rules/getting-a-busy-person-into-the-meeting/teams-request-to-join.png"
-/>
+<imageEmbed alt="Image" size="medium" showBorder={true} figurePrefix="none" figure="In Microsoft Teams, add someone to the call by Show Participants | Request to join" src="/uploads/rules/getting-a-busy-person-into-the-meeting/teams-request-to-join.png" />


### PR DESCRIPTION
as per @adamcogan 's email:

**Subject: Rules to Better Meetings | SSW.Rules**

https://www.ssw.com.au/rules/rules-to-better-meetings

> 3. The ceremony prefix can be removed if you prefer - I would mention SMSing them the day before