### PR TITLE
🐛 Fix all frontmatter validation failures on main

### DIFF
--- a/public/uploads/rules/ai-investigation-prompts/rule.mdx
+++ b/public/uploads/rules/ai-investigation-prompts/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you use AI to explore unfamiliar code?
 uri: ai-investigation-prompts
+seoDescription: Use AI to explore unfamiliar codebases and cut onboarding time from months to minutes with on-demand analysis of projects, bugs, and features
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai.mdx
 authors:

--- a/public/uploads/rules/chain-agentic-workflows-together/rule.mdx
+++ b/public/uploads/rules/chain-agentic-workflows-together/rule.mdx
@@ -1,7 +1,7 @@
 ---
 type: rule
 title: Do you know when to Chain GitHub Agentic Workflows together?
-uri: keep-agentic-workflows-granular
+uri: chain-agentic-workflows-together
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
 authors:
@@ -11,6 +11,7 @@ related:
   - rule: public/uploads/rules/agentic-workflows/rule.mdx
 redirects:
   - perform-single-task-agentic-workflows
+  - keep-agentic-workflows-granular
 guid: 7c431def-6fbc-4296-8769-d9d4d082d2ad
 seoDescription: 'Learn why you should create new GitHub Agentic Workflows when you have steps that depend on one another, and how to chain workflows together.'
 created: 2026-03-13T00:00:00.000Z

--- a/public/uploads/rules/design-spec-review/rule.mdx
+++ b/public/uploads/rules/design-spec-review/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Do you know how to run a Design Spec review?'
 uri: design-spec-review
+seoDescription: Run a Design Spec review to align on product goals, users, and constraints before designing screens, avoiding rework and design debt
 categories:
   - category: categories/design/rules-to-better-designers.mdx
   - category: categories/client-engagement/rules-to-better-specification-reviews.mdx

--- a/public/uploads/rules/design-spec-review/rule.mdx
+++ b/public/uploads/rules/design-spec-review/rule.mdx
@@ -7,7 +7,7 @@ categories:
   - category: categories/client-engagement/rules-to-better-specification-reviews.mdx
 authors:
   - title: Micaela Blank
-    url: 'https://ssw.com.au/people/micaela-blank'
+    url: 'https://www.ssw.com.au/people/micaela-blank'
 related:
   - rule: public/uploads/rules/what-is-a-spec-review/rule.mdx
   - rule: public/uploads/rules/user-journey-mapping/rule.mdx

--- a/public/uploads/rules/home-assistant-app/rule.mdx
+++ b/public/uploads/rules/home-assistant-app/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you use the Home Assistant app?
 uri: home-assistant-app
+seoDescription: Use the Home Assistant Companion App to turn your phone into a smart home command center with dashboards, controls, phone sensors, and push notifications
 categories:
   - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:

--- a/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
+++ b/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you know how to connect to multiple homes in Home Assistant?
 uri: how-to-connect-multiple-homes-home-assistant
+seoDescription: Connect to multiple Home Assistant servers from one phone using the Companion App, with clean ways to keep locations separated
 categories:
   - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:

--- a/public/uploads/rules/internal-priority-alignment/rule.mdx
+++ b/public/uploads/rules/internal-priority-alignment/rule.mdx
@@ -18,7 +18,7 @@ related:
   - rule: public/uploads/rules/bench-master/rule.mdx
 redirects: []
 guid: ea9036b3-649f-4555-8a4b-8ba7de56de50
-seoDescription: null
+seoDescription: Run weekly Priority Alignment meetings so Bench Masters keep developer assignments aligned with company goals and stakeholder priorities
 created: 2024-10-11T00:00:00.000Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au

--- a/public/uploads/rules/migrate-from-control4-to-home-assistant/rule.mdx
+++ b/public/uploads/rules/migrate-from-control4-to-home-assistant/rule.mdx
@@ -6,7 +6,7 @@ categories:
   - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:
   - title: Kiki Biancatti
-    url: 'https://ssw.com.au/people/kaique-biancatti'
+    url: 'https://www.ssw.com.au/people/kaique-biancatti'
 related:
   - rule: public/uploads/rules/home-assistant-app/rule.mdx
 guid: 87c33a1d-a8ac-43d2-b9a9-bf434ab73a47

--- a/public/uploads/rules/migrate-from-control4-to-home-assistant/rule.mdx
+++ b/public/uploads/rules/migrate-from-control4-to-home-assistant/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you know how to migrate from Control4 to Home Assistant?
 uri: migrate-from-control4-to-home-assistant
+seoDescription: Migrate from Control4 to Home Assistant with a parallel, room-by-room cutover using KNX as the backbone and Node-RED for automation logic
 categories:
   - category: categories/office-automation/rules-to-better-home-assistant.mdx
 authors:

--- a/public/uploads/rules/monitor-ai-cost-and-usage/rule.mdx
+++ b/public/uploads/rules/monitor-ai-cost-and-usage/rule.mdx
@@ -8,7 +8,7 @@ authors:
   - title: Gordon Beeming
     url: 'https://www.ssw.com.au/people/gordon-beeming'
   - title: Josh Berman
-    url: 'https://ssw.com.au/people/josh-berman'
+    url: 'https://www.ssw.com.au/people/josh-berman'
 guid: 84a2ebf1-9591-4d94-b7b8-ab99c64c0235
 created: 2026-03-05T22:45:56.927Z
 createdBy: Josh Berman

--- a/public/uploads/rules/monitor-ai-cost-and-usage/rule.mdx
+++ b/public/uploads/rules/monitor-ai-cost-and-usage/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: Do you monitor AI cost and usage?
 uri: monitor-ai-cost-and-usage
+seoDescription: Monitor AI token consumption, API calls, and agent activity to keep variable AI usage costs visible and under control
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
 authors:

--- a/public/uploads/rules/password-security-recipe/rule.mdx
+++ b/public/uploads/rules/password-security-recipe/rule.mdx
@@ -11,7 +11,7 @@ related:
 - rule: public/uploads/rules/multi-factor-authentication-enabled/rule.mdx
 - rule: public/uploads/rules/secure-password-share/rule.mdx
 - rule: public/uploads/rules/password-complexities/rule.mdx
-seoDescription: null
+seoDescription: Secure passwords using hash, salt, and pepper so a stolen password database is useless to attackers
 title: Do you know the recipe for secure passwords?
 categories:
   - category: categories/infrastructure-and-networking/rules-to-better-security.mdx

--- a/public/uploads/rules/screencloud-channels-playlists/rule.mdx
+++ b/public/uploads/rules/screencloud-channels-playlists/rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: ScreenCloud - Do you know when to use Channels and Playlists?
 uri: screencloud-channels-playlists
+seoDescription: Learn when to use ScreenCloud Playlists vs Channels so your digital signage stays scalable, easy to update, and consistent across screens
 categories:
   - category: categories/infrastructure-and-networking/rules-to-better-signage.mdx
 authors:

--- a/public/uploads/rules/set-up-auxiliary-accounting/rule.mdx
+++ b/public/uploads/rules/set-up-auxiliary-accounting/rule.mdx
@@ -6,7 +6,7 @@ created: 2025-09-29 22:53:34.710000+00:00
 guid: ca50e896-5fe9-43b0-8def-4ead1f9a8349
 related:
 - rule: public/uploads/rules/importance-of-reconciliation/rule.mdx
-seoDescription: null
+seoDescription: Set up auxiliary accounting for Accounts Receivable in Kingdee by linking the Customer dimension for detailed tracking beyond the account balance
 title: Kingdee - Do you know how to set up auxiliary accounting for Accounts Receivables?
   (China only)
 categories:

--- a/scripts/frontmatter-validator/frontmatter-validator.js
+++ b/scripts/frontmatter-validator/frontmatter-validator.js
@@ -212,7 +212,7 @@ function parseFrontmatterToJson(fileContents) {
 function extractFrontMatter(fileContents) {
   if (!fileContents) return undefined;
   let frontmatterString;
-  const frontmatterMatch = /^---([\s\S]*?)---/.exec(fileContents);
+  const frontmatterMatch = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/.exec(fileContents);
 
   if (!frontmatterMatch) return undefined;
   frontmatterString = frontmatterMatch[1];


### PR DESCRIPTION
### What triggered this change?

The **Validate-Frontmatter-in-All-Rules** GitHub Action has been failing on every push to main.

### What was changed?

Running the validator locally against all 3,805 rules surfaced 12 failing files, in 3 groups:

**1. Missing or empty `seoDescription` (10 rules)** — added a description based on each rule's intro:

* `internal-priority-alignment`, `password-security-recipe`, `set-up-auxiliary-accounting` (were `null`)
* `screencloud-channels-playlists`, `ai-investigation-prompts`, `migrate-from-control4-to-home-assistant`, `how-to-connect-multiple-homes-home-assistant`, `home-assistant-app`, `monitor-ai-cost-and-usage`, `design-spec-review` (were missing)

**2. `uri` / folder mismatch (1 rule)** — `chain-agentic-workflows-together` still had the stale `uri: keep-agentic-workflows-granular` from its old framing (#12232), while its title, folder, and category reference all use the new name. Changed the `uri` to match the folder and added the old uri to `redirects` so existing links keep working.

**3. Validator bug (`tweet-rules-you-follow`)** — the validator reported this rule as missing title/guid/uri/authors, but the file is fine. The frontmatter-extraction regex `/^---([\s\S]*?)---/` stops at the *first* `---` anywhere, and this rule's `archivedreason` URL contains `#9---general-content-...`, so the YAML was truncated mid-value. Fixed the regex to require the closing `---` on its own line. Re-validated all 3,805 rules and all category files after the change — zero errors.

### Verification

```
node scripts/frontmatter-validator/frontmatter-validator.js --file all_rules_files.txt
No frontmatter validation errors found.  (exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)