### PR TITLE
Add intro video to understand-azure-private-networking rule

### DIFF
--- a/public/uploads/rules/understand-azure-private-networking/rule.mdx
+++ b/public/uploads/rules/understand-azure-private-networking/rule.mdx
@@ -25,6 +25,8 @@ redirects:
 
 <endIntro />
 
+<youtubeEmbed url="https://www.youtube.com/watch?v=88cfFXVE50Y" description="Video: Azure Private Networking Explained | Ben Neoh | SSW Rules (6 min)" />
+
 ## What is Azure Private Networking?
 
 Azure Private Networking allows Azure services to be accessed through private IP addresses inside a Virtual Network (VNet) instead of the public internet. It uses features such as Azure Private Link and Private Endpoints to create secure, private connections between your applications and Azure services.


### PR DESCRIPTION
### What

Adds a YouTube video embed to the [understand-azure-private-networking](public/uploads/rules/understand-azure-private-networking/rule.mdx) rule.

- **Video:** [Azure Private Networking Explained | Ben Neoh | SSW Rules](https://www.youtube.com/watch?v=88cfFXVE50Y) (6 min)
- **Placement:** near the top, immediately after `<endIntro />`, per the SSW rule house style
- **Description format:** `Video: <Title> (<N> min)` with the required duration

The video's presenter, Ben Neoh, is also the rule's author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)