### PR TITLE
Add rule: Do you set the required roles for the Tender Team?

### DIFF
--- a/categories/client-engagement/rules-to-better-tenders.mdx
+++ b/categories/client-engagement/rules-to-better-tenders.mdx
@@ -5,6 +5,7 @@ uri: rules-to-better-tenders
 guid: 471816bf-f0df-4835-bf4d-66a90f6f1adc
 seoDescription: SSW's rules for responding to software tenders. Learn how to write winning tender responses that demonstrate technical capability and clear value.
 index:
+  - rule: public/uploads/rules/set-tender-team-roles/rule.mdx
   - rule: public/uploads/rules/personalised-tender-responses/rule.mdx
   - rule: public/uploads/rules/do-you-define-win-strategies-and-win-themes/rule.mdx
   - rule: public/uploads/rules/bid-no-bid-process/rule.mdx

--- a/public/uploads/rules/set-tender-team-roles/rule.mdx
+++ b/public/uploads/rules/set-tender-team-roles/rule.mdx
@@ -1,0 +1,62 @@
+---
+title: Do you set the required roles for the Tender Team?
+uri: set-tender-team-roles
+categories:
+  - category: categories/client-engagement/rules-to-better-tenders.mdx
+authors:
+  - title: Ulysses Maclaren
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+guid: bcae193d-678f-456d-a7da-69ddf0e9d0a4
+seoDescription: >-
+  Before responding to a tender, assign the four key roles on the Tender Team -
+  Bid Manager, Bid Writer, Sales, and Pre-sales Solution Architect - so nothing
+  falls through the cracks.
+created: 2026-06-23T00:00:00.000Z
+createdBy: Ulysses Maclaren
+createdByEmail: ulyssesmaclaren@ssw.com.au
+lastUpdated: 2026-06-23T00:00:00.000Z
+lastUpdatedBy: Ulysses Maclaren
+lastUpdatedByEmail: ulyssesmaclaren@ssw.com.au
+---
+
+A tender is a team effort, but if you don't agree up front on who owns what, important parts of the bid get dropped, deadlines slip, and the response ends up disjointed. Before you start writing, assign the four key roles on the Tender Team so every responsibility has a clear owner.
+
+<endIntro />
+
+There are four roles to set on every Tender Team. One person can cover more than one role, but every responsibility below must be owned by someone.
+
+## Bid Manager
+
+The Bid Manager runs the bid and is accountable for getting it submitted on time and to plan.
+
+* Sets the bid plan
+* Measures progress against the plan
+* Measures progress against the gates (e.g. G0, G1)
+
+## Bid Writer
+
+The Bid Writer owns the written quality and consistency of the response. This role can be - and often is - carried out by the Bid Manager.
+
+* Writes the non-technical parts of the bid - Executive Summary, Company Overview, and References
+* Owns formatting and consistency across the whole bid
+
+This role has historically been a gap on tender teams, so make sure it is explicitly assigned to someone.
+
+## Sales
+
+Sales owns the client relationship and the commercial shape of the bid.
+
+* Owns the client interface
+* Owns the [Win Strategy](/do-you-define-win-strategies-and-win-themes)
+* Sets the target price
+* Owns the commercial aspects of the bid
+
+## Pre-sales Solution Architect
+
+The Pre-sales Solution Architect owns the technical solution in the bid. This should be drawn from a pool of architects rather than relying on one person.
+
+* Owns the Solution Overview for the bid
+* Assigned from the pool at G0 or G1
+* By default, this person is also the resource selected to run the project if the bid is won
+
+Maintain a pool of Pre-sales Solution Architects so you are never blocked waiting on a single person. Today Cookie and Gert can fill this role - actively grow the pool beyond them.


### PR DESCRIPTION
## Description

Adds a new rule to **Rules to Better Tenders**, positioned as **rule #1** in the category.

**Title:** Do you set the required roles for the Tender Team?

The rule defines the four key roles every Tender Team should assign before responding to a tender so nothing falls through the cracks:

- **Bid Manager** — runs the bid, accountable for on-time submission
- **Bid Writer** — owns written quality and consistency (historically a gap)
- **Sales** — owns the client relationship and commercial shape of the bid
- **Pre-sales Solution Architect** — owns the technical solution

## Changes

- Added `public/uploads/rules/set-tender-team-roles/rule.mdx`
- Added the rule as the first entry in `categories/client-engagement/rules-to-better-tenders.mdx`

Frontmatter validation passes; GUID and URI confirmed unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)