### PR TITLE
Add video to Centralize AI Workflows rule

### DIFF
--- a/public/uploads/rules/centralize-ai-workflows/rule.mdx
+++ b/public/uploads/rules/centralize-ai-workflows/rule.mdx
@@ -28,6 +28,11 @@ Centralizing your AI workflows means distributing skills, plugins, and agent con
 
 <endIntro />
 
+<youtubeEmbed
+  url="https://www.youtube.com/watch?v=jdjaYhuQ7_s"
+  description="Video: AI Teams workflows | Ulysses Maclarren | SSW Rules (1 min)"
+/>
+
 ## Why centralize your AI workflows?
 
 Skills and plugins are only worth writing once. If each developer maintains their own copy, you lose the main benefit - consistency.

--- a/public/uploads/rules/centralize-ai-workflows/rule.mdx
+++ b/public/uploads/rules/centralize-ai-workflows/rule.mdx
@@ -29,7 +29,7 @@ Centralizing your AI workflows means distributing skills, plugins, and agent con
 <endIntro />
 
 <youtubeEmbed
-  url="https://www.youtube.com/watch?v=jdjaYhuQ7_s"
+  url="https://www.youtube.com/watch?v=lrRfo2h0O9o"
   description="Video: AI Teams workflows | Ulysses Maclaren | SSW Rules (1 min)"
 />
 

--- a/public/uploads/rules/centralize-ai-workflows/rule.mdx
+++ b/public/uploads/rules/centralize-ai-workflows/rule.mdx
@@ -30,7 +30,7 @@ Centralizing your AI workflows means distributing skills, plugins, and agent con
 
 <youtubeEmbed
   url="https://www.youtube.com/watch?v=lrRfo2h0O9o"
-  description="Video: AI Teams workflows | Ulysses Maclaren | SSW Rules (1 min)"
+  description="Video: The Smarter Way to Share AI Skills | Ulysses Maclaren | SSW Rules (1 min)"
 />
 
 ## Why centralize your AI workflows?

--- a/public/uploads/rules/centralize-ai-workflows/rule.mdx
+++ b/public/uploads/rules/centralize-ai-workflows/rule.mdx
@@ -30,7 +30,7 @@ Centralizing your AI workflows means distributing skills, plugins, and agent con
 
 <youtubeEmbed
   url="https://www.youtube.com/watch?v=jdjaYhuQ7_s"
-  description="Video: AI Teams workflows | Ulysses Maclarren | SSW Rules (1 min)"
+  description="Video: AI Teams workflows | Ulysses Maclaren | SSW Rules (1 min)"
 />
 
 ## Why centralize your AI workflows?


### PR DESCRIPTION
Adds a 1 min YouTube video to the [Centralize AI Workflows rule](/rules/centralize-ai-workflows), placed just after `<endIntro />` per house style.

- **Video:** AI Teams workflows | Ulysses Maclarren | SSW Rules (1 min)
- **URL:** https://www.youtube.com/watch?v=jdjaYhuQ7_s

🤖 Generated with [Claude Code](https://claude.com/claude-code)