### PR TITLE
Remove leftover TODO box from MAC address rule

### DIFF
--- a/public/uploads/rules/how-to-find-your-mac-address/rule.mdx
+++ b/public/uploads/rules/how-to-find-your-mac-address/rule.mdx
@@ -30,17 +30,6 @@ To help with automation (e.g. [SophieBot](https://sswsophie.com/sophiebot/)) you
 
 
 <boxEmbed
-  style="todo"
-  body={<>
-    **TODO: Uly**
-  </>}
-  figurePrefix="none"
-  figure=""
-/>
-
-
-
-<boxEmbed
   style="greybox"
   body={<>
     Learn more about [SSW SophieBot AI and its feature of employees' presence check on SugarLearning](https://my.sugarlearning.com/SSW/items/12973/smart-office-ssw-sophiehub-and-ssw-sophiebot).


### PR DESCRIPTION
**TL;DR** Removes a stray `TODO: Uly` placeholder box that is rendering live on the [How to find your MAC address](https://www.ssw.com.au/rules/how-to-find-your-mac-address) rule.

**Pain:** The published rule shows an internal `**TODO: Uly**` box to readers, which is an unfinished editorial note that should never have shipped.

**Solution:** Deleted the orphaned `<boxEmbed style="todo">` block containing `**TODO: Uly**`. No other content changed.