### PR TITLE
Add 'Do you use gates to manage your tenders?' rule (and fix gate model)

### DIFF
--- a/categories/client-engagement/rules-to-better-tenders.mdx
+++ b/categories/client-engagement/rules-to-better-tenders.mdx
@@ -6,6 +6,7 @@ guid: 471816bf-f0df-4835-bf4d-66a90f6f1adc
 seoDescription: SSW's rules for responding to software tenders. Learn how to write winning tender responses that demonstrate technical capability and clear value.
 index:
   - rule: public/uploads/rules/set-tender-team-roles/rule.mdx
+  - rule: public/uploads/rules/tender-gates/rule.mdx
   - rule: public/uploads/rules/personalised-tender-responses/rule.mdx
   - rule: public/uploads/rules/do-you-define-win-strategies-and-win-themes/rule.mdx
   - rule: public/uploads/rules/bid-no-bid-process/rule.mdx

--- a/public/uploads/rules/set-tender-team-roles/rule.mdx
+++ b/public/uploads/rules/set-tender-team-roles/rule.mdx
@@ -56,7 +56,7 @@ Sales owns the client relationship and the commercial shape of the bid.
 The Pre-sales Solution Architect owns the technical solution in the bid. This should be drawn from a pool of architects rather than relying on one person.
 
 * Owns the Solution Overview for the bid
-* Assigned from the pool at Gate 0 or Gate 1
+* Assigned from the pool at [Gate 0 or Gate 1](/tender-gates)
 * By default, this person is also the resource selected to run the project if the bid is won
 
 Maintain a pool of Pre-sales Solution Architects so you are never blocked waiting on a single person. Today Cookie and Gert can fill this role - actively grow the pool beyond them.

--- a/public/uploads/rules/set-tender-team-roles/rule.mdx
+++ b/public/uploads/rules/set-tender-team-roles/rule.mdx
@@ -31,7 +31,7 @@ The Bid Manager runs the bid and is accountable for getting it submitted on time
 
 * Sets the bid plan
 * Measures progress against the plan
-* Measures progress against the gates (Gate 1 - Bid/No-Bid through to Gate 4 - Submission)
+* Measures progress against the [gates](/tender-gates) (Gate 0 through to Gate 3)
 
 ## Bid Writer
 
@@ -56,7 +56,7 @@ Sales owns the client relationship and the commercial shape of the bid.
 The Pre-sales Solution Architect owns the technical solution in the bid. This should be drawn from a pool of architects rather than relying on one person.
 
 * Owns the Solution Overview for the bid
-* Assigned from the pool at Gate 1 (Bid/No-Bid)
+* Assigned from the pool at Gate 0 or Gate 1
 * By default, this person is also the resource selected to run the project if the bid is won
 
 Maintain a pool of Pre-sales Solution Architects so you are never blocked waiting on a single person. Today Cookie and Gert can fill this role - actively grow the pool beyond them.

--- a/public/uploads/rules/tender-gates/rule.mdx
+++ b/public/uploads/rules/tender-gates/rule.mdx
@@ -1,0 +1,44 @@
+---
+title: Do you use gates to manage your tenders?
+uri: tender-gates
+categories:
+  - category: categories/client-engagement/rules-to-better-tenders.mdx
+authors:
+  - title: Ulysses Maclaren
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+guid: 0d11cb69-3167-4299-b359-d9849c7c1bb5
+seoDescription: >-
+  Manage tenders with clear gates - from committing resources pre-tender (Gate
+  0) through to signing the contract (Gate 3). Each gate commits named
+  resources, not just a go/no-go.
+created: 2026-06-23T00:00:00.000Z
+createdBy: Ulysses Maclaren
+createdByEmail: ulyssesmaclaren@ssw.com.au
+lastUpdated: 2026-06-23T00:00:00.000Z
+lastUpdatedBy: Ulysses Maclaren
+lastUpdatedByEmail: ulyssesmaclaren@ssw.com.au
+---
+
+A tender can quietly soak up days of effort before anyone has formally decided it is worth pursuing - or committed the people needed to win it. Teams often treat a gate as a simple "go/no-go" tick box, but the real value of a gate is committing *named resources* to the next stage. Without gates, work happens by default and the right people are never locked in.
+
+<endIntro />
+
+A **gate** is a checkpoint where the business decides whether to commit named resources to the next stage of a tender. Passing a gate is not just a go/no-go decision - it means specific, named people are committed to the work ahead.
+
+There are four gates in the tender process.
+
+## Gate 0 - Commit resources pre-tender
+
+Before a tender is even on the table, decide whether to invest in positioning for the opportunity - and commit the named people who will do that work. This is not just a "go/no-go"; named resources are committed.
+
+## Gate 1 - Commit resources to complete the tender
+
+Once the tender is released, decide whether to respond and commit the named [Tender Team](/set-tender-team-roles) to complete the response. Again, this is not just a "go/no-go" - named resources are committed.
+
+## Gate 2 - Submit the tender
+
+Commit to finalising and submitting the tender response by the deadline.
+
+## Gate 3 - Sign the contract and hand over to the business
+
+If the bid is won, sign the contract and hand the engagement over to the business to deliver.


### PR DESCRIPTION
## Description

Adds a new **Rules to Better Tenders** rule (positioned as **#2**, after the Tender Team roles rule) explaining what each tender gate is for.

The gate model (authoritative, per SSW):

- **Gate 0** — Commit resources pre-tender (named resources, not just a go/no-go)
- **Gate 1** — Commit resources to complete the tender (named resources, not just a go/no-go)
- **Gate 2** — Submit the tender
- **Gate 3** — Sign the contract and hand over to the business

## Changes

- Added `public/uploads/rules/tender-gates/rule.mdx`
- Added it as the 2nd entry in `categories/client-engagement/rules-to-better-tenders.mdx`
- **Corrected** the `set-tender-team-roles` rule: its gate references previously said "Gate 1 - Bid/No-Bid through to Gate 4" / "at Gate 1 (Bid/No-Bid)", which do **not** match the actual Gate 0–3 model. Updated to "Gate 0 through to Gate 3" / "at Gate 0 or Gate 1", and cross-linked the new rule.

Frontmatter validation and markdownlint pass; GUID and URI confirmed unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)