### PR TITLE
public/uploads/rules/write a good pull request added yakshaver box (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -35,19 +35,34 @@ seoDescription: Discover tips on writing effective Pull Requests with clear titl
 created: 2020-07-17T01:21:08.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-04-14T00:29:51.264Z
+lastUpdated: 2026-06-29T21:09:20.229Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 archivedreason: null
 ---
 
-As a software developer, you are going to create Pull Requests (PRs) that you want to be easy for others to review and approve. The quality of a Pull Request can vary - from cryptic to well-written.
+As a software developer, you are going to create Pull Requests (PRs) that you want to be easy for others to review and approve. The quality of a Pull Request can vary from cryptic to well-written.
 
 Including a little bit of context helps your reviewer understand changes quickly so they can review your PR faster and give better suggestions.
 
-There are 2 essential things you should have when writing a Pull Request:
-
 <endIntro />
+
+<boxEmbed
+  body={<>
+    ### Use YakShaver to make PBIs and PRs easier to review
+    
+    You can save time by not writing PBIs manually. Simply record your screen and voice with [YakShaver](https://yakshaver.ai/), then let AI turn your walkthrough into a clear PBI.
+    
+    YakShaver gives reviewers the context, intent, and key points they need to understand the change faster.
+    
+    Link your PR to the PBI so all the details, decisions, and background are easy to access during review.
+  </>}
+  figurePrefix="none"
+  figure=""
+  style="yakshaver"
+/>
+
+There are 2 essential things you should have in a great Pull Request:
 
 ## 1. Concise and self-explanatory **title**
 
@@ -87,36 +102,40 @@ Having the **"What"** information allows the reviewers to quickly understand wha
 
 The Pull Request description is a medium for the developer to tell the reviewers what the changes are about.
 
-Good **PR descriptions** provide context to help others quickly understand the problem, solution, and rationale. This minimizes confusion, accelerates reviews, and improves overall code quality.
-
 <boxEmbed
-  style="tips"
   body={<>
-    **Tip:** For rare straight-forward changes, the self-explanatory title might be enough. You should still make sure there is enough details so the reviewer knows what initiated the changes.
+    ### Use YakShaver to make PBIs and PRs easier to review
     
-    E.g.: “Fixed broken LinkedIn link caught by CodeAuditor on footer”
+    You can save time by not writing PBIs manually. Simply record your screen and voice with [YakShaver](https://yakshaver.ai/), then let AI turn your walkthrough into a clear PBI.
+    
+    YakShaver gives reviewers the context, intent, and key points they need to understand the change faster.
+    
+    Link your PR to the PBI so all the details, decisions, and background are easy to access during review.
   </>}
   figurePrefix="none"
   figure=""
+  style="yakshaver"
 />
+
+Good **PR descriptions** provide context to help others quickly understand the problem, solution, and rationale. This minimizes confusion, accelerates reviews, and improves overall code quality.
 
 Examples of sentences to have in a good PR description:
 
-> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
 
-> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
+> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
 
-> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
 
-> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
 
-> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
+> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
 
-> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
-> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
+> "I/We noticed a problem: **{{ DETAILS }}**"
 
 If there is an area you are uncertain about, add:
 
@@ -124,7 +143,7 @@ If there is an area you are uncertain about, add:
 
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
+> "Done - see email: **{{ EMAIL SUBJECT }}**"
 
 <boxEmbed
   style="tips"
@@ -178,7 +197,18 @@ If the PR is closing an email task after merged, remember to refer back to it:
   figure=""
 />
 
-### How to approach making a Pull Request
+<boxEmbed
+  style="info"
+  body={<>
+    **Exception:** For **rare** straight-forward changes, the self-explanatory title might be enough. You should still make sure there is enough details so the reviewer knows what initiated the changes.
+    
+    E.g.: “Fixed broken LinkedIn link caught by CodeAuditor on footer”
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+***
 
 <youtubeEmbed url="https://www.youtube.com/watch?v=d8yGY6KsYys&t=29s" description="Video: 5 Tips For Better Pull Requests (11 min)" />
 

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -135,21 +135,21 @@ Good **PR descriptions** provide context to help others quickly understand the p
 
 Examples of sentences to have in a good PR description:
 
-> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
 
-> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
+> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
 
-> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
 
-> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
 
-> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
+> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
 
-> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
-> "I/We noticed a problem: **{{ DETAILS }}**"
+> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
 
 If there is an area you are uncertain about, add:
 
@@ -157,7 +157,7 @@ If there is an area you are uncertain about, add:
 
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **{{ EMAIL SUBJECT }}**"
+> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
 
 <boxEmbed
   style="tips"

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -35,7 +35,7 @@ seoDescription: Discover tips on writing effective Pull Requests with clear titl
 created: 2020-07-17T01:21:08.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T23:46:18.269Z
+lastUpdated: 2026-06-30T02:13:18.616Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 archivedreason: null
@@ -116,6 +116,30 @@ Having the **"What"** information allows the reviewers to quickly understand wha
 
 The Pull Request description is a medium for the developer to tell the reviewers what the changes are about.
 
+Good **PR descriptions** provide context to help others quickly understand the problem, solution, and rationale. This minimizes confusion, accelerates reviews, and improves overall code quality.
+
+Examples of sentences to have in a good PR description:
+
+> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+
+> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
+
+> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+
+> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+
+> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
+
+> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+
+If you noticed that a change needed to be made and had no specific task/issue, use:
+
+> "I/We noticed a problem: **{{ DETAILS }}**"
+
+If there is an area you are uncertain about, add:
+
+> "I'm looking for feedback on this code"
+
 <boxEmbed
   body={<>
     ### Use YakShaver to make PBIs and PRs easier to review
@@ -131,33 +155,9 @@ The Pull Request description is a medium for the developer to tell the reviewers
   style="yakshaver"
 />
 
-Good **PR descriptions** provide context to help others quickly understand the problem, solution, and rationale. This minimizes confusion, accelerates reviews, and improves overall code quality.
-
-Examples of sentences to have in a good PR description:
-
-> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
-
-> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
-
-> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
-
-> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
-
-> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
-
-> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
-
-If you noticed that a change needed to be made and had no specific task/issue, use:
-
-> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
-
-If there is an area you are uncertain about, add:
-
-> "I'm looking for feedback on this code"
-
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
+> "Done - see email: **{{ EMAIL SUBJECT }}**"
 
 <boxEmbed
   style="tips"

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -35,7 +35,7 @@ seoDescription: Discover tips on writing effective Pull Requests with clear titl
 created: 2020-07-17T01:21:08.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-06-29T21:09:20.229Z
+lastUpdated: 2026-06-29T23:46:18.269Z
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 archivedreason: null
@@ -46,6 +46,20 @@ As a software developer, you are going to create Pull Requests (PRs) that you wa
 Including a little bit of context helps your reviewer understand changes quickly so they can review your PR faster and give better suggestions.
 
 <endIntro />
+
+## Most PRs benefit from a PBI
+
+A PBI is useful when the PR represents planned work, a feature, a bug fix, client work, or anything that needs business context, acceptance criteria, or traceability.
+
+But for small or obvious changes, a PBI can be unnecessary red tape, for example:
+
+* Fixing a typo
+* Updating a broken link
+* Minor formatting/content cleanup
+* Small refactor with no functional change
+* Dependency/config cleanup where the PR explains the reason clearly
+
+PRs should be linked to a PBI when the change needs business context, acceptance criteria, prioritization, or future traceability. For small, obvious, or low-risk changes, a clear PR title and description may be enough.
 
 <boxEmbed
   body={<>
@@ -121,21 +135,21 @@ Good **PR descriptions** provide context to help others quickly understand the p
 
 Examples of sentences to have in a good PR description:
 
-> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
 
-> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
+> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
 
-> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
 
-> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
 
-> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
+> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
 
-> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
-> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
+> "I/We noticed a problem: **{{ DETAILS }}**"
 
 If there is an area you are uncertain about, add:
 
@@ -143,7 +157,7 @@ If there is an area you are uncertain about, add:
 
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
+> "Done - see email: **{{ EMAIL SUBJECT }}**"
 
 <boxEmbed
   style="tips"

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -120,21 +120,21 @@ Good **PR descriptions** provide context to help others quickly understand the p
 
 Examples of sentences to have in a good PR description:
 
-> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
 
-> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
+> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
 
-> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
 
-> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
 
-> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
+> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
 
-> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
-> "I/We noticed a problem: **{{ DETAILS }}**"
+> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
 
 If there is an area you are uncertain about, add:
 
@@ -157,7 +157,7 @@ If there is an area you are uncertain about, add:
 
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **{{ EMAIL SUBJECT }}**"
+> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
 
 <boxEmbed
   style="tips"

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -121,21 +121,21 @@ Good **PR descriptions** provide context to help others quickly understand the p
 
 Examples of sentences to have in a good PR description:
 
-> "Relates to **#{{ ISSUE NUMBER or URL }}**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
+> "Relates to **#&#123;&#123; ISSUE NUMBER or URL &#125;&#125;**" (⚠️ see [avoid linking to Issues you do **not** want to close](/avoid-auto-closing-issues/))
 
-> "From email subject: **{{ EMAIL SUBJECT }}**" (similar to the rule on [warn then call](/warn-then-call))
+> "From email subject: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**" (similar to the rule on [warn then call](/warn-then-call))
 
-> "As per my conversation with **{{ NAME(S) }}**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
+> "As per my conversation with **&#123;&#123; NAME(S) &#125;&#125;**" (similar to "[as per our conversation](/as-per-our-conversation-emails)" rule)
 
-> "Worked with **{{ @MENTION(S) }}**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
+> "Worked with **&#123;&#123; @MENTION(S) &#125;&#125;**" (as per [pair or mob programming](/do-you-use-co-creation-patterns) rule)
 
-> "This PR is to **{{ ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) }}**" (anything that was not possible to explain in the title)
+> "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
 
-> "See **{{ SCREENSHOT / DONE VIDEO }}** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+> "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
-> "I/We noticed a problem: **{{ DETAILS }}**"
+> "I/We noticed a problem: **&#123;&#123; DETAILS &#125;&#125;**"
 
 If there is an area you are uncertain about, add:
 
@@ -143,7 +143,7 @@ If there is an area you are uncertain about, add:
 
 If the PR is closing an email task after merged, remember to refer back to it:
 
-> "Done - see email: **{{ EMAIL SUBJECT }}**"
+> "Done - see email: **&#123;&#123; EMAIL SUBJECT &#125;&#125;**"
 
 <boxEmbed
   style="tips"


### PR DESCRIPTION
Added YakShaver box as per @adamcogan 's email subject: **GitHub PRs are worse than YakShaver**

Adam thinks every PR should help the reviewer to see the before and after. Adam had a hard time reading the diff, so he believes a video (via YakShaver) would solve the problem.

This PR is to add this extra process to the rule.

> Tiago

> 1. Do we have a rule on this?
> <img width="320" height="240" alt="SSWConsultingSSW Rules Content  publicuploadsrulesstick to-the-agenda-and-complete-the-meetings-goalrule (PR from TinaCMS)" src="https://github.com/user-attachments/assets/444fd361-e5a6-4048-a369-09ff2fe34e5f" />

 
> Figure: Bad example - hard to visualize before and after
> -a