### PR TITLE
public/uploads/rules/github content changes added yakshaver (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: 'GitHub makes reviewing changes easy through "Pull Requests". Re
 created: 2022-05-02T23:52:00.699Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T23:42:41.277Z
+lastUpdated: 2026-06-29T23:44:13.713Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---

--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: 'GitHub makes reviewing changes easy through "Pull Requests". Re
 created: 2022-05-02T23:52:00.699Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T20:58:32.846Z
+lastUpdated: 2026-06-29T23:42:41.277Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
@@ -56,9 +56,13 @@ Done! Your review has been submitted ⭐
 
 <boxEmbed
   body={<>
-    ### Use YakShaver to make changes easier to review
+    ### Use YakShaver to create PBIs and make PR changes easier to review
     
-    Some Pull Requests are too complex to understand from the diff alone. When the context is not obvious, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change.
+    A PR does not always need a PBI, but it should always make the reason for the change easy to understand.
+    
+    Some Pull Requests are too complex to understand from the diff alone. Use a PBI when the work needs context, review criteria, or traceability beyond the PR itself.
+    
+    In these cases, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change.
     
     YakShaver turns that explanation into a clear PBI, making the intent, impact, and review points visible to everyone.
   </>}

--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -1,80 +1,68 @@
 ---
-authors:
-- title: Adam Cogan
-  url: https://www.ssw.com.au/people/adam-cogan
-- title: Piers Sinclair
-  url: https://www.ssw.com.au/people/piers-sinclair
-created: 2022-05-02 23:52:00.699000+00:00
-guid: d48a43d5-83cd-4336-838b-b8e54187e3c1
-related:
-- rule: public/uploads/rules/include-links-in-dones/rule.mdx
-seoDescription: GitHub makes reviewing changes easy through "Pull Requests". Reviewing
-  a Pull Request involves examining changes using tabs - Conversations, Commits, Checks,
-  and Files changed.
-title: Do you know how to make content changes on GitHub?
+type: rule
+title: Do you know how to review GitHub content changes?
+uri: github-content-changes
 categories:
   - category: categories/project-delivery/rules-to-better-github.mdx
-type: rule
-uri: github-content-changes
+authors:
+  - title: Adam Cogan
+    url: 'https://www.ssw.com.au/people/adam-cogan'
+  - title: Piers Sinclair
+    url: 'https://www.ssw.com.au/people/piers-sinclair'
+related:
+  - rule: public/uploads/rules/include-links-in-dones/rule.mdx
+guid: d48a43d5-83cd-4336-838b-b8e54187e3c1
+seoDescription: 'GitHub makes reviewing changes easy through "Pull Requests". Reviewing a Pull Request involves examining changes using tabs - Conversations, Commits, Checks, and Files changed.'
+created: 2022-05-02T23:52:00.699Z
+createdBy: Tiago Araujo
+createdByEmail: TiagoAraujo@ssw.com.au
+lastUpdated: 2026-06-29T20:54:56.628Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
 
 Some websites use GitHub to manage their content (e.g. [SSW Rules](https://github.com/SSWConsulting/SSW.Rules.Content)). GitHub makes reviewing changes easy through "Pull Requests".
 
-A Pull Request is a request to make changes to 1 or more files. GitHub provides out of the box functionality for reviewing changes in a pull request. This process is as follows:
+A Pull Request is a request to make changes to 1 or more files. GitHub provides out of the box functionality for reviewing changes in a pull request. 
 
 <endIntro />
 
-1. Open the Pull Request
-2. Examine the changes using the tabs:
-   * **Conversations:** Comments people have made about the change
-   * **Commits:** Summary of the changes the requester has made
-   * **Checks:** You can ignore this if you are not a developer
-   * **Important - Files changed:** See the difference between the old and new files being changed. Red highlighting indicates deleted parts and green highlighting indicates added parts.
-     This visual preview of the changes to a markdown file is accessed via **Files changed | Display the rich diff**
+## Reviewing
 
+Open the Pull Request and examine the changes using the tabs:
 
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
+* **Conversations:** Comments people have made about the change
+* **Commits:** Summary of the changes the requester has made
+* **Checks:** You can ignore this if you are not a developer
+* **Files changed (important):** See the difference between the old and new files being changed. Red highlighting indicates deleted parts and green highlighting indicates added parts.
+  This visual preview of the changes to a markdown file is accessed via **Files changed | Display the rich diff**
+
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Reviewing tabs in a GitHub Pull Request" src="https://user-images.githubusercontent.com/79821522/113648288-bb515b80-96cf-11eb-9f9c-3169e2f64a95.png" />
+
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="The view via &#x22;Display the rich diff&#x22; button" src="https://user-images.githubusercontent.com/79821522/113648341-d15f1c00-96cf-11eb-8357-81a79ac0765d.png" />
+
+## Approving / asking for extra changes
+
+Go to **Files changed | Review changes** and** **Select an option:
+
+1. Choose "Approve" to mark it as ready to go live
+   Add a comment with feedback (if necessary)
+2. Choose "Comment" for general feedback when PR it's not ready for approval
+3. Choose "Request changes" for mandatory changes to the PR
+
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Steps for submitting a Pull Request review" src="https://user-images.githubusercontent.com/79821522/113798232-26656580-9796-11eb-92dd-00a4385cac8b.png" />
+
+Done! Your review has been submitted ⭐
+
+<boxEmbed
+  body={<>
+    ## Use YakShaver to make changes easier to review
+    
+    Some Pull Requests are too complex to understand from the diff alone. When the context is not obvious, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change.
+    
+    YakShaver turns that explanation into a clear PBI, making the intent, impact, and review points visible to everyone.
+  </>}
   figurePrefix="none"
-  figure="Reviewing tabs in a GitHub Pull Request"
-  src="https://user-images.githubusercontent.com/79821522/113648288-bb515b80-96cf-11eb-9f9c-3169e2f64a95.png"
+  figure=""
+  style="yakshaver"
 />
-
-
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure='The view via "Display the rich diff" button'
-  src="https://user-images.githubusercontent.com/79821522/113648341-d15f1c00-96cf-11eb-8357-81a79ac0765d.png"
-/>
-
-
-3. Approve OR ask for changes
-
-   a. Go to **Files changed | Review changes**
-    b. Select an option:
-
-   * Choose "Approve" to mark it as ready to go live
-     Add a comment with feedback (if necessary)
-   * Choose "Comment" for general feedback when PR it's not ready for approval
-   * Choose "Request changes" for mandatory changes to the PR
-
-   c. Press "Submit review" so that the requester can see it
-
-
-<imageEmbed
-  alt="Image"
-  size="large"
-  showBorder={false}
-  figurePrefix="none"
-  figure="Steps for submitting a Pull Request review"
-  src="https://user-images.githubusercontent.com/79821522/113798232-26656580-9796-11eb-92dd-00a4385cac8b.png"
-/>
-
-
-4. Done - your review has been submitted ⭐

--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: 'GitHub makes reviewing changes easy through "Pull Requests". Re
 created: 2022-05-02T23:52:00.699Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T23:44:13.713Z
+lastUpdated: 2026-06-29T23:52:11.642Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
@@ -58,13 +58,11 @@ Done! Your review has been submitted ⭐
   body={<>
     ### Use YakShaver to create PBIs and make PR changes easier to review
     
-    A PR does not always need a PBI, but it should always make the reason for the change easy to understand.
+    Most PRs will need a PBI. It should make the reason for the change easy to understand.
     
-    Some Pull Requests are too complex to understand from the diff alone. Use a PBI when the work needs context, review criteria, or traceability beyond the PR itself.
+    If a Pull Request with no PBI linked gets too complex to understand from the diff alone, create a PBI to show the context, review criteria, or traceability beyond the PR itself.
     
-    In these cases, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change.
-    
-    YakShaver turns that explanation into a clear PBI, making the intent, impact, and review points visible to everyone.
+    In these cases, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change. YakShaver turns that explanation into a clear PBI, making the intent, impact, and review points visible to everyone.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: 'GitHub makes reviewing changes easy through "Pull Requests". Re
 created: 2022-05-02T23:52:00.699Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T20:54:56.628Z
+lastUpdated: 2026-06-29T20:58:32.846Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
@@ -56,7 +56,7 @@ Done! Your review has been submitted ⭐
 
 <boxEmbed
   body={<>
-    ## Use YakShaver to make changes easier to review
+    ### Use YakShaver to make changes easier to review
     
     Some Pull Requests are too complex to understand from the diff alone. When the context is not obvious, use [YakShaver](https://yakshaver.ai/) to record your screen and voice while walking through the change.
     


### PR DESCRIPTION
Added YakShaver box as per @adamcogan 's email subject: **GitHub PRs are worse than YakShaver**

Adam thinks every PR should help the reviewer to see the before and after. Adam had a hard time reading the diff, so he believes a video (via YakShaver) would solve the problem.

This PR is to add this extra process to the rule.

> Tiago

> 1. Do we have a rule on this?
> <img width="320" height="240" alt="SSWConsultingSSW Rules Content  publicuploadsrulesstick to-the-agenda-and-complete-the-meetings-goalrule (PR from TinaCMS)" src="https://github.com/user-attachments/assets/444fd361-e5a6-4048-a369-09ff2fe34e5f" />

 
> Figure: Bad example - hard to visualize before and after
> -a