### PR TITLE
Add Tip 4 (SME checks the rough edit) to rules/video-recordings

### DIFF
--- a/public/uploads/rules/video-recordings/rule.mdx
+++ b/public/uploads/rules/video-recordings/rule.mdx
@@ -20,7 +20,7 @@ createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 lastUpdated: 2026-07-23T10:03:23.710Z
 lastUpdatedBy: 'Harkirat Singh [SSW]'
-lastUpdatedByEmail: sandhukirat23@gmail.com
+lastUpdatedByEmail: harksingh@ssw.com.au
 ---
 
 Just like developing an app – recording a public video is easier when you get incremental feedback along the way.

--- a/public/uploads/rules/video-recordings/rule.mdx
+++ b/public/uploads/rules/video-recordings/rule.mdx
@@ -14,13 +14,13 @@ related:
   - rule: public/uploads/rules/content-check-before-public-facing-video/rule.mdx
   - rule: public/uploads/rules/done-video/rule.mdx
 guid: 04671bcf-e631-4d87-a51c-fb64fb7007b3
-seoDescription: 'Improve video presentations with 3 coaching tips: get a coach, get interrupted, and clap when you make a mistake to help editors.'
+seoDescription: 'Improve video presentations with 4 coaching tips: get a coach, get interrupted, clap when you make a mistake, and get the rough edit checked by an SME.'
 created: 2026-06-22T14:26:58.023Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-07-23T05:07:25.825Z
-lastUpdatedBy: Isaac Lombard
-lastUpdatedByEmail: isaaclombard@ssw.com.au
+lastUpdated: 2026-07-23T09:48:54.000Z
+lastUpdatedBy: 'Harkirat Singh [SSW]'
+lastUpdatedByEmail: harksingh@ssw.com.au
 ---
 
 Just like developing an app – recording a public video is easier when you get incremental feedback along the way.
@@ -45,7 +45,7 @@ That often means the issues are found too late:
 
 ## ✅ The solution
 
-When recording an important video, use these 3 coaching tips.
+When recording an important video, use these 4 coaching tips.
 
 ### Tip 1: Get a coach
 
@@ -58,8 +58,6 @@ This is especially important [before recording public videos](https://www.ssw.co
 <boxEmbed
   body={<>
     Consider writing up a draft script first and sending it to your coach for initial feedback.
-    
-    <imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="good" figure="Recording alongside a coach" src="/uploads/rules/video-recordings/rough-recording-during-coaching.png" />
   </>}
   figurePrefix="none"
   figure=""
@@ -93,15 +91,32 @@ Without these markers, it's surprisingly easy to miss those moments during the e
 
 After clapping, **pause briefly**, reset your posture, make eye contact with the camera, and restart the sentence or section.
 
+### Tip 4: Get the rough edit checked by an SME
+
+Do not go straight from raw footage to a polished video.
+
+Once the footage is roughly cut together, share the rough edit with a Subject Matter Expert (SME) - ideally the same person who coached you. Watch it together on a call so they react to what the audience will actually see.
+
+They can catch:
+
+* Anything technically wrong or out of date
+* Claims that need a demo or evidence
+* Sections that drag, repeat, or lose the point
+* Missing context the audience needs
+
+Changes are cheap while the edit is rough. Once the music, captions, and colour grading are done, every fix costs the editor real time. This is the video version of a [Test Please](https://www.ssw.com.au/rules/test-please-for-video).
+
+<imageEmbed alt="Two people reviewing a rough video edit together on a Teams call" size="large" showBorder={false} figurePrefix="good" figure="Sharing the rough edit with an SME on a Teams call and getting feedback before the final edit." src="/uploads/rules/video-recordings/rough-recording-during-coaching.png" />
+
 <boxEmbed
   body={<>
     **Note:** Do **not** edit it all yourself. If you are not a video editor, do not spend hours trying to perfect the edit yourself. Instead:
-    
+
     * Get the raw recordings ready
     * Sit with an editor
     * Step through the footage together
     * Decide what to cut, simplify, or re-record
-    
+
     This is usually faster and gives a better result.
   </>}
   figurePrefix="none"

--- a/public/uploads/rules/video-recordings/rule.mdx
+++ b/public/uploads/rules/video-recordings/rule.mdx
@@ -18,9 +18,9 @@ seoDescription: 'Improve video presentations with 4 coaching tips: get a coach, 
 created: 2026-06-22T14:26:58.023Z
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
-lastUpdated: 2026-07-23T09:48:54.000Z
+lastUpdated: 2026-07-23T10:03:23.710Z
 lastUpdatedBy: 'Harkirat Singh [SSW]'
-lastUpdatedByEmail: harksingh@ssw.com.au
+lastUpdatedByEmail: sandhukirat23@gmail.com
 ---
 
 Just like developing an app – recording a public video is easier when you get incremental feedback along the way.
@@ -95,7 +95,7 @@ After clapping, **pause briefly**, reset your posture, make eye contact with the
 
 Do not go straight from raw footage to a polished video.
 
-Once the footage is roughly cut together, share the rough edit with a Subject Matter Expert (SME) - ideally the same person who coached you. Watch it together on a call so they react to what the audience will actually see.
+Once the footage is roughly cut together, share the rough edit with a Subject Matter Expert (SME) - ideally the same person who coached you. Watch it together on a call so they react to and can give you the feedback.
 
 They can catch:
 
@@ -104,22 +104,6 @@ They can catch:
 * Sections that drag, repeat, or lose the point
 * Missing context the audience needs
 
-Changes are cheap while the edit is rough. Once the music, captions, and colour grading are done, every fix costs the editor real time. This is the video version of a [Test Please](https://www.ssw.com.au/rules/test-please-for-video).
+Changes are cheap while the edit is rough. Once the music, captions, and other edits are done, every fix costs the editor real time. This is the video version of a [Test Please](https://www.ssw.com.au/rules/test-please-for-video).
 
 <imageEmbed alt="Two people reviewing a rough video edit together on a Teams call" size="large" showBorder={false} figurePrefix="good" figure="Sharing the rough edit with an SME on a Teams call and getting feedback before the final edit." src="/uploads/rules/video-recordings/rough-recording-during-coaching.png" />
-
-<boxEmbed
-  body={<>
-    **Note:** Do **not** edit it all yourself. If you are not a video editor, do not spend hours trying to perfect the edit yourself. Instead:
-
-    * Get the raw recordings ready
-    * Sit with an editor
-    * Step through the footage together
-    * Decide what to cut, simplify, or re-record
-
-    This is usually faster and gives a better result.
-  </>}
-  figurePrefix="none"
-  figure=""
-  style="info"
-/>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

as per my conversation with @adamcogan , @isaaclombardssw, @calumjs & @BigMark824 

> 2. What was changed?

* Added **Tip 4: Get the rough edit checked by an SME** - share the rough cut with a subject matter expert (ideally the coach) and watch it together, so technical errors, unsupported claims, and sections that drag get caught while changes are still cheap. Links to the existing [Test Please for video](https://www.ssw.com.au/rules/test-please-for-video) rule.
* Moved the Teams call screenshot from Tip 1 to Tip 4, with a caption that describes what it actually shows, plus real alt text instead of `alt="Image"`.
* Updated the intro line and `seoDescription` from 3 tips to 4.
* Removed pre-existing trailing whitespace that was failing markdownlint MD009.

**Suggested review order**

1. `public/uploads/rules/video-recordings/rule.mdx` - the only file. Read the new Tip 4 section first (it is the actual addition), then the Tip 1 box to confirm the screenshot removal reads fine without it, then the intro and frontmatter counter bumps.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

🤖 Claude Code
Validated with the frontmatter validator and markdownlint - both pass.
