### PR TITLE
Add skill-safety link and Superpowers plugin to Centralize AI Workflows rule

### DIFF
--- a/public/uploads/rules/centralize-ai-workflows/rule.mdx
+++ b/public/uploads/rules/centralize-ai-workflows/rule.mdx
@@ -81,7 +81,16 @@ This keeps distribution in git, where it belongs: changes go through PR review, 
 
 <boxEmbed
   body={<>
-    Skills and plugins are prompt injections by design - a malicious one can instruct the agent to run destructive commands or exfiltrate data. Before you distribute anything org-wide, read it in full and review updates like code. A central, reviewed repository is safer than everyone grabbing files from random third-party marketplaces.
+    You don't have to build everything yourself. There are some great community plugins worth adding - for example the [Superpowers plugin by Obra](https://github.com/obra/superpowers), which packages a full development methodology as composable skills, from brainstorming and design through test-driven implementation, code review, and deployment.
+  </>}
+  figurePrefix="good"
+  figure="Pull proven community plugins into your central marketplace instead of reinventing them"
+  style="greybox"
+/>
+
+<boxEmbed
+  body={<>
+    Skills and plugins are prompt injections by design - a malicious one can instruct the agent to run destructive commands or exfiltrate data. Before you distribute anything org-wide, [verify its safety](/rules/verify-ai-skill-safety) - read it in full and review updates like code. A central, reviewed repository is safer than everyone grabbing files from random third-party marketplaces.
   </>}
   figurePrefix="none"
   figure=""


### PR DESCRIPTION
Two additions to the [Centralize AI Workflows rule](/rules/centralize-ai-workflows):

1. **Skill-safety link** - the existing prompt-injection warning box now links to [Do you verify the safety of AI skills before using them?](/rules/verify-ai-skill-safety)
2. **Community plugin greybox** - a new greybox in the "no enterprise plan" section pointing to the [Superpowers plugin by Obra](https://github.com/obra/superpowers), with a brief note on what it does

🤖 Generated with [Claude Code](https://claude.com/claude-code)