### PR TITLE
categories/communication/rules to better meetings reordering (PR from TinaCMS)

### DIFF
--- a/categories/communication/rules-to-better-meetings.mdx
+++ b/categories/communication/rules-to-better-meetings.mdx
@@ -1,32 +1,36 @@
 ---
-_template: category
 type: category
 title: Rules to Better Meetings
-guid: cf08b1ee-84d0-418f-8098-68496da29094
 uri: rules-to-better-meetings
-seoDescription: How to run effective, productive meetings. Learn best practices for agendas, facilitation, time management, and follow-up actions.
+guid: cf08b1ee-84d0-418f-8098-68496da29094
+seoDescription: 'How to run effective, productive meetings. Learn best practices for agendas, facilitation, time management, and follow-up actions.'
 index:
-- rule: public/uploads/rules/make-sure-the-meeting-needs-to-exist/rule.mdx
-- rule: public/uploads/rules/only-invite-the-minimum-number-of-people-possible/rule.mdx
-- rule: public/uploads/rules/teams-meetings-vs-group-chats/rule.mdx
-- rule: public/uploads/rules/the-3-criteria-that-make-a-good-meeting/rule.mdx
-- rule: public/uploads/rules/great-meetings/rule.mdx
-- rule: public/uploads/rules/share-the-agenda/rule.mdx
-- rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
-- rule: public/uploads/rules/recognize-anchoring-effects/rule.mdx
-- rule: public/uploads/rules/uncover-hidden-anchor-client/rule.mdx
-- rule: public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
-- rule: public/uploads/rules/creating-action-items/rule.mdx
-- rule: public/uploads/rules/loop-someone-in/rule.mdx
-- rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
-- rule: public/uploads/rules/keep-track-of-a-parking-lot-for-topics/rule.mdx
-- rule: public/uploads/rules/getting-a-busy-person-into-the-meeting/rule.mdx
-- rule: public/uploads/rules/record-teams-meetings/rule.mdx
-- rule: public/uploads/rules/use-ai-for-meeting-notes/rule.mdx
-- rule: public/uploads/rules/speak-up-in-meetings/rule.mdx
-- rule: public/uploads/rules/meetings-in-english/rule.mdx
-- rule: public/uploads/rules/test-your-microphone-camera-and-audio-before-meetings/rule.mdx
-
+  - rule: public/uploads/rules/make-sure-the-meeting-needs-to-exist/rule.mdx
+  - rule: public/uploads/rules/great-meetings/rule.mdx
+  - rule: public/uploads/rules/only-invite-the-minimum-number-of-people-possible/rule.mdx
+  - rule: public/uploads/rules/getting-a-busy-person-into-the-meeting/rule.mdx
+  - rule: public/uploads/rules/share-the-agenda/rule.mdx
+  - rule: public/uploads/rules/test-your-microphone-camera-and-audio-before-meetings/rule.mdx
+  - rule: public/uploads/rules/teams-meetings-vs-group-chats/rule.mdx
+  - rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
+  - rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
+  - rule: public/uploads/rules/meetings-in-english/rule.mdx
+  - rule: public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
+  - rule: public/uploads/rules/keep-track-of-a-parking-lot-for-topics/rule.mdx
+  - rule: public/uploads/rules/speak-up-in-meetings/rule.mdx
+  - rule: public/uploads/rules/recognize-anchoring-effects/rule.mdx
+  - rule: public/uploads/rules/uncover-hidden-anchor-client/rule.mdx
+  - rule: public/uploads/rules/creating-action-items/rule.mdx
+  - rule: public/uploads/rules/record-teams-meetings/rule.mdx
+  - rule: public/uploads/rules/use-ai-for-meeting-notes/rule.mdx
+  - rule: public/uploads/rules/loop-someone-in/rule.mdx
+  - rule: public/uploads/rules/the-3-criteria-that-make-a-good-meeting/rule.mdx
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-23T21:51:26.795Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
+_template: category
 ---
 
 Meetings that lack efficiency frequently occur because:


### PR DESCRIPTION
as per @adamcogan 's request

> 1. The 2 circles should be moved up because they happen before the meeting
> 2. The 2 others about recording should be next to each other

<img width="445" height="446" alt="Screenshot 2026-06-23 at 2 51 38 PM" src="https://github.com/user-attachments/assets/c4a556ec-fcbc-4ec9-b794-6a3b9a72f308" />
