### PR TITLE
📅 Book developers rule - Book in likely-to-continue bookings

### DIFF
--- a/public/uploads/rules/book-developers-for-a-project/rule.mdx
+++ b/public/uploads/rules/book-developers-for-a-project/rule.mdx
@@ -40,6 +40,8 @@ It is the responsibility of Account Managers to book developers for known client
   figure=""
 />
 
+**Tip:** If you're 90% sure a booking will continue, book it in. It's better to have a small chance that the client might stop, than showing someone as free when they're likely not.
+
 To see which developers are available for booking:
 
 <imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="ok" figure="Using the Service Calendar, you can see who is and is not available at a given time" src="/uploads/rules/book-developers-for-a-project/service-calendar-crm-online-version-blurred.png" />


### PR DESCRIPTION
Adds a tip to the [Book developers for a project](https://www.ssw.com.au/rules/book-developers-for-a-project) rule: if you're 90% sure a booking will continue, book it in — a small chance the client stops is better than showing someone as free when they're likely not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)