### PR TITLE
Add rules for csproj hygiene, build diagnostics, and NuGet management

### DIFF
--- a/categories/software-engineering/rules-to-better-net-projects.mdx
+++ b/categories/software-engineering/rules-to-better-net-projects.mdx
@@ -19,6 +19,11 @@ index:
   - rule: public/uploads/rules/optimize-ef-core-queries/rule.mdx
   - rule: public/uploads/rules/use-loggermessage-in-net/rule.mdx
   - rule: public/uploads/rules/directory-build-props/rule.mdx
+  - rule: public/uploads/rules/use-central-package-management/rule.mdx
+  - rule: public/uploads/rules/use-msbuild-binlogs/rule.mdx
+  - rule: public/uploads/rules/use-global-json/rule.mdx
+  - rule: public/uploads/rules/control-nuget-package-sources/rule.mdx
+  - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx
   - rule: public/uploads/rules/minimal-apis/rule.mdx
   - rule: public/uploads/rules/multiple-startup-projects/rule.mdx
   - rule: public/uploads/rules/share-your-developer-secrets-securely/rule.mdx

--- a/categories/software-engineering/rules-to-better-net10-migrations.mdx
+++ b/categories/software-engineering/rules-to-better-net10-migrations.mdx
@@ -20,6 +20,7 @@ index:
   - rule: public/uploads/rules/migrate-global-asax-to-asp-net-core/rule.mdx
   - rule: public/uploads/rules/know-how-to-migrate-owin-to-asp-net-core/rule.mdx
   - rule: public/uploads/rules/know-how-to-migrate-web-config-to-asp-net-core/rule.mdx
+  - rule: public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
   - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx
   - rule: public/uploads/rules/dotnet-upgrade-for-complex-projects/rule.mdx
   - rule: public/uploads/rules/do-you-check-your-api-serialisation-format/rule.mdx

--- a/public/uploads/rules/control-nuget-package-sources/rule.mdx
+++ b/public/uploads/rules/control-nuget-package-sources/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/defend-against-package-supply-chain-attacks/rule.mdx
   - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx

--- a/public/uploads/rules/control-nuget-package-sources/rule.mdx
+++ b/public/uploads/rules/control-nuget-package-sources/rule.mdx
@@ -1,0 +1,77 @@
+---
+type: rule
+title: Do you control your NuGet package sources?
+uri: control-nuget-package-sources
+seoDescription: Commit a nuget.config to control your NuGet package sources and use Package Source Mapping to prevent dependency confusion attacks when using private feeds.
+guid: 4b60da4d-3256-4278-ad78-088a931fd0cb
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/defend-against-package-supply-chain-attacks/rule.mdx
+  - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx
+  - rule: public/uploads/rules/use-central-package-management/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net-projects.mdx
+---
+
+If your repository has no `nuget.config`, package restore depends on whatever sources happen to be configured on each machine - a recipe for "restores fine for me" surprises. It gets worse when you add a private feed: if an internal package name also exists on nuget.org, NuGet may happily pull the **public** one. Attackers exploit exactly this with **dependency confusion** attacks - publishing malicious packages under names they guess companies use internally.
+
+The fix is to make package sources part of the repository, not the machine.
+
+<endIntro />
+
+## Commit a nuget.config
+
+Add a `nuget.config` at the repository root, and start it with `<clear />` so machine-level sources can't leak into the build:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="MyCompany" value="https://pkgs.dev.azure.com/mycompany/_packaging/mycompany/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+**✅ Good example - Sources are explicit, versioned, and identical for every developer and CI agent**
+
+## Map packages to the right source
+
+With multiple sources, [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping?WT.mc_id=DT-MVP-33518) (NuGet 6.0+) declares which packages are allowed to come from which feed:
+
+```xml
+<packageSourceMapping>
+  <packageSource key="nuget.org">
+    <package pattern="*" />
+  </packageSource>
+  <packageSource key="MyCompany">
+    <package pattern="MyCompany.*" />
+  </packageSource>
+</packageSourceMapping>
+```
+
+**✅ Good example - MyCompany.* packages can only ever come from the private feed, killing dependency confusion**
+
+Without this, NuGet treats all sources as equal candidates:
+
+```xml
+<packageSources>
+  <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  <add key="MyCompany" value="https://pkgs.dev.azure.com/mycompany/_packaging/mycompany/nuget/v3/index.json" />
+</packageSources>
+```
+
+**❌ Bad example - No mapping means a public package named MyCompany.Core could be restored instead of your internal one**
+
+## Keep credentials out of the file
+
+`nuget.config` is committed, so it must never contain PATs or passwords:
+
+* ✅ Use `packageSourceCredentials` with environment variable references, or better
+* ✅ Use a credential provider (e.g. [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)) so auth happens outside the repo
+
+For the broader picture on supply-chain risks (lockfiles, install scripts, typosquatting), see [Do you defend against package supply chain attacks?](/defend-against-package-supply-chain-attacks).

--- a/public/uploads/rules/directory-build-props/rule.mdx
+++ b/public/uploads/rules/directory-build-props/rule.mdx
@@ -35,11 +35,10 @@ This can be used for:
 
 ### Examples
 
-
 <boxEmbed
   style="greybox"
   body={<>
-    
+
 **Project1.csproj:**
 
 ```xml
@@ -119,3 +118,41 @@ This can be used for:
 </Project>
 ```**  
 **✅ Good example - Centralized configuration**  
+
+## What about Directory.Build.targets?
+
+MSBuild auto-imports a second file, `Directory.Build.targets`, and the difference between the 2 is **when** they are imported:
+
+* `Directory.Build.props` is imported **early** - before the project's own content. Perfect for **defaults** that individual projects may still override
+* `Directory.Build.targets` is imported **late** - after the project's content and the SDK targets. Perfect for **overrides** and shared build logic that must react to (or win over) whatever a project sets
+
+Rule of thumb: **defaults go in .props, overrides and custom targets go in .targets**.
+
+```xml
+<Project>
+  <!-- Reacts to a property each project sets in its own body,
+       which is only reliable in .targets (imported after the project) -->
+  <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts\packages</PackageOutputPath>
+  </PropertyGroup>
+
+  <!-- Custom build step shared by every project -->
+  <Target Name="PrintBuildInfo" AfterTargets="Build">
+    <Message Importance="high" Text="Built $(MSBuildProjectName) ($(TargetFramework))" />
+  </Target>
+</Project>
+```
+
+**✅ Good example - Directory.Build.targets reacting to per-project properties and defining a shared target**
+
+**Note:** MSBuild only auto-imports the **nearest** `Directory.Build.props`/`.targets` above each project. If you need multiple levels (e.g. one at the repo root plus one for the `tests` folder), the inner file must import the outer one explicitly:
+
+```xml
+<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+```
+
+**Tip:** If a property doesn't have the value you expect and you can't work out which file set it, [capture a binlog](/use-msbuild-binlogs) and search for the property - the Structured Log Viewer shows every assignment and where it came from.
+
+## What about package versions?
+
+`Directory.Build.props` centralizes **build configuration**. To centralize **NuGet package versions** the same way, use a `Directory.Packages.props` file - see [Do you use Central Package Management?](/use-central-package-management).

--- a/public/uploads/rules/lock-nuget-dependencies/rule.mdx
+++ b/public/uploads/rules/lock-nuget-dependencies/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/defend-against-package-supply-chain-attacks/rule.mdx
   - rule: public/uploads/rules/cache-dependencies-in-github-actions/rule.mdx

--- a/public/uploads/rules/lock-nuget-dependencies/rule.mdx
+++ b/public/uploads/rules/lock-nuget-dependencies/rule.mdx
@@ -1,0 +1,72 @@
+---
+type: rule
+title: Do you lock your NuGet dependencies?
+uri: lock-nuget-dependencies
+seoDescription: Make .NET builds repeatable by enabling NuGet lock files with RestorePackagesWithLockFile and enforcing them in CI with dotnet restore --locked-mode.
+guid: 92ed0137-8c47-49a8-980e-8a897f2509ad
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/defend-against-package-supply-chain-attacks/rule.mdx
+  - rule: public/uploads/rules/cache-dependencies-in-github-actions/rule.mdx
+  - rule: public/uploads/rules/use-central-package-management/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net-projects.mdx
+---
+
+JavaScript developers commit `package-lock.json` without thinking about it - yet most .NET teams run `dotnet restore` with no lock file at all. That means the exact packages your build uses can change between restores without any code change: floating versions (`8.*`) resolve to something new, or a transitive dependency publishes a new version that shifts your whole graph. The build that passed yesterday and the one deployed today may not be running the same bytes.
+
+NuGet has lock files too - they're just off by default.
+
+<endIntro />
+
+## Enable lock files
+
+Turn them on for every project in one place - your [Directory.Build.props](/directory-build-props):
+
+```xml
+<PropertyGroup>
+  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+</PropertyGroup>
+```
+
+The next `dotnet restore` generates a `packages.lock.json` per project recording the exact resolved version **and content hash** of every direct and transitive package. Commit these files.
+
+## Enforce them in CI
+
+A lock file only guarantees repeatability if CI refuses to deviate from it:
+
+```bash
+dotnet restore
+```
+
+**❌ Bad example - CI re-resolves the dependency graph, so it can build something no developer has tested**
+
+```bash
+dotnet restore --locked-mode
+```
+
+**✅ Good example - Restore fails (NU1004) if the graph no longer matches the committed lock file**
+
+You can also enforce this via MSBuild so it applies automatically on CI:
+
+```xml
+<PropertyGroup>
+  <RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
+</PropertyGroup>
+```
+
+## Why it's worth it
+
+* **Repeatable builds** - the same commit always restores the same package graph
+* **Supply-chain protection** - the recorded content hashes mean a tampered or re-published package fails restore instead of silently shipping. See [Do you defend against package supply chain attacks?](/defend-against-package-supply-chain-attacks)
+* **Better caching** - the lock file is the ideal cache key for NuGet packages in CI. See [Do you cache dependencies in GitHub Actions?](/cache-dependencies-in-github-actions)
+* **Reviewable upgrades** - dependency changes show up as lock file diffs in PRs, and Dependabot/Renovate keep them updated
+
+## Notes
+
+* To intentionally update the graph (e.g. after editing package versions), run `dotnet restore --force-evaluate`
+* Lock files are per-project and per-target framework - multi-targeted solutions will see bigger diffs
+* Combine with [Central Package Management](/use-central-package-management): CPM decides the versions you *want*, the lock file proves the graph you *got*

--- a/public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
+++ b/public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/migration-plans/rule.mdx
   - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx

--- a/public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
+++ b/public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
@@ -1,0 +1,122 @@
+---
+type: rule
+title: Do you migrate your csproj files to SDK-style?
+uri: migrate-to-sdk-style-csproj
+seoDescription: Convert legacy .NET project files to the SDK-style csproj format with try-convert, handle web and desktop project gotchas, and clean up leftover cruft for small, maintainable project files.
+guid: 8003aee9-0300-4c51-8936-078ca0591349
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/migration-plans/rule.mdx
+  - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx
+  - rule: public/uploads/rules/directory-build-props/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net10-migrations.mdx
+---
+
+Legacy `.csproj` files are hundreds of lines of XML: every source file listed explicitly (a merge conflict every time 2 people add a file), NuGet references via `packages.config` and `HintPath`s, and no support for multi-targeting. Converting to the **SDK-style** format is the first mechanical step of any .NET migration (see [Do you have a .NET migration plan?](/migration-plans)) - and it pays off immediately, even while you're still targeting .NET Framework.
+
+<endIntro />
+
+## What is the SDK-style format?
+
+An SDK-style project starts with `<Project Sdk="Microsoft.NET.Sdk">` and comes with smart defaults:
+
+* **Implicit file globbing** - all `*.cs` files are compiled automatically; no `<Compile Include="..." />` needed
+* **Sensible property defaults** - `OutputType` defaults to `Library`, `AssemblyName` and `RootNamespace` default to the project name, `Debug`/`Release` configurations are built in
+* **Generated assembly info** - `AssemblyVersion`, `Company` etc. are generated from MSBuild properties, replacing `AssemblyInfo.cs`
+* **PackageReference** - NuGet dependencies are project data; no `packages.config`, `HintPath`s, or `packages` folder
+* **Multi-targeting** - `<TargetFrameworks>net48;net10.0</TargetFrameworks>` lets one project build for both frameworks during a migration
+
+**Important:** SDK-style does **not** mean modern .NET - an SDK-style project can still target `net48`. That's exactly what makes incremental migration possible: change the *format* first, the *framework* later.
+
+## Convert with try-convert
+
+Use the [try-convert](https://github.com/dotnet/try-convert) dotnet tool:
+
+```bash
+dotnet tool install -g try-convert
+```
+
+Convert while keeping your current target framework, so the format change is the *only* change:
+
+```bash
+try-convert --keep-current-tfms
+```
+
+For web projects, conversion must be forced:
+
+```bash
+try-convert --keep-current-tfms --force-web-conversion
+```
+
+Alternatively, the [.NET Upgrade Assistant](https://dotnet.microsoft.com/en-us/platform/upgrade-assistant) performs the conversion as part of a full upgrade - see [Do you know how to modernize .NET applications?](/dotnet-modernization-tools).
+
+## Watch out for these gotchas
+
+* **ASP.NET Framework web projects** - there is no SDK-style equivalent of a `System.Web`-based project. Converting the class libraries first and handling the web project via the incremental (side-by-side) approach is usually the right move - see [Do you know how to migrate Web Apps to .NET?](/migrating-web-apps-to-dotnet)
+* **WinForms / WPF projects** - add `<UseWindowsForms>true</UseWindowsForms>` or `<UseWPF>true</UseWPF>`, and when you later add a modern target framework use `net10.0-windows` - see [Do you know how to multi-target your .NET projects?](/manage-compatibility-for-different-tfms)
+* **packages.config** - `try-convert` migrates it to `PackageReference`. Afterwards, only *direct* dependencies should remain - transitive packages no longer need to be listed
+* **Convert bottom-up, one project per PR** - start with the projects that have no project references and work upward, so each conversion builds and can be reviewed in isolation
+
+## Clean up after converting
+
+Conversion tools err on the side of caution, so converted `.csproj` files usually keep legacy leftovers. The whole point of SDK-style projects is that they are small enough to read in one screen and rarely cause merge conflicts - leftover cruft throws those benefits away.
+
+After conversion, go through each project and remove:
+
+* **`<Compile>` items** that just re-include what the glob already covers
+* **Properties restating defaults** - `OutputType=Library`, `AssemblyName`/`RootNamespace` equal to the project name, empty `Debug|Release` `PropertyGroup` blocks
+* **Legacy metadata** - `ProjectGuid`, `ProjectTypeGuids`, `SchemaVersion`, `AppDesignerFolder`, `FileAlignment`
+* **Legacy imports** - `<Import Project="...Microsoft.CSharp.targets" />` and `packages.config`-era `.props`/`.targets` imports (the SDK handles these)
+* **`Reference` items with `HintPath`s** into a `packages` folder - replace with `PackageReference`
+* **`AssemblyInfo.cs`** - delete it and move any meaningful values (company, product, `InternalsVisibleTo`) into the csproj or [Directory.Build.props](/directory-build-props). If you keep it, set `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` or the build fails with `CS0579: Duplicate 'AssemblyVersion' attribute`
+
+Then pull the properties that are identical across projects (target framework, nullability, analyzers) up into a `Directory.Build.props`, and manage package versions with [Central Package Management](/use-central-package-management).
+
+## Before and after
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Northwind.Domain</RootNamespace>
+    <AssemblyName>Northwind.Domain</AssemblyName>
+    <TargetFramework>net10.0</TargetFramework>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Entities\Customer.cs" />
+    <Compile Include="Entities\Order.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+</Project>
+```
+
+**❌ Bad example - Converted but never cleaned: every line here is either a default or legacy noise**
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+**✅ Good example - The same project after cleanup (with shared properties in Directory.Build.props)**
+
+## Verify as you go
+
+Converting and cleaning up csproj files is exactly the kind of change that *shouldn't* alter build output - prove it:
+
+* Build before and after, and compare the binaries in `bin\`
+* If something behaves differently, [capture a binlog](/use-msbuild-binlogs) of both builds and compare the evaluated properties and compiled items
+* Keep the conversion and the cleanup in their own commits (or PRs) separate from functional changes, so reviewers can skim them with confidence

--- a/public/uploads/rules/migration-plans/rule.mdx
+++ b/public/uploads/rules/migration-plans/rule.mdx
@@ -89,11 +89,13 @@ For a list of potential breaking changes when migrating to later versions of .NE
 
 The first thing you want to do is update your projects' `csproj` files to the new SDK-style format. This greatly simplifies the contents of the file, and will allow you to easily target multiple versions of .NET framework monikers simultaneously (more on this below).
 
+For a detailed walkthrough of the conversion, its gotchas, and the post-conversion cleanup, see [Do you migrate your csproj files to SDK-style?](/migrate-to-sdk-style-csproj)
+
 <boxEmbed
   style="greybox"
   body={<>
     **Tip:** You can use the [try-convert](https://github.com/dotnet/try-convert) dotnet tool to convert your projects to the new sdk style csproj format.
-    
+
     Install the tool using:
     
     ```bash
@@ -127,7 +129,7 @@ Multi-targeting both your original .NET Framework version *and* your future .NET
   style="greybox"
   body={<>
     Why is this important?
-    
+
     Imagine you *don't* do this, and instead, you simply target the newer version of .NET only. You get a list of 100 build errors due to breaking changes - too many to handle for 1 Sprint (or 2 Sprints, or 3).
     
     You start fixing these build errors. You go from 100 errors to 50 - progress!

--- a/public/uploads/rules/use-central-package-management/rule.mdx
+++ b/public/uploads/rules/use-central-package-management/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/directory-build-props/rule.mdx
   - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx

--- a/public/uploads/rules/use-central-package-management/rule.mdx
+++ b/public/uploads/rules/use-central-package-management/rule.mdx
@@ -1,0 +1,120 @@
+---
+type: rule
+title: Do you use Central Package Management?
+uri: use-central-package-management
+seoDescription: Manage NuGet package versions in one place with Central Package Management (CPM). Learn how Directory.Packages.props eliminates version drift, simplifies upgrades, and keeps multi-project .NET solutions consistent.
+guid: 3931506a-fbb9-49fb-95b1-57e00e7e65cf
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/directory-build-props/rule.mdx
+  - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx
+  - rule: public/uploads/rules/control-nuget-package-sources/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net-projects.mdx
+---
+
+In a solution with many projects, NuGet package versions end up scattered across every `.csproj` file. Sooner or later 2 projects reference different versions of the same package, and you start seeing version drift, `NU1605` package downgrade errors, and runtime binding failures. Upgrading a package means hunting through dozens of files and hoping you didn't miss one.
+
+[Central Package Management (CPM)](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management?WT.mc_id=DT-MVP-33518) fixes this by declaring every package version once, in a single `Directory.Packages.props` file.
+
+<endIntro />
+
+## What is Central Package Management?
+
+CPM is a NuGet feature (available since NuGet 6.2 / .NET SDK 6.0.300 / Visual Studio 2022 17.2) that moves all package **versions** out of your project files and into one `Directory.Packages.props` file at the root of your repository:
+
+* Projects still declare **which** packages they use with `<PackageReference>`
+* `Directory.Packages.props` declares **what version** every package resolves to
+* NuGet raises an error (`NU1008`) if a project tries to specify its own version
+
+This works the same way as [Directory.Build.props](/directory-build-props) - it applies automatically to every project below it in the directory tree.
+
+## Why it matters
+
+* **One place to upgrade** - bumping a package version is a one-line change, no matter how many projects use it
+* **No version drift** - 2 projects can never silently reference different versions of the same package
+* **Smaller csproj files** - project files only say what they depend on, not which version
+* **Easier reviews** - package upgrades show up as a single-file diff
+
+## How to enable it
+
+**Directory.Packages.props:**
+
+```xml
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+  </ItemGroup>
+</Project>
+```
+
+Then remove the `Version` attributes from your project files:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
+  <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+</ItemGroup>
+```
+
+**❌ Bad example - Versions repeated (and already drifting) in every csproj**
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  <PackageReference Include="Serilog.AspNetCore" />
+</ItemGroup>
+```
+
+**✅ Good example - Projects declare dependencies, Directory.Packages.props owns the versions**
+
+## Handy extras
+
+### Version overrides
+
+If a single project genuinely needs a different version (e.g. during a migration), use `VersionOverride` rather than abandoning CPM:
+
+```xml
+<PackageReference Include="Serilog.AspNetCore" VersionOverride="9.0.0" />
+```
+
+Use this sparingly - every override is a little piece of version drift you've chosen to keep.
+
+### Global package references
+
+Packages that every project should consume (analyzers, source linking, banned API checks) can be declared once as a `GlobalPackageReference`:
+
+```xml
+<ItemGroup>
+  <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+</ItemGroup>
+```
+
+### Transitive pinning
+
+CPM can also pin **transitive** dependencies - packages you don't reference directly - which is useful for forcing patched versions of vulnerable transitive packages:
+
+```xml
+<PropertyGroup>
+  <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+</PropertyGroup>
+```
+
+## Migrating an existing solution
+
+For small solutions, move the versions by hand. For anything bigger, use the community [CentralisedPackageConverter](https://github.com/Webreaper/CentralisedPackageConverter) tool:
+
+```bash
+dotnet tool install -g CentralisedPackageConverter
+central-pkg-converter .
+```
+
+If you are planning a .NET migration, consolidating package versions with CPM **before** you start makes the upgrade dramatically easier - see [Do you have a .NET migration plan?](/migration-plans).

--- a/public/uploads/rules/use-global-json/rule.mdx
+++ b/public/uploads/rules/use-global-json/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/when-to-target-lts-versions/rule.mdx
   - rule: public/uploads/rules/directory-build-props/rule.mdx

--- a/public/uploads/rules/use-global-json/rule.mdx
+++ b/public/uploads/rules/use-global-json/rule.mdx
@@ -1,0 +1,79 @@
+---
+type: rule
+title: Do you pin your .NET SDK version with global.json?
+uri: use-global-json
+seoDescription: Pin the .NET SDK version with a global.json file so every developer and CI agent builds with the same SDK. Learn rollForward policies and how to avoid surprise breakages from SDK updates.
+guid: a6a1bd8c-196f-4453-9bdb-787f0dbf74d2
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/when-to-target-lts-versions/rule.mdx
+  - rule: public/uploads/rules/directory-build-props/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net-projects.mdx
+---
+
+Without a `global.json`, the `dotnet` CLI silently uses the **latest SDK installed on the machine**. That means a teammate who just installed a newer SDK (or a CI image that updated overnight) can build your repo with a different compiler, different analyzers, and different language version than everyone else - and you find out via a broken build or, worse, subtly different output.
+
+A one-file fix makes the SDK version part of the repository.
+
+<endIntro />
+
+## What is global.json?
+
+A [global.json](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json?WT.mc_id=DT-MVP-33518) file at the root of your repository tells the `dotnet` CLI which SDK version to use:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}
+```
+
+**✅ Good example - SDK pinned to the 10.0.x band, newer feature bands allowed, previews blocked**
+
+You can generate one with:
+
+```bash
+dotnet new globaljson --sdk-version 10.0.100
+```
+
+## Pick a sensible rollForward policy
+
+Pinning to an *exact* version is usually too strict - every developer would need that precise patch installed. The `rollForward` setting controls how flexible the match is:
+
+* `latestPatch` - same feature band, latest patch (e.g. `10.0.100` → `10.0.1xx`). Safest for strict reproducibility
+* `latestFeature` - same major.minor, latest feature band and patch (e.g. `10.0.100` → `10.0.2xx`). **Good default for most teams**
+* `latestMajor` - effectively "use the newest SDK", which is the same as having no `global.json` - avoid
+* `disable` - exact version only. Reserve for build environments you fully control
+
+## Keep CI on the same SDK
+
+Make your pipeline read the same file instead of duplicating the version:
+
+```yaml
+- uses: actions/setup-dotnet@v4
+  with:
+    dotnet-version: 9.0.x
+```
+
+**❌ Bad example - CI hardcodes an SDK that will drift from what developers use**
+
+```yaml
+- uses: actions/setup-dotnet@v4
+  with:
+    global-json-file: global.json
+```
+
+**✅ Good example - CI resolves the SDK from global.json, so there is a single source of truth**
+
+## Tips
+
+* Put `global.json` at the **repository root** so it governs every project - the CLI searches upward from the working directory and uses the first one it finds
+* Update it deliberately (in a PR) when adopting a new SDK, so the whole team and CI move together - this pairs well with [targeting the right LTS/STS version](/when-to-target-lts-versions)
+* If a build fails with "The command could not be loaded... requested SDK version not found", the machine is missing the pinned SDK - the error is your friend: install the right SDK instead of building with a random one

--- a/public/uploads/rules/use-msbuild-binlogs/rule.mdx
+++ b/public/uploads/rules/use-msbuild-binlogs/rule.mdx
@@ -2,7 +2,7 @@
 type: rule
 title: Do you use binlogs to diagnose build issues?
 uri: use-msbuild-binlogs
-seoDescription: Diagnose .NET build problems fast with MSBuild binary logs (binlogs). Learn how to capture a binlog with dotnet build -bl and analyze it in the MSBuild Structured Log Viewer.
+seoDescription: Diagnose .NET build problems fast with MSBuild binary logs (binlogs). Capture a binlog with dotnet build -bl, analyze it in the MSBuild Structured Log Viewer, or let AI assistants query it via the Microsoft Binlog MCP Server.
 guid: 8e08959b-cc35-4c0f-9d2b-4f8bf798f343
 created: 2026-07-24T00:00:00.000Z
 authors:
@@ -48,6 +48,34 @@ Things that are painful with console output and trivial in the viewer:
 * **Why did this rebuild?** - task inputs/outputs are recorded, so you can see which file triggered an incremental rebuild
 * **Preprocessed project view** - see a project's XML with every import expanded inline, exactly as MSBuild evaluated it
 
+## Let AI analyze your binlogs
+
+Binlogs aren't just for humans. The [Microsoft Binlog MCP Server](https://devblogs.microsoft.com/dotnet/msbuild-binlog-mcp-server/) lets AI assistants (GitHub Copilot, Claude Code, etc.) query a binlog directly - it's built on the same engine as the Structured Log Viewer and exposes tools for exactly the investigations above: errors and warnings with full context, property tracing, the most expensive projects/targets/tasks, embedded file search, and comparing 2 builds.
+
+The easiest setup is the `dotnet-msbuild` plugin from the [.NET Agent Skills repo](https://github.com/dotnet/skills), which bundles the MCP server with curated skills for build investigation. You can also register the server manually:
+
+```json
+{
+  "servers": {
+    "binlog-mcp": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": ["tool", "run", "Microsoft.AITools.BinlogMcp"]
+    }
+  }
+}
+```
+
+**✅ Good example - .vscode/mcp.json registering the Binlog MCP Server as a dotnet tool**
+
+Once connected, capture a binlog and ask questions like:
+
+* "Why did this build fail?"
+* "Where did `TargetFramework` get its value in MyProject?"
+* "Compare `local.binlog` and `ci.binlog` - why is CI slower?"
+
+This also works beyond the chat window - an agent in your pipeline can pick up the binlog from a failed build and post a diagnosis, see [MCP Beyond the Chat Window: Build Diagnostics in CI](https://devblogs.microsoft.com/dotnet/mcp-build-diagnostics-workflows/).
+
 ## Use binlogs instead of diagnostic text logs
 
 ```bash
@@ -85,4 +113,5 @@ The worst place to debug a build is a CI agent you can't touch. Produce a binlog
 A binlog embeds **environment variables**, command lines, and the full content of your project and targets files. Treat it like a memory dump:
 
 * ❌ Never attach a binlog to a public GitHub issue
+* ⚠️ The same caution applies to AI tooling - an assistant connected to the Binlog MCP Server can read everything in the log, including environment variables
 * ✅ Share via private channels, and rotate any secrets that were in environment variables if one leaks

--- a/public/uploads/rules/use-msbuild-binlogs/rule.mdx
+++ b/public/uploads/rules/use-msbuild-binlogs/rule.mdx
@@ -1,0 +1,88 @@
+---
+type: rule
+title: Do you use binlogs to diagnose build issues?
+uri: use-msbuild-binlogs
+seoDescription: Diagnose .NET build problems fast with MSBuild binary logs (binlogs). Learn how to capture a binlog with dotnet build -bl and analyze it in the MSBuild Structured Log Viewer.
+guid: 8e08959b-cc35-4c0f-9d2b-4f8bf798f343
+created: 2026-07-24T00:00:00.000Z
+authors:
+  - title: Kosta Madorsky
+    url: https://www.ssw.com.au/people/kosta-madorsky
+related:
+  - rule: public/uploads/rules/directory-build-props/rule.mdx
+  - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-net-projects.mdx
+---
+
+Some build failures are easy - the error tells you exactly what to fix. Then there are the others: a property that mysteriously has the wrong value, a stale DLL being copied from who-knows-where, a build that works locally but fails in CI, or a multi-targeted project that behaves differently per framework. Staring at console output (or a 200 MB diagnostic text log) is a slow way to solve these.
+
+MSBuild **binary logs (binlogs)** capture everything the build did - every project, property, item, task, and environment variable - in a compact, searchable file.
+
+<endIntro />
+
+## Capturing a binlog
+
+Add `-bl` to any build-related command:
+
+```bash
+dotnet build -bl
+dotnet restore -bl:restore.binlog
+dotnet publish -bl:publish.binlog
+```
+
+This produces an `msbuild.binlog` file (or the name you specified) in the current directory.
+
+For builds started **inside Visual Studio**, install the [Project System Tools extension](https://github.com/dotnet/project-system-tools) to capture binlogs from IDE builds.
+
+## Analyzing it with the Structured Log Viewer
+
+Open the file in the free [MSBuild Structured Log Viewer](https://msbuildlog.com) - it turns the log into a navigable tree with full-text search.
+
+Things that are painful with console output and trivial in the viewer:
+
+* **"Where did this property value come from?"** - search `$property TargetFramework` and see every assignment, including which `.props` file set it. Invaluable when debugging [Directory.Build.props](/directory-build-props) inheritance and [multi-targeting conditions](/manage-compatibility-for-different-tfms)
+* **NuGet version conflicts** - capture a restore binlog to see exactly how a `NU1605` downgrade or version conflict was resolved
+* **Double writes** - the viewer flags 2 different source files being copied to the same output path (the classic cause of "stale DLL" bugs)
+* **Slow builds** - the Timeline and "Top 10 most expensive tasks" views show where the time actually goes
+* **Why did this rebuild?** - task inputs/outputs are recorded, so you can see which file triggered an incremental rebuild
+* **Preprocessed project view** - see a project's XML with every import expanded inline, exactly as MSBuild evaluated it
+
+## Use binlogs instead of diagnostic text logs
+
+```bash
+dotnet build -v:diag > build.log
+```
+
+**❌ Bad example - Diagnostic verbosity dumps hundreds of MB of unsearchable text and still misses structure**
+
+```bash
+dotnet build -bl
+```
+
+**✅ Good example - A binlog is smaller, complete, and opens in a purpose-built viewer**
+
+## Capture binlogs in CI
+
+The worst place to debug a build is a CI agent you can't touch. Produce a binlog in your pipeline and upload it as an artifact when the build fails:
+
+```yaml
+- name: Build
+  run: dotnet build -bl:build.binlog
+
+- name: Upload binlog
+  if: failure()
+  uses: actions/upload-artifact@v4
+  with:
+    name: binlog
+    path: build.binlog
+```
+
+**✅ Good example - GitHub Actions publishing a binlog on failure, so "works on my machine" arguments end with evidence**
+
+## ⚠️ Binlogs contain secrets
+
+A binlog embeds **environment variables**, command lines, and the full content of your project and targets files. Treat it like a memory dump:
+
+* ❌ Never attach a binlog to a public GitHub issue
+* ✅ Share via private channels, and rotate any secrets that were in environment variables if one leaks

--- a/public/uploads/rules/use-msbuild-binlogs/rule.mdx
+++ b/public/uploads/rules/use-msbuild-binlogs/rule.mdx
@@ -8,6 +8,8 @@ created: 2026-07-24T00:00:00.000Z
 authors:
   - title: Kosta Madorsky
     url: https://www.ssw.com.au/people/kosta-madorsky
+  - title: Kaha Mason
+    url: https://www.ssw.com.au/people/kaha-mason/
 related:
   - rule: public/uploads/rules/directory-build-props/rule.mdx
   - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx


### PR DESCRIPTION
## Add rules for csproj hygiene, build diagnostics, and NuGet management

### Why

The .NET categories had no coverage of several everyday build/project-file topics: MSBuild binlogs, Central Package Management, `Directory.Build.targets`, `global.json`, NuGet source control/locking, and SDK-style csproj conversion was only briefly covered inside `migration-plans`. This PR fills those gaps.

### New rules

**Rules to Better .NET Projects:**

* **Do you use Central Package Management?** (`use-central-package-management`) - `Directory.Packages.props`, `VersionOverride`, `GlobalPackageReference`, transitive pinning, and migration tooling
* **Do you use binlogs to diagnose build issues?** (`use-msbuild-binlogs`) - capturing with `dotnet build -bl`, the MSBuild Structured Log Viewer, AI-assisted analysis via the new [Microsoft Binlog MCP Server](https://devblogs.microsoft.com/dotnet/msbuild-binlog-mcp-server/), CI binlog artifacts, and the secrets warning
* **Do you pin your .NET SDK version with global.json?** (`use-global-json`) - `rollForward` policies and keeping CI on the same SDK as developers
* **Do you control your NuGet package sources?** (`control-nuget-package-sources`) - committed `nuget.config` with `<clear />` and Package Source Mapping against dependency confusion
* **Do you lock your NuGet dependencies?** (`lock-nuget-dependencies`) - `RestorePackagesWithLockFile`, `--locked-mode` in CI, ties into the existing caching and supply-chain rules

**Rules to Better .NET 10 Migrations:**

* **Do you migrate your csproj files to SDK-style?** (`migrate-to-sdk-style-csproj`) - what SDK-style gives you, converting with `try-convert` / Upgrade Assistant, gotchas (System.Web projects, WinForms/WPF, `packages.config`), and a post-conversion cleanup checklist with before/after examples

### Updated rules

* **`directory-build-props`** - new "What about Directory.Build.targets?" section (props = early/defaults, targets = late/overrides, multi-level import chaining) plus cross-links to the new binlog and CPM rules
* **`migration-plans`** - the "Upgrade the csproj files" section now links to the new SDK-style rule for the detailed walkthrough

### Checks

* ✅ Frontmatter validator passes on all new/changed files
* ✅ markdownlint passes (also auto-fixed pre-existing whitespace issues in `directory-build-props` and `migration-plans`)
* ✅ New rules added to both category `index` arrays (SDK-style rule placed before `manage-compatibility-for-different-tfms` to match migration order)

### Notes for reviewers

* No images yet - screenshots of the Structured Log Viewer would be a good follow-up for `use-msbuild-binlogs`
* The Binlog MCP Server is in preview - content verified against the June 2026 .NET blog announcement
