### PR TITLE
🦅 Content Hawk: refresh stale JavaScript and jQuery rules

### DIFF
--- a/public/uploads/rules/do-you-avoid-relying-on-javascript-for-crucial-actions/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-relying-on-javascript-for-crucial-actions/rule.mdx
@@ -13,8 +13,8 @@ lastUpdatedBy: William Yin
 lastUpdatedByEmail: WilliamYin@ssw.com.au
 redirects: []
 seoDescription: Don't rely on JavaScript for crucial actions, ensuring your website
-  remains accessible and usable without it, as an estimated 2% of users may have JavaScript
-  disabled.
+  remains accessible and usable without it, as some users may not receive your JavaScript
+  at all.
 title: Do you avoid relying on Javascript for crucial actions?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
@@ -28,7 +28,7 @@ JavaScript should be used to enhance the overall user experience and not as a de
 
 <endIntro />
 
-JavaScript is very useful for improving user-interaction, along with reducing the number of requests made on the server; but it can be disabled - an estimated 2% of web users do not have JavaScript enabled
+JavaScript is very useful for improving user-interaction, along with reducing the number of requests made on the server; but you can't assume every visitor will receive it. Some users disable JavaScript, and others lose it to a flaky connection or a script that fails to load
 
 Depending on your audience you may choose to disregard this rule, but for mainstream websites it is highly recommended that you don't rely on JavaScript for crucial actions, such as **validation** or **business-logic** purposes. Do a server-side validation instead.
 

--- a/public/uploads/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript/rule.mdx
@@ -23,7 +23,7 @@ isArchived: false
 archivedreason: null
 ---
 
-TTypeScript is JavaScript with optional static types. It was released by Microsoft in 2012 and has grown heavily in popularity, becoming the most-used language on GitHub in 2025. TypeScript is now the default choice for many modern JavaScript codebases because it catches errors earlier, improves editor autocomplete, makes refactoring safer, and documents data shapes through types.
+TypeScript is JavaScript with optional static types. It was released by Microsoft in 2012 and has grown heavily in popularity, becoming the [most-used language on GitHub in 2025](https://github.blog/news-insights/octoverse/octoverse-a-new-developer-joins-github-every-second-as-ai-leads-typescript-to-1/). TypeScript is now the default choice for many modern JavaScript codebases because it catches errors earlier, improves editor autocomplete, makes refactoring safer, and documents data shapes through types.
 
 So what are the [benefits of TypeScript](/rules/use-typescript)?
 

--- a/public/uploads/rules/do-you-know-which-version-of-jquery-to-use/rule.mdx
+++ b/public/uploads/rules/do-you-know-which-version-of-jquery-to-use/rule.mdx
@@ -35,4 +35,4 @@ If your site needs to support Internet Explorer 6, 7, and 8, you should not use 
 
 The jQuery authors made a decision to deprecate support for older versions of IE from version 2.0 onwards.  Even though support for these browsers has been discontinued, the authors have commited to maintaining version 1.9 so it's safe to keep using it.
 
-For more information about the changes, see the [jQuery blog post about the version 2.0 release](https://blog.jquery.com/).
+For more information about the changes, see the [jQuery blog post about the version 2.0 release](https://blog.jquery.com/2013/04/18/jquery-2-0-released/).

--- a/public/uploads/rules/do-you-place-scripts-at-the-bottom-of-your-page/rule.mdx
+++ b/public/uploads/rules/do-you-place-scripts-at-the-bottom-of-your-page/rule.mdx
@@ -12,8 +12,8 @@ lastUpdated: 2021-06-17 17:15:32.446000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com
 redirects: []
-seoDescription: Optimize page load times by placing JavaScript files at the bottom
-  of your HTML, just before the closing body tag.
+seoDescription: Optimize page load times by loading your scripts with the defer or
+  async attribute so they don't block the page.
 title: Do you place scripts at the bottom of your page?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
@@ -25,19 +25,19 @@ Bear in mind that the load time is a very important aspect on web development. T
 
 <endIntro />
 
-It's known that when a browser loads a script, it can’t continue on until the entire file has been loaded.
+It's known that a script without `defer` or `async` blocks the browser from parsing the rest of the page until the file has been downloaded and run. Slower pages cost you users, so you want your scripts to load without holding up the content.
 
-Once JavaScript files have the purpose to add functionality - something happen after a button is clicked for example — there is no good reason to load the JS file before the button itself.
-
-So go ahead and place JS files at the bottom of the HTML, just before the closing body tag.
+The modern approach is to keep your scripts in the `<head>` and add the `defer` attribute. Deferred scripts download in parallel while the page is parsed, then run in order once the HTML is ready.
 
 ```html
-...
-<script type="text/javascript" src="file.js"></script>
-  </body>
-    </html>
+<head>
+  ...
+  <script src="file.js" defer></script>
+</head>
 ```
 
-**Figure: Place JavaScript at the bottom of your HTML**
+**✅ Figure: Good example - defer lets the script load without blocking the page**
 
-Tests at a big online sales company revealed that every 100 ms increase in load time decreased sales by 1%.
+Use `async` instead of `defer` for independent scripts (such as analytics) that don't depend on the DOM or on each other.
+
+If you can't use `defer` or `async`, the legacy fallback is to place your scripts at the bottom of the HTML, just before the closing `</body>` tag, so they load after the page content.

--- a/public/uploads/rules/do-you-remove-language-from-your-script-tag/rule.mdx
+++ b/public/uploads/rules/do-you-remove-language-from-your-script-tag/rule.mdx
@@ -13,8 +13,8 @@ lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com
 redirects:
 - do-you-remove-＂language＂-from-your-script-tag
-seoDescription: Remove outdated "language" attribute and specify scripting language
-  as a content type instead.
+seoDescription: Remove the outdated "language" attribute from your script tags, and
+  omit the optional "type" attribute for JavaScript.
 title: Do you remove "Language" from your script tag?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
@@ -26,16 +26,16 @@ Years ago, it was common to have the "language" attribute within the script tags
 
 <endIntro />
 
-Since these identifiers are not standard, this attribute has been deprecated in favor of "type".
+Since the "language" attribute is not standard, it is obsolete and should be removed. For JavaScript, the "type" attribute is optional too and can be left out.
 
 ```html
-<script href="script.js" language="javascript"></script>
+<script src="script.js" language="javascript"></script>
 ```
-**❌ Figure: Bad example - Language attribute has been deprecated**  
+**❌ Figure: Bad example - The "language" attribute is obsolete**  
 
 ```html
-<script href="script.js" type="text/javascript"></script>
+<script src="script.js"></script>
 ```
-**✅ Figure: Good example - The scripting language is specified as a content type**  
+**✅ Figure: Good example - No "language" attribute, and "type" omitted since JavaScript is the default**  
 
-Read more on [W3C - Specifying the scripting language](https://www.w3.org/TR/html4/interact/scripts.html#h-18.2.2).
+Read more on [MDN - The Script element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).

--- a/public/uploads/rules/do-you-separate-javascript-functionality-aka-unobtrusive-javascript/rule.mdx
+++ b/public/uploads/rules/do-you-separate-javascript-functionality-aka-unobtrusive-javascript/rule.mdx
@@ -27,7 +27,7 @@ A website can be broken down into three main development parts: content, design 
 
 <endIntro />
 
-All JavaScript code should go into an external .js file (linked to the document with a &lt;script&gt; tag in the head of the page) and not embedded within HTML. The same should be done for CSS files. Don't bloat your HTML file and confuse search engines. Separate the legitimate content from what is programming code.
+All JavaScript code should go into an external .js file (linked to the document with a &lt;script defer&gt; tag) and not embedded within HTML. The same should be done for CSS files. Don't bloat your HTML file and confuse search engines. Separate the legitimate content from what is programming code.
 
 ```html
 <a onclick="action()" href="#">Click Here</a>

--- a/public/uploads/rules/do-you-use-bundling-and-or-amd/rule.mdx
+++ b/public/uploads/rules/do-you-use-bundling-and-or-amd/rule.mdx
@@ -26,22 +26,22 @@ type: rule
 uri: do-you-use-bundling-and-or-amd
 ---
 
-Minification and AMD are techniques to improve javascript performance. They can both can be used with vanilla JavaScript and with Typescript
+Minification and modules are techniques to improve JavaScript performance. They can both be used with vanilla JavaScript and with TypeScript
 
 <endIntro />
 
-### AMD and RequireJs
+### Modules
 
-AMD is a client-side technology that allows you to break you Js code into small inter-dependent modules. The modules (and thier dependencies) required to render a particular page are determined at runtime and subsequently downloaded by Javascript. RequireJs is a popular AMD implementation.
-**✅ Pro: Only the js modules you need are downloaded**  
-**❌ Con: Each module is downloaded in a separate http request**  
+Splitting your JavaScript into small inter-dependent modules lets the browser load only what a page needs. Native ES Modules (`import` / `export`) are the standard way to do this today and are supported directly by modern browsers and bundlers. The older AMD format and its popular implementation RequireJS have largely been replaced by ES Modules.
+**✅ Pro: Only the modules you need are loaded**  
+**❌ Con: Requesting many small modules separately adds overhead, so bundle them for production**  
 
 ### Bundling and Minification
 
 This is a server side technique that combines and optimises client side files into single, optimised downloads.
 
-ASP.Net contains excellent server-side bundling support as outlined here: [http://www.asp.net/mvc/overview/performance/bundling-and-minification](http://www.asp.net/mvc/overview/performance/bundling-and-minification)
+ASP.NET Core provides server-side bundling and minification support, as outlined here: [Bundle and minify static assets in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/client-side/bundling-and-minification).
 
-ASP.Net vnext & VS 2015 also provides support for using task runners like Gulp or Grunt for bundling and minification.
+ASP.NET Core also supports bundling and minification through modern build tooling and bundlers such as webpack, Vite, or esbuild.
 **✅ Pro: Fewer Http requests and smaller files**  
 **❌ Con: All client side modules are included in a single download**

--- a/public/uploads/rules/do-you-use-lodash-to-perform-your-daily-_-foreach/rule.mdx
+++ b/public/uploads/rules/do-you-use-lodash-to-perform-your-daily-_-foreach/rule.mdx
@@ -24,7 +24,7 @@ type: rule
 uri: do-you-use-lodash-to-perform-your-daily-_-foreach
 ---
 
-In a nutshell, Lo-Dash is a super useful library that gives you access to over 100 extremely performant functions to help you avoid reinventing the wheel whilst writing JavaScript.
+In a nutshell, Lodash is a super useful library that gives you access to a large collection of extremely performant functions to help you avoid reinventing the wheel whilst writing JavaScript.
 
 You can get lodash from [GitHub repository](https://github.com/lodash/lodash), [cdnjs](https://cdnjs.com/libraries/lodash.js) or via [NPM](https://www.npmjs.com/package/lodash). Once done you can include a reference in your HTML.
 
@@ -41,14 +41,14 @@ This new simplified array of account numbers was then used in a dropdown to filt
 
 ```js
 this.accountNumberDropDownData = _.chain(this.sharedDataSource)
-  .pluck("AccountNumber")
+  .map("AccountNumber")
   .uniq()
   .sortBy()
   .value();
 ```
 **✅ Good example - Simple one line of TypeScript which would take many line of code without lodash**  
 
-If you have been into JavaScript development for a while you may of also heard about underscore.js which is very similar to Lo-Dash but has some fundamental differences.
+If you have been into JavaScript development for a while you may of also heard about underscore.js which is very similar to Lodash but has some fundamental differences.
 
 > I created Lo-Dash to provide more consistent cross-environment iteration support for arrays, strings, objects, and arguments objects1. It has since become a superset of Underscore, providing more consistent API behavior, more features (like AMD support, deep clone, and deep merge), more thorough documentation and unit tests (tests which run in Node, Ringo, Rhino, Narwhal, PhantomJS, and browsers), better overall performance and optimizations for large arrays/object iteration, and more flexibility with custom builds and template pre-compilation utilities.
 > **— John-David Dalton**

--- a/public/uploads/rules/do-you-use-the-best-javascript-libraries/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-best-javascript-libraries/rule.mdx
@@ -14,8 +14,8 @@ lastUpdated: 2019-03-05 17:55:42+00:00
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 redirects: []
-seoDescription: Discover the top JavaScript frameworks to boost your web development
-  skills in 2016 with expert insights from SSW.
+seoDescription: Discover how to choose the best JavaScript frameworks for your web
+  projects with expert insights from SSW.
 title: Do you use the best JavaScript libraries?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
@@ -23,12 +23,9 @@ type: rule
 uri: do-you-use-the-best-javascript-libraries
 ---
 
-It's
-important to keep on top of what the best JavaScript frameworks are.
+It's important to keep on top of what the best JavaScript frameworks are.
 
-In
-this explosive video Ben Cull, SSW Solution Architect, will bombard you with
-what are the best JavaScript Frameworks to use in 2016.
+In this video, Ben Cull, SSW Solution Architect, runs through how to evaluate and choose between the leading JavaScript frameworks.
 
 <endIntro />
 

--- a/public/uploads/rules/the-best-tool-to-debug-javascript/rule.mdx
+++ b/public/uploads/rules/the-best-tool-to-debug-javascript/rule.mdx
@@ -59,8 +59,7 @@ Chrome is by far the most popular browser for the average web developer followed
 **3. Debug in an IDE**
 It is often more effort than it is worth to debug JavaScript in your IDE and it is still not very popular. If your app is a server-s ide NodeJS JavaScript app then it is very different since this type of JavaScript app does not run in the browser and this is what the IDE is designed for.
 
-- [Visual Studio Code Chrome Debugger](https://github.com/Microsoft/vscode-chrome-debug) - Painful to set up source maps for advanced JavaScript applications that run in memory dev servers like WebPack Dev Server.
-- Visual Studio 2015 - Only works with TypeScript in Internet Explorer
+- [JavaScript debugging in VS Code](https://code.visualstudio.com/docs/nodejs/browser-debugging) - Debugging for Chrome and Edge is built into VS Code, so there is no extension to install. Source maps for in-memory dev servers (like Vite or Webpack Dev Server) work out of the box.
 
 
 <imageEmbed
@@ -68,7 +67,7 @@ It is often more effort than it is worth to debug JavaScript in your IDE and it 
   size="large"
   showBorder={false}
   figurePrefix="none"
-  figure="Visual Studio Chrome Debugger with breakpoint set"
+  figure="Debugging JavaScript in VS Code with a breakpoint set"
   src="/uploads/rules/the-best-tool-to-debug-javascript/debug-js-3.png"
 />
 

--- a/public/uploads/rules/web-ui-libraries/rule.mdx
+++ b/public/uploads/rules/web-ui-libraries/rule.mdx
@@ -166,7 +166,7 @@ When evaluating a component library, also keep in mind:
 * **[Chakra UI](https://chakra-ui.com)** - A modular and accessible component library for React with a focus on design flexibility
 * **[Mantine](https://mantine.dev)** - A flexible and fully accessible UI library with 100+ customizable components and hooks for React
 * **[PrimeReact](https://primereact.org)** - A comprehensive collection of components for React, part of the PrimeFaces family
-* **[NextUI](https://nextui.org)** - A modern React UI library optimized for dark mode by default with customizable components
+* **[HeroUI](https://www.heroui.com)** (formerly NextUI) - A React UI library with accessible, customizable components and dark mode by default
 * **[React Suite](https://rsuitejs.com)** - A set of React components built for middle and back-office applications
 * **[KendoUI](https://www.telerik.com/kendo-ui)** - Offers advanced HTML and jQuery controls for data grids, charts, and more
 

--- a/public/uploads/rules/what-are-the-best-examples-of-technically-cool-jquery-plug-ins/rule.mdx
+++ b/public/uploads/rules/what-are-the-best-examples-of-technically-cool-jquery-plug-ins/rule.mdx
@@ -27,6 +27,4 @@ Below are some of the best technically cool jQuery plug-ins. Use these as guidel
 <endIntro />
 
 - [Ajax Upload](https://www.jqueryscript.net/demo/jQuery-AJAX-File-Uploader-FileUp/)
-- [AutoSuggest jQuery plugin](https://drew.tenderapp.com/kb/autosuggest-jquery-plugin) (Type in the textbox to see suggestions)
-- [Open Standard Media Player (jQuery + HTML5)](http://mediafront.org/osmplayer/#.Yji37ZrMLso)
-- [jsPlumb Flowchart Builder](https://demo.jsplumbtoolkit.com/flowchart-builder/)
+- [jsPlumb Flowchart Builder](https://jsplumbtoolkit.com/demonstrations/flowchart-builder)


### PR DESCRIPTION
### 📝 Summary
Audited all 27 rules in [Rules to Better JavaScript and jQuery](https://www.ssw.com.au/rules/rules-to-better-javascript-and-jquery) for outdated, inaccurate, deprecated, and dead-link content. This PR actions 12 rules (2 tiers). Each change was verified against the live page AND the current first-party source.
**Tier A - clear defects:**
- `do-you-remove-language-from-your-script-tag` - `<script href=...>` loads nothing; fixed to `src` in both examples. `type="text/javascript"` is now optional in HTML5, and the reference link moved from the obsolete HTML 4.01 spec to MDN.
- `do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript` - fixed the `TTypeScript` typo (first word on the page) and added an inline citation for the retained "most-used language on GitHub in 2025" statistic.
- `do-you-use-lodash-to-perform-your-daily-_-foreach` - the showcase snippet used `_.pluck`, removed in Lodash 4.0 (2016); changed to `_.map`. Modernised "Lo-Dash" to "Lodash" in prose (the John-David Dalton quotation is left verbatim).
- `web-ui-libraries` - NextUI was rebranded to HeroUI; `nextui.org` now 301-redirects to `heroui.com`. Updated the name and link.
- `what-are-the-best-examples-of-technically-cool-jquery-plug-ins` - removed two dead links (AutoSuggest = site closed, osmplayer = parked domain) and fixed the moved jsPlumb Flowchart Builder demo URL.
- `do-you-use-the-best-javascript-libraries` - a rule about staying current was hard-pinned to "2016"; removed the year from the body and seoDescription.
- `the-best-tool-to-debug-javascript` - the `vscode-chrome-debug` extension was deprecated and its repo archived in 2022; debugging is now built into VS Code. Repointed to the official docs and deleted the dead "Visual Studio 2015 / Internet Explorer" bullet.
- `do-you-use-bundling-and-or-amd` - reframed AMD/RequireJS to native ES Modules, fixed the dead ASP.NET bundling link to Microsoft Learn, and made the "VS 2015 / Gulp or Grunt" tooling version-agnostic.
- `do-you-know-which-version-of-jquery-to-use` (archived rule) - the "jQuery 2.0 release post" link pointed at the blog homepage; repointed to the actual post.

**Tier B - staleness and uncited numbers:**
- `do-you-avoid-relying-on-javascript-for-crucial-actions` - dropped the uncited "2%" figure (body + seoDescription) and reframed qualitatively.
- `do-you-separate-javascript-functionality-aka-unobtrusive-javascript` - a plain `<script>` in the `<head>` is render-blocking; changed to `<script defer>`.
- `do-you-place-scripts-at-the-bottom-of-your-page` - added the modern `defer`/`async` approach and framed bottom-of-body as the legacy fallback; dropped the uncited "big online sales company... 100ms = 1% sales" statistic.

### 🤷‍♂️ Why
Every finding was cross-checked against the live rendered page and the raw source, then verified at a reputable, current, ungated source:
- **href vs src**: the `<script>` element loads external files via `src`; `href` is inert. [MDN - The Script element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
- **TypeScript #1 on GitHub**: confirmed at GitHub's own Octoverse report - "August 2025 marks the first time TypeScript emerged as the most used language on GitHub, surpassing Python." [GitHub Octoverse 2025](https://github.blog/news-insights/octoverse/octoverse-a-new-developer-joins-github-every-second-as-ai-leads-typescript-to-1/) (published Oct 2025, updated Feb 2026).
- **Lodash `_.pluck`**: removed in v4.0.0; use `_.map` with the property shorthand. [Lodash docs](https://lodash.com/docs/) / [Changelog](https://github.com/lodash/lodash/wiki/Changelog).
- **NextUI -> HeroUI**: `https://nextui.org` returns `301 Moved Permanently` to `https://heroui.com/` (verified). [HeroUI repo](https://github.com/heroui-inc/heroui).
- **Dead jQuery plugin links**: `drew.tenderapp.com` returns "There isn't a Tender here! This site is closed."; `mediafront.org/osmplayer` serves a bare placeholder. The jsPlumb demo moved to [jsplumbtoolkit.com/demonstrations/flowchart-builder](https://jsplumbtoolkit.com/demonstrations/flowchart-builder) (verified 200).
- **VS Code Chrome debugger**: `microsoft/vscode-chrome-debug` was deprecated and archived (2022); JavaScript debugging is built into VS Code. [VS Code browser debugging docs](https://code.visualstudio.com/docs/nodejs/browser-debugging).
- **AMD/RequireJS**: superseded by native ES Modules. [MDN - JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules). The old ASP.NET bundling doc now redirects to marketing; the canonical doc lives at [Microsoft Learn](https://learn.microsoft.com/en-us/aspnet/core/client-side/bundling-and-minification) (verified 200).
- **jQuery 2.0 post**: [blog.jquery.com/2013/04/18/jquery-2-0-released](https://blog.jquery.com/2013/04/18/jquery-2-0-released/) (verified 200) is the post the sentence references, not the blog homepage.
- **script placement / defer**: `defer` downloads in parallel and runs after parsing, superseding bottom-of-body placement. [MDN - The Script element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
- **Uncited stats dropped**: the "2%" JS-disabled figure and the "100ms = 1% sales" figure had no inline source. Rather than assert an unbacked number, both were reframed. (Context for the 2% figure: GDS measured ~1.1% - [gds.blog.gov.uk](https://gds.blog.gov.uk/2013/10/21/how-many-people-are-missing-out-on-javascript-enhancement/).)

### 🧪 Test plan
- Compare each changed rule against its live page (e.g. https://www.ssw.com.au/rules/do-you-remove-language-from-your-script-tag/) to confirm the edit reads naturally and in-voice.
- Follow every cited reference link above and confirm each resolves (HTTP 200, no paywall/login/form gate) and supports the claim.
- Confirm the two removed jQuery-plugin links are genuinely dead and the jsPlumb replacement demo loads.
- Confirm `nextui.org` still redirects to `heroui.com`.
- Frontmatter validator passes on all 12 files (`scripts/frontmatter-validator`): reported "No frontmatter validation errors found."
- Note: 3 Tier C findings that would invert a rule's whole premise (see review comments) are deliberately NOT edited here - they are raised as inline comments for a human editorial decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
