### PR TITLE
Azure Marketplace rule: Add link to new consulting page

### DIFF
--- a/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
+++ b/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
@@ -15,8 +15,8 @@ seoDescription: 'Learn how to create an Azure Marketplace offer, including the r
 created: 2025-09-12T04:20:00.000Z
 createdBy: Hark
 createdByEmail: harksingh@ssw.com.au
-lastUpdated: 2026-05-01T05:14:59.354Z
-lastUpdatedBy: Hark
+lastUpdated: 2026-06-30T23:26:23.575Z
+lastUpdatedBy: 'Harkirat Singh [SSW]'
 lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null
 ---
@@ -80,5 +80,14 @@ For detailed guidance on each step, see the [Azure Application publishing guide]
 <imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="good" figure="SSW.EagleEye is published to Azure Marketplace" src="/uploads/rules/create-azure-marketplace-offer/eagleeye-azure-marketplace.png" />
 
 ***
+
+<boxEmbed
+  body={<>
+    This is a box.
+  </>}
+  figurePrefix="none"
+  figure=""
+  style="tips"
+/>
 
 SSW has helped multiple customers get their products onto the Azure Marketplace. We can help you too. Visit [SSW's Azure consulting](https://www.ssw.com.au/consulting/azure) to book a free initial meeting.

--- a/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
+++ b/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
@@ -9,13 +9,15 @@ authors:
     url: 'https://www.ssw.com.au/people/luke-mao'
   - title: Jim Zheng
     url: 'https://www.ssw.com.au/people/jim-zheng'
+  - title: Hark Singh
+    url: 'https://www.ssw.com.au/people/Hark-Singh'
 redirects: null
 guid: 56b5a7f1-ddfc-4752-917d-0dbe6db9b954
 seoDescription: 'Learn how to create an Azure Marketplace offer, including the required steps, assets, and configurations to successfully publish your solution.'
 created: 2025-09-12T04:20:00.000Z
 createdBy: Hark
 createdByEmail: harksingh@ssw.com.au
-lastUpdated: 2026-06-30T23:39:33.580Z
+lastUpdated: 2026-06-30T23:40:22.865Z
 lastUpdatedBy: 'Harkirat Singh [SSW]'
 lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null

--- a/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
+++ b/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: 'Learn how to create an Azure Marketplace offer, including the r
 created: 2025-09-12T04:20:00.000Z
 createdBy: Hark
 createdByEmail: harksingh@ssw.com.au
-lastUpdated: 2026-06-30T23:26:23.575Z
+lastUpdated: 2026-06-30T23:39:33.580Z
 lastUpdatedBy: 'Harkirat Singh [SSW]'
 lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null
@@ -83,11 +83,11 @@ For detailed guidance on each step, see the [Azure Application publishing guide]
 
 <boxEmbed
   body={<>
-    This is a box.
+    SSW has helped multiple customers get their products onto the Azure Marketplace. We can help you too.
+    
+    Visit [SSW's Azure Marketplace consulting](https://www.ssw.com.au/consulting/azure-marketplace) to book a free initial meeting.
   </>}
   figurePrefix="none"
   figure=""
   style="tips"
 />
-
-SSW has helped multiple customers get their products onto the Azure Marketplace. We can help you too. Visit [SSW's Azure consulting](https://www.ssw.com.au/consulting/azure) to book a free initial meeting.

--- a/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
+++ b/public/uploads/rules/create-azure-marketplace-offer/rule.mdx
@@ -4,6 +4,7 @@ title: Do you know how to create an Azure Marketplace offer?
 uri: create-azure-marketplace-offer
 categories:
   - category: categories/project-delivery/rules-to-better-azure-marketplace.mdx
+sidebarVideo: 'https://www.youtube.com/watch?v=bgoviwhWNPE'
 authors:
   - title: Luke Mao
     url: 'https://www.ssw.com.au/people/luke-mao'
@@ -17,7 +18,7 @@ seoDescription: 'Learn how to create an Azure Marketplace offer, including the r
 created: 2025-09-12T04:20:00.000Z
 createdBy: Hark
 createdByEmail: harksingh@ssw.com.au
-lastUpdated: 2026-06-30T23:40:22.865Z
+lastUpdated: 2026-06-30T23:42:37.331Z
 lastUpdatedBy: 'Harkirat Singh [SSW]'
 lastUpdatedByEmail: harksingh@ssw.com.au
 archivedreason: null


### PR DESCRIPTION
As per Adam's email task, need to create new Azure marketplace consulting page (https://www.ssw.com.au/consulting/azure-marketplace) and then link on the rule