### PR TITLE
Archiving legacy tech rules

### DIFF
--- a/public/uploads/rules/backup-your-databases-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/backup-your-databases-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: backup-your-databases-tfs2010-migration
+isArchived: true
 ---
 
 Run your daily backups to provide a safety net should things go wrong.

--- a/public/uploads/rules/backup-your-databases-tfs2012-migration/rule.mdx
+++ b/public/uploads/rules/backup-your-databases-tfs2012-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
 type: rule
 uri: backup-your-databases-tfs2012-migration
+isArchived: true
 ---
 
 Before starting your upgrade, you should back up all your TFS databases.

--- a/public/uploads/rules/best-free-resources-for-angularjs/rule.mdx
+++ b/public/uploads/rules/best-free-resources-for-angularjs/rule.mdx
@@ -1,11 +1,11 @@
 ---
-archivedreason: null
+archivedreason: "AngularJS (Angular 1.x) reached end-of-life in January 2022. See [Do you know why to upgrade from AngularJS to Angular?](/rules/why-upgrade-to-latest-angular)"
 authors: []
 created: 2016-02-19 14:02:15+00:00
 createdBy: Jernej Kavka
 createdByEmail: JernejKavka@ssw.com.au
 guid: 7f1b7701-cb35-43c0-a7d7-86a572f09baf
-isArchived: false
+isArchived: true
 lastUpdated: 2016-02-19 14:07:37+00:00
 lastUpdatedBy: Jernej Kavka
 lastUpdatedByEmail: JernejKavka@ssw.com.au

--- a/public/uploads/rules/check-in-policies-to-enable-in-tfs/rule.mdx
+++ b/public/uploads/rules/check-in-policies-to-enable-in-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -7,7 +7,7 @@ created: 2013-05-21 15:22:11+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 437bf01f-c956-4cd7-a215-6e9344fda3f8
-isArchived: false
+isArchived: true
 lastUpdated: 2021-11-11 00:48:42.949000+00:00
 lastUpdatedBy: Tylah Kapa [SSW]
 lastUpdatedByEmail: tylahkapa@gmail.com

--- a/public/uploads/rules/compatibility-issues-between-sql-server-2000-and-2005/rule.mdx
+++ b/public/uploads/rules/compatibility-issues-between-sql-server-2000-and-2005/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "SQL Server 2000 and 2005 are long out of support, so these version compatibility issues are no longer relevant."
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2019-11-22 21:30:51+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 4c551f85-4bbe-4b91-9a61-937119cfcb99
-isArchived: false
+isArchived: true
 lastUpdated: 2020-01-06 23:23:33+00:00
 lastUpdatedBy: Christian Morford-Waite
 lastUpdatedByEmail: ChristianMWaite@ssw.com.au

--- a/public/uploads/rules/disable-connections-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/disable-connections-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -16,6 +16,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: disable-connections-tfs2010-migration
+isArchived: true
 ---
 
 Once you are ready to start you need to make sure that no one can access the existing TFS 2008 server while you do the migration.

--- a/public/uploads/rules/disable-connections-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/disable-connections-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: disable-connections-tfs2015-migration
+isArchived: true
 ---
 
 It is important that while you're upgrading, nobody can check in. Any check-ins after you backup your database will be lost.

--- a/public/uploads/rules/do-a-quick-test-after-the-upgrade-finishes-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/do-a-quick-test-after-the-upgrade-finishes-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: do-a-quick-test-after-the-upgrade-finishes-tfs2010-migration
+isArchived: true
 ---
 
 All of the hard work has been done, now you need to do a quick test.

--- a/public/uploads/rules/do-a-quick-test-after-the-upgrade-finishes-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/do-a-quick-test-after-the-upgrade-finishes-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: do-a-quick-test-after-the-upgrade-finishes-tfs2015-migration
+isArchived: true
 ---
 
 After upgrading TFS, you should do a quick [smoke test](http://en.wikipedia.org/wiki/Smoke_testing) to ensure TFS is running as expected.

--- a/public/uploads/rules/do-you-always-set-infopath-compatibility-mode-to-design-for-both-rich-and-web-client-forms/rule.mdx
+++ b/public/uploads/rules/do-you-always-set-infopath-compatibility-mode-to-design-for-both-rich-and-web-client-forms/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Microsoft InfoPath was discontinued (last release 2013) and removed from modern SharePoint, so this guidance no longer applies."
 authors:
 - title: John Liu
   url: https://www.ssw.com.au/people/john-liu
@@ -7,7 +7,7 @@ created: 2009-12-04 08:15:38+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: 6f48b409-49d9-46a3-8bed-b7e860770915
-isArchived: false
+isArchived: true
 lastUpdated: 2015-10-08 00:04:12+00:00
 lastUpdatedBy: William Yin
 lastUpdatedByEmail: WilliamYin@ssw.com.au

--- a/public/uploads/rules/do-you-always-use-data-connection-library-for-infopath-forms/rule.mdx
+++ b/public/uploads/rules/do-you-always-use-data-connection-library-for-infopath-forms/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Microsoft InfoPath was discontinued (last release 2013) and removed from modern SharePoint, so this guidance no longer applies."
 authors:
 - title: John Liu
   url: https://www.ssw.com.au/people/john-liu
@@ -7,7 +7,7 @@ created: 2009-12-04 08:14:26+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: ed35bc0a-f67d-4c7a-b6a4-769e97a4f1d2
-isArchived: false
+isArchived: true
 lastUpdated: 2015-10-08 00:06:44+00:00
 lastUpdatedBy: William Yin
 lastUpdatedByEmail: WilliamYin@ssw.com.au

--- a/public/uploads/rules/do-you-avoid-making-changes-to-individual-css-styles-using-jquery/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-making-changes-to-individual-css-styles-using-jquery/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Tiago Araujo
   url: https://www.ssw.com.au/people/tiago-araujo
@@ -7,7 +7,7 @@ created: 2012-07-26 13:08:55+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 2adca90a-3482-44f5-a3d4-06391521cf0a
-isArchived: false
+isArchived: true
 lastUpdated: 2015-08-24 01:08:15+00:00
 lastUpdatedBy: William Yin
 lastUpdatedByEmail: WilliamYin@ssw.com.au

--- a/public/uploads/rules/do-you-call-angularjs-services-from-your-kendo-datasource/rule.mdx
+++ b/public/uploads/rules/do-you-call-angularjs-services-from-your-kendo-datasource/rule.mdx
@@ -19,8 +19,8 @@ createdByEmail: TiagoAraujo@ssw.com.au
 lastUpdated: 2021-03-17T05:22:32.290Z
 lastUpdatedBy: Jack Leerson
 lastUpdatedByEmail: 77082983+JackLeerson@users.noreply.github.com
-isArchived: false
-archivedreason: null
+isArchived: true
+archivedreason: "AngularJS (Angular 1.x) reached end-of-life in January 2022. See [Do you know why to upgrade from AngularJS to Angular?](/rules/why-upgrade-to-latest-angular)"
 ---
 
 To keep a good separation of concerns between your AngularJS controllers and your data service layers you should always call an AngularJS service or factory from your Kendo datasource logic.

--- a/public/uploads/rules/do-you-configure-your-tfs-to-be-accessible-from-outside-the-network/rule.mdx
+++ b/public/uploads/rules/do-you-configure-your-tfs-to-be-accessible-from-outside-the-network/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - noimage: true
   title: David Klein
@@ -15,7 +15,7 @@ created: 2011-11-18 03:53:00+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
 guid: c0ecaeb8-a15d-40aa-8617-b62004fe22ac
-isArchived: false
+isArchived: true
 lastUpdated: 2014-05-07 04:10:43+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-confirm-your-list-of-installed-sharepoint-2007-solutions/rule.mdx
+++ b/public/uploads/rules/do-you-confirm-your-list-of-installed-sharepoint-2007-solutions/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: John Liu
   url: https://www.ssw.com.au/people/john-liu
@@ -7,7 +7,7 @@ created: 2010-12-23 02:58:25+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: 8dc67ddb-a180-4320-afef-206a8e3bc755
-isArchived: false
+isArchived: true
 lastUpdated: 2014-02-28 04:04:07+00:00
 lastUpdatedBy: Martin Li
 lastUpdatedByEmail: MartinLi@ssw.com.au

--- a/public/uploads/rules/do-you-consider-seo-in-your-angularjs-application/rule.mdx
+++ b/public/uploads/rules/do-you-consider-seo-in-your-angularjs-application/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "AngularJS (Angular 1.x) reached end-of-life in January 2022. See [Do you know why to upgrade from AngularJS to Angular?](/rules/why-upgrade-to-latest-angular)"
 authors:
 - title: Duncan Hunter
   url: https://www.ssw.com.au/people/duncan-hunter
@@ -9,7 +9,7 @@ created: 2014-10-31 00:22:28+00:00
 createdBy: Duncan Hunter
 createdByEmail: DuncanHunter@ssw.com.au
 guid: a2762f52-7604-417f-8be4-dbf1abb14a62
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-16 22:19:58.927000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
+++ b/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: John Liu
   url: https://www.ssw.com.au/people/john-liu
@@ -11,7 +11,7 @@ created: 2010-12-23 02:52:32+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: 07b8d204-ea81-4e1e-ab6b-5ff1295216d5
-isArchived: false
+isArchived: true
 lastUpdated: 2021-02-26 01:16:07.024000+00:00
 lastUpdatedBy: Christian Morford-Waite [SSW]
 lastUpdatedByEmail: ChristianMWaite@ssw.com.au

--- a/public/uploads/rules/do-you-document-the-details-of-your-sharepoint-2007-web-application/rule.mdx
+++ b/public/uploads/rules/do-you-document-the-details-of-your-sharepoint-2007-web-application/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: William Yin
   url: https://www.ssw.com.au/people/william-yin
@@ -9,7 +9,7 @@ created: 2010-12-23 03:03:19+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: 58ecd81e-d3ac-4599-989f-7172773d1c0c
-isArchived: false
+isArchived: true
 lastUpdated: 2012-08-10 10:09:42+00:00
 lastUpdatedBy: Lu Zhang
 lastUpdatedByEmail: LuZhang@ssw.com.au

--- a/public/uploads/rules/do-you-get-a-new-tfs-2012-server-ready/rule.mdx
+++ b/public/uploads/rules/do-you-get-a-new-tfs-2012-server-ready/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -7,7 +7,7 @@ created: 2012-06-20 03:51:49+00:00
 createdBy: Damian Brady
 createdByEmail: DamianBrady@ssw.com.au
 guid: 40f7b3c9-03f1-48b4-8a5a-548e7cdb5b1b
-isArchived: false
+isArchived: true
 lastUpdated: 2012-06-20 03:51:49+00:00
 lastUpdatedBy: Damian Brady
 lastUpdatedByEmail: DamianBrady@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-create-a-new-web-application-and-site-collection-in-sharepoint-2010/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-create-a-new-web-application-and-site-collection-in-sharepoint-2010/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: Matthew Hodgkins
   url: https://www.ssw.com.au/people/matthew-hodgkins
@@ -9,7 +9,7 @@ created: 2010-12-23 06:35:25+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: 5fe6155f-6b61-4864-bb33-33486bf4b2eb
-isArchived: false
+isArchived: true
 lastUpdated: 2010-12-23 06:35:25+00:00
 lastUpdatedBy: SSW2000\johnliu
 lastUpdatedByEmail: johnliu@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-integrate-with-sharepoint-2010/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-integrate-with-sharepoint-2010/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: Martin Hinshelwood
   url: https://www.ssw.com.au/people/martin-hinshelwood
@@ -7,7 +7,7 @@ created: 2010-05-17 09:25:55+00:00
 createdBy: Martin Hinshelwood
 createdByEmail: MartinHinshelwood@ssw.com.au
 guid: 7e99fec6-a420-42c0-beeb-742b94eb5cf3
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:57:13+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-rename-files-that-under-sourcesafe-control/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-rename-files-that-under-sourcesafe-control/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Visual SourceSafe (and TFVC) are long dead. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -10,7 +10,7 @@ created: 2009-12-04 08:40:45+00:00
 createdBy: SSW2000\cindywang
 createdByEmail: CindyWang@ssw.com.au
 guid: 5097d3f0-e86d-4cbe-9f89-1b3d22d2b38c
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:56:50+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-restore-your-content-database-to-sharepoint-2010/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-restore-your-content-database-to-sharepoint-2010/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: Matthew Hodgkins
   url: https://www.ssw.com.au/people/matthew-hodgkins
@@ -7,7 +7,7 @@ created: 2010-12-23 07:29:16+00:00
 createdBy: SSW2000\johnliu
 createdByEmail: johnliu@ssw.com.au
 guid: ae0f46a9-3029-4d8d-b206-e7841812cd78
-isArchived: false
+isArchived: true
 lastUpdated: 2010-12-23 07:29:42+00:00
 lastUpdatedBy: SSW2000\johnliu
 lastUpdatedByEmail: johnliu@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-rollback-changes-in-tfs/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-rollback-changes-in-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - noimage: true
   title: David Klein
@@ -15,7 +15,7 @@ created: 2011-11-18 03:52:54+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
 guid: 6980541f-5084-4ef7-b997-51d90f4e6885
-isArchived: false
+isArchived: true
 lastUpdated: 2014-05-07 04:03:38+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-know-how-to-upgrade-your-tfs2010-databases-the-big-one/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-upgrade-your-tfs2010-databases-the-big-one/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -7,7 +7,7 @@ created: 2012-06-11 00:04:57+00:00
 createdBy: Damian Brady
 createdByEmail: DamianBrady@ssw.com.au
 guid: 9a1bafe3-42cf-4859-ba69-f24d6b478f07
-isArchived: false
+isArchived: true
 lastUpdated: 2021-02-26 05:05:12.889000+00:00
 lastUpdatedBy: Christian Morford-Waite
 lastUpdatedByEmail: ChristianMWaite@ssw.com.au

--- a/public/uploads/rules/do-you-know-the-best-visual-studio-extensions-and-nuget-packages-for-angularjs/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-best-visual-studio-extensions-and-nuget-packages-for-angularjs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "AngularJS (Angular 1.x) reached end-of-life in January 2022. See [Do you know why to upgrade from AngularJS to Angular?](/rules/why-upgrade-to-latest-angular)"
 authors:
 - title: Duncan Hunter
   url: https://www.ssw.com.au/people/duncan-hunter
@@ -7,7 +7,7 @@ created: 2014-10-30 23:31:36+00:00
 createdBy: Duncan Hunter
 createdByEmail: DuncanHunter@ssw.com.au
 guid: d49afb68-176d-40d7-b66f-464a38f1469a
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-12 00:09:01.408000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/do-you-know-the-easiest-way-to-enter-timesheets-with-tfs/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-easiest-way-to-enter-timesheets-with-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2011-08-30 13:27:24+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: d57a1a40-2b06-4e28-af46-3c6f722c31e7
-isArchived: false
+isArchived: true
 lastUpdated: 2021-07-02 01:41:37.719000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/do-you-know-to-regularly-do-a-get-latest-from-tfs/rule.mdx
+++ b/public/uploads/rules/do-you-know-to-regularly-do-a-get-latest-from-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -7,7 +7,7 @@ created: 2012-03-05 23:56:50+00:00
 createdBy: Damian Brady
 createdByEmail: DamianBrady@ssw.com.au
 guid: 59306ecd-ec0d-43ae-8f0c-431dd7fe2891
-isArchived: false
+isArchived: true
 lastUpdated: 2021-02-26 05:05:12.891000+00:00
 lastUpdatedBy: Christian Morford-Waite
 lastUpdatedByEmail: ChristianMWaite@ssw.com.au

--- a/public/uploads/rules/do-you-need-to-migrate-the-history-from-vss-to-tfs/rule.mdx
+++ b/public/uploads/rules/do-you-need-to-migrate-the-history-from-vss-to-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Visual SourceSafe (and TFVC) are long dead. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - noimage: true
   title: David Klein
@@ -15,7 +15,7 @@ created: 2011-11-18 03:52:46+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
 guid: c4f91635-787a-4d8e-b5be-ffa8f9125e7f
-isArchived: false
+isArchived: true
 lastUpdated: 2014-05-07 04:07:05+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-remove-the-need-to-type-tfs/rule.mdx
+++ b/public/uploads/rules/do-you-remove-the-need-to-type-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -9,7 +9,7 @@ created: 2015-05-05 19:58:17+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 3d5efb3b-12ed-4d73-be25-23b214a0a7d8
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-12 20:28:05.438000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/do-you-secure-your-web-services-using-wcf-over-wse3-and-ssl/rule.mdx
+++ b/public/uploads/rules/do-you-secure-your-web-services-using-wcf-over-wse3-and-ssl/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "WCF and WSE3 are legacy .NET Framework technologies not carried forward to modern .NET. See [Do you choose the right web API technology?](/rules/choose-the-right-api-tech)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -10,7 +10,7 @@ created: 2009-12-04 08:39:23+00:00
 createdBy: SSW2000\cindywang
 createdByEmail: CindyWang@ssw.com.au
 guid: 63388838-ff65-414b-83db-69691db56d69
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:56:48+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-use-configuration-management-application-block/rule.mdx
+++ b/public/uploads/rules/do-you-use-configuration-management-application-block/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "The Enterprise Library Configuration Management Application Block is deprecated and unsupported on modern .NET. Use the built-in configuration/options pattern instead."
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -10,7 +10,7 @@ created: 2009-12-04 08:39:10+00:00
 createdBy: SSW2000\cindywang
 createdByEmail: CindyWang@ssw.com.au
 guid: 83914d3f-6c83-49cc-a2bc-f9cdd244c952
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:56:47+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2009-12-04 07:50:59+00:00
 createdBy: Jay Lin
 createdByEmail: JayLin@sydney.ssw.com.au
 guid: 27612f09-8114-4b19-b7c3-66f172c94a15
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:57:16+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2009-12-04 07:52:09+00:00
 createdBy: Jay Lin
 createdByEmail: JayLin@sydney.ssw.com.au
 guid: 1ac30e8d-adcc-4f6c-902f-806bfbc15d4c
-isArchived: false
+isArchived: true
 lastUpdated: 2010-10-20 08:57:16+00:00
 lastUpdatedBy: System Account
 lastUpdatedByEmail: Unknown@ssw.com.au

--- a/public/uploads/rules/do-you-use-jquery-with-the-web-api-to-build-responsive-ui/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-with-the-web-api-to-build-responsive-ui/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Stephensen
   url: https://www.ssw.com.au/people/adam-stephensen
@@ -7,7 +7,7 @@ created: 2012-10-19 17:42:10+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: d713532c-be5c-4bf1-baf9-39bc8ff7a196
-isArchived: false
+isArchived: true
 lastUpdated: 2012-11-02 07:11:39+00:00
 lastUpdatedBy: Adam Stephensen
 lastUpdatedByEmail: AdamStephensen@ssw.com.au

--- a/public/uploads/rules/do-you-use-the-right-service-in-sharepoint-2013/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-right-service-in-sharepoint-2013/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "On-premises SharePoint 2007/2010/2013 is out of support. See the modern SharePoint Online rules, e.g. [Do you get rid of legacy items in SharePoint Online?](/rules/do-you-get-rid-of-legacy-items-in-sharepoint-online)"
 authors:
 - title: John Liu
   url: https://www.ssw.com.au/people/john-liu
@@ -7,7 +7,7 @@ created: 2013-08-27 06:43:25+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
 guid: 1121ed6a-f914-4786-b8a7-39df507a8c42
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-31 19:31:41.649000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/get-a-developer-to-test-the-migration-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/get-a-developer-to-test-the-migration-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Martin Hinshelwood
   url: https://www.ssw.com.au/people/martin-hinshelwood
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: get-a-developer-to-test-the-migration-tfs2010-migration
+isArchived: true
 ---
 
 Getting someone else to test the migration is the best way to make sure that you have not missed anything.

--- a/public/uploads/rules/get-a-developer-to-test-the-migration-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/get-a-developer-to-test-the-migration-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Martin Hinshelwood
   url: https://www.ssw.com.au/people/martin-hinshelwood
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: get-a-developer-to-test-the-migration-tfs2015-migration
+isArchived: true
 ---
 
 It is important to get another developer to check the migration for issues.

--- a/public/uploads/rules/how-to-integrate-raygun-with-visualstudio-tfs/rule.mdx
+++ b/public/uploads/rules/how-to-integrate-raygun-with-visualstudio-tfs/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Eric Phan
   url: https://www.ssw.com.au/people/eric-phan
@@ -7,7 +7,7 @@ created: 2016-10-25 17:10:28+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: cd59e270-70b7-4dd3-9a90-64d2dd5849ea
-isArchived: false
+isArchived: true
 lastUpdated: 2016-10-25 17:16:20+00:00
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au

--- a/public/uploads/rules/keep-your-tfs-build-server/rule.mdx
+++ b/public/uploads/rules/keep-your-tfs-build-server/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Danijel Malik
   url: https://www.ssw.com.au/people/danijel-malik
@@ -7,7 +7,7 @@ created: 2017-01-17 13:06:32+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: c36ecd30-7fc7-4e9b-a729-b2d001f84016
-isArchived: false
+isArchived: true
 lastUpdated: 2017-01-17 14:24:05+00:00
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au

--- a/public/uploads/rules/plan-your-additional-steps-tfs2012-migration/rule.mdx
+++ b/public/uploads/rules/plan-your-additional-steps-tfs2012-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2012-migration.mdx
 type: rule
 uri: plan-your-additional-steps-tfs2012-migration
+isArchived: true
 ---
 
 More steps will be required to integrate your SharePoint site and set up your Build servers.

--- a/public/uploads/rules/plan-your-additional-steps-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/plan-your-additional-steps-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors: []
 created: 2015-08-13 13:46:55+00:00
 guid: e19a2338-c4cd-430d-93a4-c6e5d43f144b
@@ -12,6 +12,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: plan-your-additional-steps-tfs2015-migration
+isArchived: true
 ---
 
 More steps will be required to integrate your SharePoint site and set up your Build servers.

--- a/public/uploads/rules/rollback-plan-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/rollback-plan-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -16,6 +16,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: rollback-plan-tfs2015-migration
+isArchived: true
 ---
 
 Always [plan for a catastrophic disaster](/disaster-recovery-plan). This means backing up your environment, and making sure you have a working plan to recover from that backup should you need to.

--- a/public/uploads/rules/run-dog-food-stats-after-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/run-dog-food-stats-after-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors: []
 created: 2009-11-08 02:01:52+00:00
 guid: e2472404-8058-45f7-96e1-ddb6a8bdb49f
@@ -13,6 +13,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: run-dog-food-stats-after-tfs2010-migration
+isArchived: true
 ---
 
 Running the "Dog Food" stats on your new TFS 2010 server is a good way to see if the upgrade was successful. You should check the new values against the [stats you noted down from your TFS 2008 server](/do-you-run-your-dog-food-stats-before1).

--- a/public/uploads/rules/run-dog-food-stats-after-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/run-dog-food-stats-after-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -15,6 +15,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: run-dog-food-stats-after-tfs2015-migration
+isArchived: true
 ---
 
 Running the [DogFoodStats](https://devblogs.microsoft.com/bharry/team-foundation-dogfood-stats/?WT.mc_id=DOP-MVP-33518) queries over the new TFS 2015 server is a good way to see if the upgrade was successful.

--- a/public/uploads/rules/run-your-dog-food-stats-before-tfs2010-migration/rule.mdx
+++ b/public/uploads/rules/run-your-dog-food-stats-before-tfs2010-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -17,6 +17,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2010-migration.mdx
 type: rule
 uri: run-your-dog-food-stats-before-tfs2010-migration
+isArchived: true
 ---
 
 1. Run the excellent DogFoodStats by Grant Holliday. These are queries on the TFS2008 database to give you stats about number of files, number of users etc.

--- a/public/uploads/rules/run-your-dog-food-stats-before-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/run-your-dog-food-stats-before-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors: []
 created: 2015-08-12 16:38:41+00:00
 guid: db69f69b-a073-4537-908d-52add92cac8a
@@ -14,6 +14,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: run-your-dog-food-stats-before-tfs2015-migration
+isArchived: true
 ---
 
 Run the excellent DogFoodStats queries:

--- a/public/uploads/rules/tfs-master-do-you-have-a-report-to-see-who-has-not-checked-in/rule.mdx
+++ b/public/uploads/rules/tfs-master-do-you-have-a-report-to-see-who-has-not-checked-in/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was superseded by Azure DevOps and modern Git-based source control. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - noimage: true
   title: David Klein
@@ -15,7 +15,7 @@ created: 2011-11-18 03:52:29+00:00
 createdBy: System Account
 createdByEmail: Unknown@ssw.com.au
 guid: 9511d525-f526-462d-8faf-d3144608dba5
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-11 23:01:06.017000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/tfs2015-migration-choices/rule.mdx
+++ b/public/uploads/rules/tfs2015-migration-choices/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors: []
 created: 2015-08-12 15:26:07+00:00
 guid: acd96e8e-9cac-47ce-bdf8-865d5c383e7e
@@ -12,6 +12,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: tfs2015-migration-choices
+isArchived: true
 ---
 
 There are two main ways to move from TFS 2013 Update 4 to TFS 2015:

--- a/public/uploads/rules/the-best-examples-of-visually-cool-jquery-plug-ins/rule.mdx
+++ b/public/uploads/rules/the-best-examples-of-visually-cool-jquery-plug-ins/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2016-11-17 15:59:22+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 7445012b-a4e6-4d3f-abb8-8a90a9c488d6
-isArchived: false
+isArchived: true
 lastUpdated: 2017-03-16 16:12:18+00:00
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au

--- a/public/uploads/rules/turn-off-database-mirroring-before-upgrading-your-tfs-databases/rule.mdx
+++ b/public/uploads/rules/turn-off-database-mirroring-before-upgrading-your-tfs-databases/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors:
 - title: Damian Brady
   url: https://www.ssw.com.au/people/damian-brady
@@ -16,6 +16,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: turn-off-database-mirroring-before-upgrading-your-tfs-databases
+isArchived: true
 ---
 
 To avoid headaches while upgrading the TFS database schemas, you should manually turn off database mirroring prior to running the Verify step of your configuration.

--- a/public/uploads/rules/upgrade-third-party-tools-tfs2015-migration/rule.mdx
+++ b/public/uploads/rules/upgrade-third-party-tools-tfs2015-migration/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "TFS was rebranded as Azure DevOps in 2018; these version-specific TFS 2010/2012/2015 migration steps are obsolete. See [Do you know the right source control to use?](/rules/do-you-know-the-right-source-control-to-use)"
 authors: []
 created: 2015-08-13 14:27:04+00:00
 guid: 645ff8bc-9625-46b2-995a-99ab9e635347
@@ -12,6 +12,7 @@ categories:
   - category: categories/project-delivery/rules-to-better-tfs-2015-migration.mdx
 type: rule
 uri: upgrade-third-party-tools-tfs2015-migration
+isArchived: true
 ---
 
 After upgrading, some third-party tools will no longer work. Check for updates for these tools.

--- a/public/uploads/rules/use-jquery-instead-of-javascript/rule.mdx
+++ b/public/uploads/rules/use-jquery-instead-of-javascript/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2016-11-17 15:55:05+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 7ced5ecb-1893-4305-b85f-962c36a9c50b
-isArchived: false
+isArchived: true
 lastUpdated: 2016-11-17 15:58:31+00:00
 lastUpdatedBy: Tiago Araujo
 lastUpdatedByEmail: TiagoAraujo@ssw.com.au

--- a/public/uploads/rules/what-are-the-best-examples-of-technically-cool-jquery-plug-ins/rule.mdx
+++ b/public/uploads/rules/what-are-the-best-examples-of-technically-cool-jquery-plug-ins/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "Using jQuery as a front-end framework is outdated; modern apps use TypeScript with a component framework. See [Do you know when to use TypeScript?](/rules/do-you-know-when-to-use-typescript-vs-javascript-and-coffeescript)"
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan
@@ -7,7 +7,7 @@ created: 2016-11-17 16:05:48+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
 guid: 963bc495-4585-4aa5-9019-1db1a342816c
-isArchived: false
+isArchived: true
 lastUpdated: 2021-03-09 17:04:03.004000+00:00
 lastUpdatedBy: Tiago Araújo [SSW]
 lastUpdatedByEmail: tiagov8@gmail.com

--- a/public/uploads/rules/write-your-angular-1-x-directives-in-typescript/rule.mdx
+++ b/public/uploads/rules/write-your-angular-1-x-directives-in-typescript/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: null
+archivedreason: "AngularJS (Angular 1.x) reached end-of-life in January 2022. See [Do you know why to upgrade from AngularJS to Angular?](/rules/why-upgrade-to-latest-angular)"
 authors:
 - title: Danijel Malik
   url: https://www.ssw.com.au/people/danijel-malik
@@ -19,6 +19,7 @@ categories:
   - category: categories/software-engineering/rules-to-better-angularjs.mdx
 type: rule
 uri: write-your-angular-1-x-directives-in-typescript
+isArchived: true
 ---
 
 Angular 1.x directives are awesome and they help you reuse your code base by being able to drop directives (aka reuasable HTML elements) into several pages without having to duplicate your code base.


### PR DESCRIPTION
## 📦 Archive 55 outdated rules covering dead/legacy technology

### Why

A sweep of active rules surfaced content built around technologies that are end-of-life or superseded. These rules no longer reflect current best practice and can mislead readers. This PR archives them (`isArchived: true`) with an `archivedreason:` note that either links to the current replacement rule or explains why the topic is no longer relevant.

No content bodies were changed — **frontmatter only**.

### What changed

| Group | # | Reason / suggested replacement |
|---|---|---|
| **TFS version-specific migrations** (2010/2012/2015) | 20 | TFS → Azure DevOps (2018); → *Do you know the right source control to use?* |
| **TFS general** (check-in policies, get-latest, build server, timesheets, rollback…) | 9 | → *Do you know the right source control to use?* |
| **Visual SourceSafe / VSS** | 2 | → *Do you know the right source control to use?* |
| **SharePoint 2007/2010/2013 (on-prem)** | 7 | → *Do you get rid of legacy items in SharePoint Online?* |
| **AngularJS / Angular 1.x** | 5 | AngularJS EOL Jan 2022; → *Do you know why to upgrade from AngularJS to Angular?* |
| **jQuery as a framework** | 7 | → *Do you know when to use TypeScript?* |
| **InfoPath** | 2 | Discontinued, removed from modern SharePoint — no replacement |
| **WCF / WSE3** | 1 | Legacy .NET Framework; → *Do you choose the right web API technology?* |
| **SQL Server 2000/2005 compatibility** | 1 | Out of support — no replacement |
| **Enterprise Library Config Mgmt App Block** | 1 | Deprecated on modern .NET |

**Total: 55 rules**

### Scope notes

- Scoped to **title-level dead-tech signals** — rules that only mention legacy tech in the body are not included.
- Deliberately **kept active**: rules that advise migrating *off* dead tech (VB6→.NET, AngularJS→Angular, Classic ASP→Azure) and still-valid advice that merely references old tech (webforms UX, TypeScript-vs-CoffeeScript, Kendo tooltips).

### Validation

- ✅ `frontmatter-validator.js` passes on all 55 files
- ✅ Diff is frontmatter-only (`isArchived` + `archivedreason`)
