### PR TITLE
Add SSW's preferred KPI metrics to employee-kpis rule

### DIFF
--- a/public/uploads/rules/employee-kpis/rule.mdx
+++ b/public/uploads/rules/employee-kpis/rule.mdx
@@ -68,7 +68,16 @@ Qualitative KPIs provide more room to make a subjective judgment.
 
 There's lots of metrics that can be measured, and the right ones are going to depend on what is important to the organization.
 
-For example, SSW is a consulting company and has particular metrics for a consultant (see [SSW template for Annual Review KPIs](https://github.com/SSWConsulting/SSW.EmployeeKPIs).
+For example, SSW is a consulting company and has particular metrics for a consultant (see [SSW template for Annual Review KPIs](https://github.com/SSWConsulting/SSW.EmployeeKPIs)).
 [Tina](https://tina.io) is a product company and there would be different metrics for an engineer.
 
 \<!-- TODO: Add link to Tina KPIs -->
+
+#### Metrics SSW uses
+
+Adam prefers KPIs that are backed by data SSW already captures, rather than numbers employees report themselves:
+
+- **[EagleEye](https://ssweagleeye.com/)** - AI-driven insights mined from company emails, giving visibility into an employee's output and communication
+- **[Checked by xxx](https://www.ssw.com.au/rules/checked-by-xxx)** - how often an employee's work (emails, code, and content) goes through a second pair of eyes
+- **YakShaves** - PBIs raised via [YakShaver](https://yakshaver.ai/), showing how proactively an employee turns problems and ideas into tracked backlog items
+- **Rule updates** - contributions to SSW's shared IP, including [SSW Rules](https://www.ssw.com.au/rules), SugarLearning content, and intranet improvements


### PR DESCRIPTION
Updates the [employee-kpis](https://www.ssw.com.au/rules/employee-kpis) rule's **Metrics to measure** section.

## Changes
- New **Metrics SSW uses** subsection covering Adam's preferred, data-backed KPIs:
  - **EagleEye** — AI insights mined from company emails
  - **Checked by xxx** — work reviewed by a second pair of eyes
  - **YakShaves** — PBIs raised via YakShaver
  - **Rule updates** — contributions to SSW Rules, SugarLearning, and the intranet
- Fixed a pre-existing unclosed `(` on the KPI template line

🤖 Generated with [Claude Code](https://claude.com/claude-code)