### PR TITLE
🦅 Content Hawk: refresh Rules to Better AI Use for 2026 accuracy

### DIFF
--- a/public/uploads/rules/avoid-automation-bias/rule.mdx
+++ b/public/uploads/rules/avoid-automation-bias/rule.mdx
@@ -108,7 +108,7 @@ When creating tools that are prone to mistakes, include exact error rates:
 <boxEmbed
   style="greybox"
   body={<>
-    [Veracode's 2025 research](https://www.veracode.com/resources/analyst-reports/2025-genai-code-security-report/) found 45% of AI-generated code contains security vulnerabilities. Ensure you review it.
+    [Veracode's 2025 research](https://www.veracode.com/blog/genai-code-security-report/) found 45% of AI-generated code contains security vulnerabilities. Ensure you review it.
   </>}
   figurePrefix="good"
   figure="More specific warning, people are more likely to take it seriously"

--- a/public/uploads/rules/avoid-automation-bias/rule.mdx
+++ b/public/uploads/rules/avoid-automation-bias/rule.mdx
@@ -108,7 +108,7 @@ When creating tools that are prone to mistakes, include exact error rates:
 <boxEmbed
   style="greybox"
   body={<>
-    Veracode's 2025 research found 45% of AI-generated code contains security vulnerabilities. Ensure you review it.
+    [Veracode's 2025 research](https://www.veracode.com/resources/analyst-reports/2025-genai-code-security-report/) found 45% of AI-generated code contains security vulnerabilities. Ensure you review it.
   </>}
   figurePrefix="good"
   figure="More specific warning, people are more likely to take it seriously"

--- a/public/uploads/rules/avoid-automation-bias/rule.mdx
+++ b/public/uploads/rules/avoid-automation-bias/rule.mdx
@@ -108,7 +108,7 @@ When creating tools that are prone to mistakes, include exact error rates:
 <boxEmbed
   style="greybox"
   body={<>
-    Studies have found that 25% of AI-generated code has security vulnerabilities. Ensure you review it.
+    Veracode's 2025 research found 45% of AI-generated code contains security vulnerabilities. Ensure you review it.
   </>}
   figurePrefix="good"
   figure="More specific warning, people are more likely to take it seriously"

--- a/public/uploads/rules/best-ai-tools/rule.mdx
+++ b/public/uploads/rules/best-ai-tools/rule.mdx
@@ -71,7 +71,7 @@ LMArena is a public, web-based platform that evaluates large language models thr
 
 * ⭐💲 **[Gamma.app](https://www.gamma.app)** - Revolutionizes presentation creation with interactive and dynamic slides
 * ⭐ **[Napkin](https://www.napkin.ai/)** - Turns your text into visuals, making it easy to share ideas in clear and engaging presentations
-* 💲 **[Beautiful.ai](https://www.beautiful.ai)** - Automatically designs stunning slides bas
+* 💲 **[Beautiful.ai](https://www.beautiful.ai)** - Automatically designs stunning slides based on your content
 * **[Pitch](https://www.pitch.com)** - Collaborative presentation tool that leverages AI for enhanced slide design and data integration
 
 ### Image and design creation

--- a/public/uploads/rules/chatgpt-can-fix-errors/rule.mdx
+++ b/public/uploads/rules/chatgpt-can-fix-errors/rule.mdx
@@ -25,7 +25,7 @@ ChatGPT helps smooth this process. Simply paste the error into ChatGPT and it wi
 For example, let's say you try to run ef migrations using the command:
 
 ```markup
-dotnet ef database-update
+dotnet ef database update
 ```
 
 If this command gives you an error like:
@@ -47,7 +47,7 @@ Then you could ask ChatGPT and it would give you the solution!
 />
 
 
-### Try it yourself, copy and paste this into [ChatGPT](https://chat.openai.com/)
+### Try it yourself, copy and paste this into [ChatGPT](https://chatgpt.com/)
 
 ```markup
 What is this error in EF Core?

--- a/public/uploads/rules/chatgpt-can-help-code/rule.mdx
+++ b/public/uploads/rules/chatgpt-can-help-code/rule.mdx
@@ -68,7 +68,7 @@ ChatGPT can be used for:
 
 
 
-### Try it yourself, copy and paste this into [ChatGPT](https://chat.openai.com)
+### Try it yourself, copy and paste this into [ChatGPT](https://chatgpt.com/)
 
 ``` markup
 What does this code do?

--- a/public/uploads/rules/chatgpt-cheat-sheet/rule.mdx
+++ b/public/uploads/rules/chatgpt-cheat-sheet/rule.mdx
@@ -172,6 +172,6 @@ For more on this prompt structure, see: [Do you know the fundamentals of Prompt 
 
 ## Prompt Chaining
 
-Prompt chaining is the technique of guiding GTP's responses by asking a series of related questions or prompts, building upon the previous answers to obtain more coherent and relevant information.
+Prompt chaining is the technique of guiding GPT's responses by asking a series of related questions or prompts, building upon the previous answers to obtain more coherent and relevant information.
 
 For an example on this, see: [Do you use prompt chaining?](/chained-prompting)

--- a/public/uploads/rules/chatgpt-security-risks/rule.mdx
+++ b/public/uploads/rules/chatgpt-security-risks/rule.mdx
@@ -66,7 +66,7 @@ You should never submit any confidential information into ChatGPT. Specifically,
 
 ### Current regulations
 
-* The EU AI Act - the world's first comprehensive AI regulation - is now in force, with most obligations applying from August 2026
+* The [EU AI Act](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) - the world's first comprehensive AI regulation - is now in force, with most obligations applying from August 2026
 * Compliance with existing data protection and privacy regulations (e.g., GDPR, CCPA) still applies
 * Expect AI-specific obligations to keep expanding, so review your regulatory exposure regularly
 

--- a/public/uploads/rules/chatgpt-security-risks/rule.mdx
+++ b/public/uploads/rules/chatgpt-security-risks/rule.mdx
@@ -66,8 +66,8 @@ You should never submit any confidential information into ChatGPT. Specifically,
 
 ### Current regulations
 
-* No specific regulations for AI systems like ChatGPT
-* Compliance with existing data protection and privacy regulations (e.g., GDPR, CCPA)
-* Proposed AI Act could become the first comprehensive regulation for AI technologies
+* The EU AI Act - the world's first comprehensive AI regulation - is now in force, with most obligations applying from August 2026
+* Compliance with existing data protection and privacy regulations (e.g., GDPR, CCPA) still applies
+* Expect AI-specific obligations to keep expanding, so review your regulatory exposure regularly
 
 Always exercise caution when using ChatGPT and avoid sharing sensitive information, as data retention policies and security measures can only provide a certain level of protection.

--- a/public/uploads/rules/chatgpt-skills-weaknesses/rule.mdx
+++ b/public/uploads/rules/chatgpt-skills-weaknesses/rule.mdx
@@ -160,9 +160,9 @@ And there are also areas where it performs poorly.
 
 ## ❌ Dont use it for
 
-### 1. Non-textual information
+### 1. Guaranteed factual accuracy
 
-It is not designed to process or generate images, audio, or other non-textual information.
+It can sound confident while being wrong. Always verify facts, figures, and citations against a trusted source before relying on them.
 
 ### 2. Mathematics
 

--- a/public/uploads/rules/connect-chatgpt-with-virtual-assistant/rule.mdx
+++ b/public/uploads/rules/connect-chatgpt-with-virtual-assistant/rule.mdx
@@ -12,7 +12,7 @@ created: 2023-04-03T19:20:03.477Z
 guid: 0e81c003-a3a4-45c9-9f5e-5871e972644f
 ---
 
-Integrating ChatGPT with your personal assistant, such as Siri for iPhone or Google Assistant for Android, can greatly enhance your mobile experience. This rule will guide you through the steps to connect ChatGPT with Siri and Google Assistant.
+Integrating ChatGPT with your personal assistant, such as Siri for iPhone or Google Assistant or Gemini for Android, can greatly enhance your mobile experience. This rule will guide you through the steps to connect ChatGPT with Siri and your Android assistant.
 
 <endIntro />
 
@@ -22,8 +22,8 @@ Integrating ChatGPT with your personal assistant, such as Siri for iPhone or Goo
 <youtubeEmbed url="https://www.youtube.com/watch?v=nnU9taPEEe4" description={"Video: Siri is AWESOME when combined with ChatGPT! (I'll show you how!) (12 min)"} />
 
 
-## Connecting ChatGPT with Google Assistant (for Android)
+## Connecting ChatGPT with Gemini or Google Assistant (for Android)
 
-At the time of writing, Android integration is a little trickier, but still totally doable!
+Google is replacing Google Assistant with Gemini on Android, so on newer devices Gemini is your built-in conversational AI out of the box.
 
-[Follow these instructions](https://www.howtogeek.com/882019/how-to-use-chatgpt-like-google-assistant-on-android/) and you should be talking to your new AI assistant in no time.
+If you still want ChatGPT specifically as your Android voice assistant, it is a little trickier but still totally doable! [Follow these instructions](https://www.howtogeek.com/882019/how-to-use-chatgpt-like-google-assistant-on-android/) and you should be talking to your new AI assistant in no time.

--- a/public/uploads/rules/copilot-lingo/rule.mdx
+++ b/public/uploads/rules/copilot-lingo/rule.mdx
@@ -40,7 +40,7 @@ Sounds familiar? Chances you were using the **personal** Copilot, while the deck
 
 ### Agents ≠ Copilots
 
-Agents are not the same as Copilots. In fact, Office 365 Copilot can **invoke** Agents. There are task-specific AIs with their own memory.
+Agents are not the same as Copilots. In fact, Microsoft 365 Copilot can **invoke** Agents. There are task-specific AIs with their own memory.
 
 There are 3 main types of Agents within the Microsoft world:
 

--- a/public/uploads/rules/digest-microsoft-form/rule.mdx
+++ b/public/uploads/rules/digest-microsoft-form/rule.mdx
@@ -94,15 +94,15 @@ See how to get the most out of your Microsoft Forms results with AI.
 2. Create a new folder containing the `.csv` file you would like to digest
 3. Open this new folder in Cursor IDE
 4. With the `.csv` open, hit `ctrl+L` (`⌘+L` for Mac users). This opens the AI panel
-5. Set your model, we like `gemini-2.5-pro` with **Thinking enabled**.
+5. Set your model, we like `gemini-3.1-pro` with **Thinking enabled**.
 6. Start prompting your .csv file!
 
 
 <boxEmbed
   style="info"
   body={<>
-    We recommend **Gemini 2.5 Pro** as it has a massive 1 million token context window, and is highly ranked for text.
-But, if there are better models at the time of reading this, use them! (see the 'Text' leaderboard on [LLMArena](https://lmarena.ai/leaderboard))
+    We recommend **Gemini 3.1 Pro** as it has a massive context window, and is highly ranked for text.
+But, if there are better models at the time of reading this, use them! (see the 'Text' leaderboard on [Arena](https://arena.ai/leaderboard/text))
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/install-chatgpt-as-an-app/rule.mdx
+++ b/public/uploads/rules/install-chatgpt-as-an-app/rule.mdx
@@ -28,7 +28,13 @@ Furthermore, ChatGPT is constantly learning and improving its abilities, which m
 * [Android](https://play.google.com/store/apps/details?id=com.openai.chatgpt)
 * [iOS](https://apps.apple.com/us/app/chatgpt/id6448311069)
 
-### How to add ChatGPT as an Edge app
+### Install the official ChatGPT desktop app
+
+OpenAI ships a native desktop app for Windows and macOS. It gives you a dedicated window, the Alt + Space companion shortcut, screenshot and file sharing, and the latest models.
+
+Download it from the [official ChatGPT download page](https://openai.com/chatgpt/download/).
+
+### No desktop app? Add ChatGPT as an Edge app
 
 
 <imageEmbed

--- a/public/uploads/rules/make-perplexity-your-default-search-engine/rule.mdx
+++ b/public/uploads/rules/make-perplexity-your-default-search-engine/rule.mdx
@@ -60,11 +60,11 @@ Here’s how you can set Perplexity as your default search engine:
 
 ### For Firefox
 
-1. **Open Firefox and go to Preferences:** Click the hamburger menu in the top-right corner and select "Preferences"
+1. **Open Firefox and go to Settings:** Click the hamburger menu in the top-right corner and select "Settings"
 2. **Navigate to the "Search" panel:** On the left-hand menu, click on "Search."
 3. **Add Perplexity as a search engine:**
 
-   * Scroll down to "One-Click Search Engines"
+   * Scroll down to "Search Shortcuts"
    * Click "Find more search engines" and manually add Perplexity by entering the URL: `https://www.perplexity.ai/search?q=%s`
 4. **Set Perplexity as the default:** Once added, click on Perplexity and select "Set as Default"
 

--- a/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
+++ b/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
@@ -37,7 +37,7 @@ Ensure that any data or models used by your AI system are appropriately licensed
 
 ### 2. Comply with industry regulations
 
-Depending on your industry, ensure your AI system complies with all relevant regulations, such as GDPR, HIPAA, or CCPA. If you operate in or serve the EU, assess where your AI system falls under the EU AI Act's risk tiers, as high-risk systems carry specific transparency, documentation, and human-oversight obligations. Compliance should include data privacy, data retention, and transparency around AI decision-making processes.
+Depending on your industry, ensure your AI system complies with all relevant regulations, such as GDPR, HIPAA, or CCPA. If you operate in or serve the EU, assess where your AI system falls under the [EU AI Act's risk tiers](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai), as high-risk systems carry specific transparency, documentation, and human-oversight obligations. Compliance should include data privacy, data retention, and transparency around AI decision-making processes.
 
 ### 3. Implement ethical AI practices
 

--- a/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
+++ b/public/uploads/rules/manage-legal-implications-of-ai/rule.mdx
@@ -25,7 +25,7 @@ Understanding and managing these legal implications is critical to safely and co
 
 * **Intellectual Property (IP) Infringement** - AI models often rely on vast datasets or pretrained models, which may incorporate proprietary data or content. Companies using AI must ensure they have the rights to use the data or models to avoid IP disputes
 
-* **Regulatory Compliance** - AI adoption is subject to various regulations depending on the industry (e.g., GDPR for data privacy in Europe, HIPAA for health information in the U.S.). Non-compliance can lead to hefty fines and legal action
+* **Regulatory Compliance** - AI adoption is subject to various regulations depending on the industry and region (e.g., the EU AI Act for AI systems in Europe, GDPR for data privacy, HIPAA for health information in the U.S.). Non-compliance can lead to hefty fines and legal action
 
 * **Ethical Use of Data** - Misusing customer data, even unintentionally, can result in legal consequences. The use of AI must align with ethical standards and respect user consent, particularly in the case of sensitive or personal information
 
@@ -37,7 +37,7 @@ Ensure that any data or models used by your AI system are appropriately licensed
 
 ### 2. Comply with industry regulations
 
-Depending on your industry, ensure your AI system complies with all relevant regulations, such as GDPR, HIPAA, or CCPA. Compliance should include data privacy, data retention, and transparency around AI decision-making processes.
+Depending on your industry, ensure your AI system complies with all relevant regulations, such as GDPR, HIPAA, or CCPA. If you operate in or serve the EU, assess where your AI system falls under the EU AI Act's risk tiers, as high-risk systems carry specific transparency, documentation, and human-oversight obligations. Compliance should include data privacy, data retention, and transparency around AI decision-making processes.
 
 ### 3. Implement ethical AI practices
 

--- a/public/uploads/rules/what-is-gpt/rule.mdx
+++ b/public/uploads/rules/what-is-gpt/rule.mdx
@@ -59,6 +59,7 @@ For example, if the training data contains a weather report talking about beauti
 
 GPT is trained on a huge amount of parameters.
 
+* GPT-5: parameter count not publicly disclosed by OpenAI - the current generation and a significant step up from GPT-4.
 * GPT-4: 1.76 **trillion** parameters.
 * GPT-3: 175 billion parameters.
 * GPT-2: 1.5 billion parameters.


### PR DESCRIPTION
### 📝 Summary

Content Hawk audit of the [Rules to Better AI Use](https://www.ssw.com.au/rules/rules-to-better-ai) category (all 30 rules audited; 14 edited, 16 rules left clean). Each change is a specific, locatable fix verified against both the live page and the raw source.

- **chatgpt-skills-weaknesses** - replaced the false "not designed to process or generate images, audio" limitation (ChatGPT is multimodal in 2026, and it contradicted the rule's own GPT-5 intro) with a real current limitation about verifying factual accuracy.
- **best-ai-tools** - completed the Beautiful.ai bullet that was truncated mid-word ("...slides bas").
- **what-is-gpt** - added GPT-5 to the parameter/generation list (count left as "not publicly disclosed" to avoid fabrication).
- **avoid-automation-bias** - updated "25% of AI-generated code has vulnerabilities" to Veracode's current 45% figure.
- **connect-chatgpt-with-virtual-assistant** - reframed the Android section around Gemini, which is replacing Google Assistant on Android.
- **chatgpt-can-fix-errors** - fixed the invalid `dotnet ef database-update` (should be `dotnet ef database update`) and updated the `chat.openai.com` link.
- **chatgpt-can-help-code** - updated the `chat.openai.com` link.
- **install-chatgpt-as-an-app** - added the official native ChatGPT desktop app as the primary option and demoted the Edge "install as app" workaround to a fallback.
- **make-perplexity-your-default-search-engine** - updated stale Firefox UI labels ("Preferences" to "Settings", "One-Click Search Engines" to "Search Shortcuts").
- **manage-legal-implications-of-ai** - added the EU AI Act to the regulatory guidance.
- **digest-microsoft-form** - updated the recommended model to Gemini 3.1 Pro and the "LLMArena" leaderboard reference to the renamed Arena (arena.ai).
- **chatgpt-cheat-sheet** - fixed "GTP" typo to "GPT".
- **copilot-lingo** - corrected "Office 365 Copilot" to "Microsoft 365 Copilot" (matches the rest of the rule and the real product name).
- **chatgpt-security-risks** - replaced "No specific regulations for AI" and "Proposed AI Act" with the fact that the EU AI Act is now in force.

### 🤷‍♂️ Why

- **Multimodal claim** - GPT-5 natively handles and generates images/audio; the "can't do non-textual" line was factually wrong and self-contradicting.
- **Beautiful.ai** - the sentence was visibly cut off ("bas") on the live page.
- **GPT-5** - GPT-5 shipped in 2025 and is the current generation; the list stopped at GPT-4. OpenAI has not published a parameter count, so none is invented.
- **AI-code vulnerabilities** - Veracode's 2025 GenAI Code Security Report found 45% of AI-generated code contains security flaws (reaffirmed Spring 2026). A rule about citing precise error rates should use the current figure.
- **Google Assistant to Gemini** - Google confirmed it is retiring Google Assistant and replacing it with Gemini on Android through 2026 ([9to5Google, Dec 2025](https://9to5google.com/2025/12/19/google-assistant-gemini-2026/)).
- **EF command** - `dotnet ef database update` (space-separated) is the real EF Core CLI command per [Microsoft Learn](https://learn.microsoft.com/en-us/ef/core/cli/dotnet); the hyphenated form is not a command and would not produce the error shown.
- **chat.openai.com** - now 308-redirects to the canonical `chatgpt.com`.
- **ChatGPT desktop app** - OpenAI now ships a native Windows/macOS app; the rule only taught the Edge PWA workaround, which is now the fallback.
- **Firefox labels** - Firefox renamed "Preferences" to "Settings" (from FF88) and "One-Click Search Engines" to "Search Shortcuts".
- **EU AI Act** - entered into force August 2024, with most obligations applying from August 2026; it is the flagship AI-specific law and was missing from the legal rule, and `chatgpt-security-risks` still called it "proposed" and said there were "no specific regulations for AI".
- **Gemini 2.5 Pro** - superseded; Gemini 3.1 Pro (released Feb 2026) is the current flagship, Gemini 3 Flash is the app default. The specific "1 million token" claim was dropped to avoid asserting an unverified spec.
- **LMArena to Arena** - LMArena rebranded to Arena (arena.ai) on 2026-01-28; the old `lmarena.ai/leaderboard` now 301-redirects, and the rule also misnamed it "LLMArena".
- **GTP / Office 365 Copilot** - a plain typo and an incorrect product name inconsistent with the rest of that rule.

### 🧪 Test plan

- Compare each edited rule against its live page (e.g. https://www.ssw.com.au/rules/best-ai-tools/) to confirm the fix addresses what a visitor currently sees.
- Follow the changed/added links and confirm they resolve: `https://chatgpt.com/`, `https://openai.com/chatgpt/download/`, `https://arena.ai/leaderboard/text`.
- Spot-check the sourced claims: Veracode 45% GenAI code report, EU AI Act entry into force (Aug 2024) and applicability (Aug 2026), `dotnet ef database update` on Microsoft Learn.
- Frontmatter validator passes on all 14 files; edits introduce no new markdownlint errors versus `main` (pre-existing lint noise is left for CI auto-fix).

**Note:** `chatgpt-can-help-code` and `chatgpt-can-fix-errors` carry `isArchived: true`; their fixes are correct and low-risk, but a maintainer may choose to deprioritise edits to archived rules. One finding (a Beads version/star-count refresh on `ai-agent-memory-systems`) was deliberately excluded as churny and low-value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
