### PR TITLE
public/uploads/rules/video recordings/rule (PR from TinaCMS)

### DIFF
--- a/public/uploads/rules/video-recordings/rule.mdx
+++ b/public/uploads/rules/video-recordings/rule.mdx
@@ -18,9 +18,9 @@ seoDescription: 'Improve video presentations with 3 coaching tips: get a coach, 
 created: 2026-06-22T14:26:58.023Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-07-06T08:13:33.290Z
-lastUpdatedBy: 'Pam Pan [SSW]'
-lastUpdatedByEmail: pampan@ssw.com.au
+lastUpdated: 2026-07-09T23:26:53.040Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 ---
 
 Recording a public video is easier when you do not try to get it perfect alone.
@@ -85,17 +85,17 @@ This feels less natural at first, but it saves time and makes the final video mu
 
 ### 🎥 Extra video tip: Clap when you make a mistake
 
-During a video recording, when you make a mistake, clap. This creates a clear spike reference in the audio, which helps the editor quickly find the mistake later.
+In a perfect world, you'd deliver everything in one clean take. But if you make a few mistakes, you don't want those hiccups to spoil your flow or force you to restart the entire recording.
 
-After clapping, pause briefly, reset your body posture, make eye contact with the camera, and restart the sentence or section.
+Instead, **mark each mistake with a quick clap**. The clap creates a visible spike in the audio waveform, making it easy to find the mistake later when editing in software such as Adobe Premiere Pro.
 
-This makes editing much easier and avoids wasting time searching through the footage.
+Without these markers, it's surprisingly easy to miss those moments during the editing process.
+
+After clapping, pause briefly, reset your posture, make eye contact with the camera, and restart the sentence or section.
 
 <boxEmbed
   body={<>
-    **Note:** Do **not** edit it all yourself.
-    
-    If you are not a video editor, do not spend hours trying to perfect the edit yourself. Instead:
+    **Note:** Do **not** edit it all yourself. If you are not a video editor, do not spend hours trying to perfect the edit yourself. Instead:
     
     * Get the raw recordings ready
     * Sit with an editor


### PR DESCRIPTION
cc @kulesy @joshberman1 @danielmackay @GordonBeeming @IvanTyapkinSSW @BrookJeynes @hveraus 

as per @adamcogan 's email request: **Re: Do you get coaching when recording important videos? | SSW.Rules**

> Add a grey box with something like the below
> 
> Why the clap ?
> 
> In the perfect world, you’d say it in one clean take… but say you make a few mistakes, you don’t want to let those hiccups spoil your flow or force you restart the whole recording.
> 
> So instead, mark each mistake with a quick clap. That clap puts a visible spike in the audio waveform, making it easy to find when you’re editing it - for example, in Adobe Premiere Pro 
> 
> Without these markers, it is surprisingly easy to miss those moments during the video editing.