### PR TITLE
Tidy Rules to Better YouTube: drop redundant title prefixes and reorder

### DIFF
--- a/categories/marketing-and-video/rules-to-better-youtube.mdx
+++ b/categories/marketing-and-video/rules-to-better-youtube.mdx
@@ -12,21 +12,21 @@ index:
 - rule: public/uploads/rules/youtube-livestreams/rule.mdx
 - rule: public/uploads/rules/manage-youtube-livestream-content/rule.mdx
 - rule: public/uploads/rules/keep-audience-happy/rule.mdx
+- rule: public/uploads/rules/monitor-youtube-analytics-and-metrics/rule.mdx
 - rule: public/uploads/rules/important-youtube-vocabulary/rule.mdx
 - rule: public/uploads/rules/video-thumbnails/rule.mdx
 - rule: public/uploads/rules/youtube-cards/rule.mdx
+- rule: public/uploads/rules/do-you-add-end-screen-to-your-youtube-videos/rule.mdx
 - rule: public/uploads/rules/hashtags-in-video-description/rule.mdx
 - rule: public/uploads/rules/transcribe-your-videos/rule.mdx
 - rule: public/uploads/rules/use-https-text/rule.mdx
+- rule: public/uploads/rules/add-sections-time-and-links-on-video-description/rule.mdx
 - rule: public/uploads/rules/premiere-pro-markers-as-youtube-chapter-links/rule.mdx
-- rule: public/uploads/rules/do-you-add-end-screen-to-your-youtube-videos/rule.mdx
 - rule: public/uploads/rules/youtube-banner-show-upcoming-events/rule.mdx
 - rule: public/uploads/rules/sort-videos-into-playlists/rule.mdx
-- rule: public/uploads/rules/monitor-youtube-analytics-and-metrics/rule.mdx
 - rule: public/uploads/rules/like-and-comment-on-videos/rule.mdx
 - rule: public/uploads/rules/do-you-create-polls-to-engage-with-your-subscribers/rule.mdx
 - rule: public/uploads/rules/browsing-do-you-add-the-youtube-center-extension/rule.mdx
-- rule: public/uploads/rules/add-sections-time-and-links-on-video-description/rule.mdx
 - rule: public/uploads/rules/do-you-have-a-dog-aka-digital-on-screen-graphic-on-your-videos/rule.mdx
   
 ---

--- a/public/uploads/rules/do-you-add-end-screen-to-your-youtube-videos/rule.mdx
+++ b/public/uploads/rules/do-you-add-end-screen-to-your-youtube-videos/rule.mdx
@@ -24,7 +24,7 @@ related:
 - rule: public/uploads/rules/image-standard-sizes-on-social-media/rule.mdx
 seoDescription: Do you add end screens to your YouTube videos? Learn how to keep viewers
   engaged by adding a call-to-action (CTA) at the end of your video.
-title: Videos - Do you add end screen to your YouTube videos?
+title: Do you add end screen to your YouTube videos?
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx
 type: rule

--- a/public/uploads/rules/important-youtube-vocabulary/rule.mdx
+++ b/public/uploads/rules/important-youtube-vocabulary/rule.mdx
@@ -15,7 +15,7 @@ redirects:
 - do-you-know-the-important-youtube-vocabulary
 seoDescription: Unlock the secrets of YouTube's most important metrics, including
   session time, watch time, pattern interrupts, CTR, and audience retention.
-title: Analytics - Do you know the important YouTube vocabulary?
+title: Do you know the important YouTube Analytics vocabulary?
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx
 type: rule

--- a/public/uploads/rules/monitor-youtube-analytics-and-metrics/rule.mdx
+++ b/public/uploads/rules/monitor-youtube-analytics-and-metrics/rule.mdx
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Channel - Do you monitor YouTube Analytics and metrics effectively?
+title: Do you monitor YouTube Analytics and metrics effectively?
 uri: monitor-youtube-analytics-and-metrics
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx

--- a/public/uploads/rules/premiere-pro-markers-as-youtube-chapter-links/rule.mdx
+++ b/public/uploads/rules/premiere-pro-markers-as-youtube-chapter-links/rule.mdx
@@ -1,7 +1,7 @@
 ---
 seoDescription: Learn how to use Premiere Pro markers for automated YouTube chapter links, saving time on video organization
 type: rule
-title: Videos - Do you use Premiere Pro Markers as YouTube Chapter Links?
+title: Do you use Premiere Pro Markers as YouTube Chapter Links?
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx
 uri: premiere-pro-markers-as-youtube-chapter-links

--- a/public/uploads/rules/videos-youtube-friendly/rule.mdx
+++ b/public/uploads/rules/videos-youtube-friendly/rule.mdx
@@ -19,7 +19,7 @@ related:
 - rule: public/uploads/rules/do-you-add-end-screen-to-your-youtube-videos/rule.mdx
 seoDescription: Optimize your videos for YouTube by creating engaging, long-form content
   that captures viewers' attention within the first 15 seconds.
-title: Videos - Do you make your videos YouTube friendly?
+title: Do you make your videos YouTube friendly?
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx
 type: rule

--- a/public/uploads/rules/where-to-upload-work-related-videos/rule.mdx
+++ b/public/uploads/rules/where-to-upload-work-related-videos/rule.mdx
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Videos - Do you know where to upload work-related videos?
+title: Do you know where to upload work-related videos?
 uri: where-to-upload-work-related-videos
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx

--- a/public/uploads/rules/youtube-cards/rule.mdx
+++ b/public/uploads/rules/youtube-cards/rule.mdx
@@ -26,7 +26,7 @@ related:
 - rule: public/uploads/rules/image-standard-sizes-on-social-media/rule.mdx
 seoDescription: Do you add cards to your YouTube videos and keep viewers engaged with
   suggested related content?
-title: Videos - Do you add cards to your YouTube videos?
+title: Do you add cards to your YouTube videos?
 categories:
   - category: categories/marketing-and-video/rules-to-better-youtube.mdx
 type: rule


### PR DESCRIPTION
## Changes

### Title cleanups
Removed redundant prefixes from rule titles:

- **Videos -** removed from 5 rules:
  - Do you know where to upload work-related videos?
  - Do you make your videos YouTube friendly?
  - Do you add cards to your YouTube videos?
  - Do you use Premiere Pro Markers as YouTube Chapter Links?
  - Do you add end screen to your YouTube videos?
- **Channel -** removed from *Do you monitor YouTube Analytics and metrics effectively?*
- **Analytics -** removed from the vocabulary rule, which is now retitled to **Do you know the important YouTube Analytics vocabulary?**

### Reordering (`categories/marketing-and-video/rules-to-better-youtube.mdx`)
- Moved **end screen** rule to right after **add cards**
- Moved **timestamp links** rule to right before **Premiere Pro Markers**
- Moved **monitor YouTube Analytics and metrics** to right before **important YouTube Analytics vocabulary**

🤖 Generated with [Claude Code](https://claude.com/claude-code)