### PR TITLE
Add Levi Jackson as acknowledgement on fixed-price rules

### DIFF
--- a/public/uploads/rules/fixed-price-vs-time-and-materials/rule.mdx
+++ b/public/uploads/rules/fixed-price-vs-time-and-materials/rule.mdx
@@ -13,6 +13,8 @@ authors:
     url: 'https://www.ssw.com.au/people/jean-thirion'
   - title: Ulysses Maclaren
     url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+  - title: Levi Jackson
+    url: 'https://www.ssw.com.au/people/levi-jackson'
 related:
   - rule: public/uploads/rules/fixed-price-deliver-the-project-and-start-the-warranty-period/rule.mdx
   - rule: public/uploads/rules/the-drawbacks-of-fixed-price-fixed-scope-contracts/rule.mdx

--- a/public/uploads/rules/the-drawbacks-of-fixed-price-fixed-scope-contracts/rule.mdx
+++ b/public/uploads/rules/the-drawbacks-of-fixed-price-fixed-scope-contracts/rule.mdx
@@ -11,6 +11,8 @@ authors:
     url: 'https://www.ssw.com.au/people/marlon-marescia'
   - title: Ulysses Maclaren
     url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+  - title: Levi Jackson
+    url: 'https://www.ssw.com.au/people/levi-jackson'
 related:
   - rule: public/uploads/rules/fixed-price-vs-time-and-materials/rule.mdx
 redirects:


### PR DESCRIPTION
Adds **Levi Jackson** ([people/levi-jackson](https://www.ssw.com.au/people/levi-jackson)) as an acknowledgement, alongside Ulysses Maclaren, on two related rules:

- `fixed-price-vs-time-and-materials`
- `the-drawbacks-of-fixed-price-fixed-scope-contracts`

Content is unchanged; only the `authors` list in each rule's frontmatter is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)