### PR TITLE
Expand tender gates and Tender Team roles rules with detailed content

### DIFF
--- a/public/uploads/rules/set-tender-team-roles/rule.mdx
+++ b/public/uploads/rules/set-tender-team-roles/rule.mdx
@@ -29,16 +29,21 @@ There are four roles to set on every Tender Team. One person can cover more than
 
 The Bid Manager runs the bid and is accountable for getting it submitted on time and to plan.
 
-* Sets the bid plan
-* Measures progress against the plan
-* Measures progress against the [gates](/tender-gates) (Gate 0 through to Gate 3)
+* Drafts and agrees the bid plan
+* Measures progress to plan
+* Sets meetings:
+  * Cadence (regular updates)
+  * Schedules the [gate](/tender-gates) meetings (G0, G1, G2, G3) with the correct attendees
+* Measures progress towards the gates
+* Helps solve issues across the bid as they arise
+* Champions the Delegation of Authority (DoA) to the business - is the resource most expected to recall the contents of the DoA
 
 ## Bid Writer
 
 The Bid Writer owns the written quality and consistency of the response. This role can be - and often is - carried out by the Bid Manager.
 
-* Writes the non-technical parts of the bid - Executive Summary, Company Overview, and References
-* Owns formatting and consistency across the whole bid
+* Writes the non-technical parts of the bid - e.g. Executive Summary, Company Overview, and References
+* Sets the standard for document quality across the bid, including but not limited to formatting
 
 This role has historically been a gap on tender teams, so make sure it is explicitly assigned to someone.
 
@@ -47,9 +52,9 @@ This role has historically been a gap on tender teams, so make sure it is explic
 Sales owns the client relationship and the commercial shape of the bid.
 
 * Owns the client interface
-* Owns the [Win Strategy](/do-you-define-win-strategies-and-win-themes)
-* Sets the target price
-* Owns the commercial aspects of the bid
+* Sets the [Win Strategy](/do-you-define-win-strategies-and-win-themes) (subject to G1/G2 approval)
+* Sets the target price (subject to G1/G2 approval)
+* Owns the commercial aspects of the bid (subject to G1/G2 approval)
 
 ## Pre-sales Solution Architect
 
@@ -60,3 +65,5 @@ The Pre-sales Solution Architect owns the technical solution in the bid. This sh
 * By default, this person is also the resource selected to run the project if the bid is won
 
 Maintain a pool of Pre-sales Solution Architects so you are never blocked waiting on a single person. Today Cookie and Gert can fill this role - actively grow the pool beyond them.
+
+*This pre-sales work is not charged.*

--- a/public/uploads/rules/tender-gates/rule.mdx
+++ b/public/uploads/rules/tender-gates/rule.mdx
@@ -29,16 +29,40 @@ There are four gates in the tender process.
 
 ## Gate 0 - Commit resources pre-tender
 
-Before a tender is even on the table, decide whether to invest in positioning for the opportunity - and commit the named people who will do that work. This is not just a "go/no-go"; named resources are committed.
+Gate 0 is used to request approval before meaningful non-Sales work is undertaken on a sales opportunity, prior to - or without - a tender being released.
+
+Gate 0 approval covers both:
+
+* Approval to conduct work on the opportunity using resources outside Sales
+* Approval of the named resources and their proposed time allocation
+
+Sales may determine that a Gate 0 meeting is required. Where required, the meeting is scheduled by the Bid Manager. Other than Sales, resources are not approved to conduct meaningful work on a sales opportunity unless Gate 0 has been passed. The Bid Manager records the outcome.
 
 ## Gate 1 - Commit resources to complete the tender
 
-Once the tender is released, decide whether to respond and commit the named [Tender Team](/set-tender-team-roles) to complete the response. Again, this is not just a "go/no-go" - named resources are committed.
+Gate 1 is used to request approval to commit resources to prepare an RFx response, or a major quote that requires non-Sales resources. This is commonly referred to as the **Go/No Go decision**.
+
+Gate 1 approval covers both:
+
+* Approval to conduct work using resources outside Sales
+* Approval of the named resources and their proposed time allocation
+
+Sales may determine that a Gate 1 meeting is required. Where required, the meeting is scheduled by the Bid Manager. A [Bid Team](/set-tender-team-roles) cannot be formed unless Gate 1 has been passed. The Bid Manager records the outcome.
 
 ## Gate 2 - Submit the tender
 
-Commit to finalising and submitting the tender response by the deadline.
+Gate 2 is used to approve finalisation and submission of the tender response by the required deadline. The target is to request Gate 2 approval at least two days before the submission deadline.
+
+The approver may:
+
+* Approve submission
+* Approve submission conditionally, on the understanding that specified conditions will be met before submission
+* Decline submission
+
+The Bid Manager records the outcome.
 
 ## Gate 3 - Sign the contract and hand over to the business
 
-If the bid is won, sign the contract and hand the engagement over to the business to deliver.
+Gate 3 is used when the bid has been won, to approve contract signature and hand the engagement over to the business for delivery.
+
+The Bid Team is responsible for ensuring the business is fully informed about the project that has been won, including the scope, commitments, assumptions, risks, obligations, commercial position, and any conditions agreed during the tender or contract process.


### PR DESCRIPTION
## Description

Fleshes out both tender rules with the detailed, authoritative content (provided by Ulysses).

### Gates rule (`tender-gates`)
Each gate now has its full definition - purpose, what the approval covers, who can call the meeting, and who records the outcome:

- **Gate 0** — Commit resources pre-tender (approval before non-Sales work begins on an opportunity)
- **Gate 1** — Commit resources to complete the tender (the Go/No Go decision; a Bid Team cannot be formed until this passes)
- **Gate 2** — Submit the tender (target: request approval ≥2 days before deadline; approve / approve conditionally / decline)
- **Gate 3** — Sign the contract and hand over to the business

### Roles rule (`set-tender-team-roles`)
- **Bid Manager:** drafts/agrees the bid plan, sets cadence + gate meetings (G0–G3) with correct attendees, measures progress to plan and gates, champions the Delegation of Authority (DoA)
- **Bid Writer:** sets the standard for document quality across the bid
- **Sales:** Win Strategy / Target Price / commercial aspects now noted as subject to G1/G2 approval
- **Pre-sales Solution Architect:** added that this pre-sales work is not charged

Frontmatter validation and markdownlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)