### PR TITLE
Fix: use SSW's actual tender gate names in Tender Team roles rule

### DIFF
--- a/public/uploads/rules/set-tender-team-roles/rule.mdx
+++ b/public/uploads/rules/set-tender-team-roles/rule.mdx
@@ -31,7 +31,7 @@ The Bid Manager runs the bid and is accountable for getting it submitted on time
 
 * Sets the bid plan
 * Measures progress against the plan
-* Measures progress against the gates (e.g. G0, G1)
+* Measures progress against the gates (Gate 1 - Bid/No-Bid through to Gate 4 - Submission)
 
 ## Bid Writer
 
@@ -56,7 +56,7 @@ Sales owns the client relationship and the commercial shape of the bid.
 The Pre-sales Solution Architect owns the technical solution in the bid. This should be drawn from a pool of architects rather than relying on one person.
 
 * Owns the Solution Overview for the bid
-* Assigned from the pool at G0 or G1
+* Assigned from the pool at Gate 1 (Bid/No-Bid)
 * By default, this person is also the resource selected to run the project if the bid is won
 
 Maintain a pool of Pre-sales Solution Architects so you are never blocked waiting on a single person. Today Cookie and Gert can fill this role - actively grow the pool beyond them.


### PR DESCRIPTION
## Description

Follow-up to #12906. The new **Do you set the required roles for the Tender Team?** rule referenced generic gate labels (`G0, G1`) that don't match SSW's actual process.

Per the **SSW - Master Tender Writing Plan**, the real gating scheme is:

- **Gate 1** — Bid / No-Bid (qualify the opportunity)
- **Gate 2** — separate solution/strategy gate
- **Gate 3** — Final review prior to submission
- **Gate 4** — Submission done

## Changes

- **Bid Manager:** "Measures progress against the gates (e.g. G0, G1)" → "(Gate 1 - Bid/No-Bid through to Gate 4 - Submission)"
- **Pre-sales Solution Architect:** "Assigned from the pool at G0 or G1" → "at Gate 1 (Bid/No-Bid)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)