### PR TITLE
Reorder rules in .NET Projects & .NET 10 Migrations categories

### DIFF
--- a/categories/software-engineering/rules-to-better-net-projects.mdx
+++ b/categories/software-engineering/rules-to-better-net-projects.mdx
@@ -8,90 +8,90 @@ redirects:
   - rules-to-better-net-core
 index:
   - rule: public/uploads/rules/why-choose-dot-net-core/rule.mdx
-  - rule: public/uploads/rules/testing-tools/rule.mdx
-  - rule: public/uploads/rules/add-local-configuration-file-for-developer-specific-settings/rule.mdx
   - rule: public/uploads/rules/when-to-target-lts-versions/rule.mdx
-  - rule: public/uploads/rules/the-best-sample-applications/rule.mdx
-  - rule: public/uploads/rules/app-config-for-developer-settings/rule.mdx
-  - rule: public/uploads/rules/do-you-use-the-result-pattern/rule.mdx
-  - rule: public/uploads/rules/do-you-know-how-to-use-connection-strings/rule.mdx
+  - rule: public/uploads/rules/project-setup/rule.mdx
+  - rule: public/uploads/rules/do-you-have-a-consistent-net-solution-structure/rule.mdx
   - rule: public/uploads/rules/use-slnx-format/rule.mdx
-  - rule: public/uploads/rules/optimize-ef-core-queries/rule.mdx
-  - rule: public/uploads/rules/use-loggermessage-in-net/rule.mdx
+  - rule: public/uploads/rules/do-you-use-solution-folders-to-neatly-structure-your-solution/rule.mdx
+  - rule: public/uploads/rules/use-global-json/rule.mdx
   - rule: public/uploads/rules/directory-build-props/rule.mdx
   - rule: public/uploads/rules/use-central-package-management/rule.mdx
-  - rule: public/uploads/rules/use-msbuild-binlogs/rule.mdx
-  - rule: public/uploads/rules/use-global-json/rule.mdx
   - rule: public/uploads/rules/control-nuget-package-sources/rule.mdx
   - rule: public/uploads/rules/lock-nuget-dependencies/rule.mdx
-  - rule: public/uploads/rules/minimal-apis/rule.mdx
-  - rule: public/uploads/rules/multiple-startup-projects/rule.mdx
-  - rule: public/uploads/rules/share-your-developer-secrets-securely/rule.mdx
-  - rule: public/uploads/rules/containerize-sql-server/rule.mdx
-  - rule: public/uploads/rules/dev-containers/rule.mdx
-  - rule: public/uploads/rules/use-a-project-portal-for-your-team-and-client/rule.mdx
+  - rule: public/uploads/rules/use-msbuild-binlogs/rule.mdx
   - rule: public/uploads/rules/store-your-secrets-securely/rule.mdx
-  - rule: public/uploads/rules/do-you-publish-your-components-to-source-safe/rule.mdx
-  - rule: public/uploads/rules/do-you-have-a-consistent-net-solution-structure/rule.mdx
-  - rule: public/uploads/rules/do-you-add-the-necessary-code-so-you-can-always-sync-the-web-config-file/rule.mdx
+  - rule: public/uploads/rules/share-your-developer-secrets-securely/rule.mdx
+  - rule: public/uploads/rules/add-local-configuration-file-for-developer-specific-settings/rule.mdx
+  - rule: public/uploads/rules/app-config-for-developer-settings/rule.mdx
+  - rule: public/uploads/rules/do-you-know-how-to-use-connection-strings/rule.mdx
+  - rule: public/uploads/rules/dev-containers/rule.mdx
+  - rule: public/uploads/rules/containerize-sql-server/rule.mdx
+  - rule: public/uploads/rules/multiple-startup-projects/rule.mdx
+  - rule: public/uploads/rules/testing-tools/rule.mdx
+  - rule: public/uploads/rules/minimal-apis/rule.mdx
+  - rule: public/uploads/rules/do-you-use-the-result-pattern/rule.mdx
+  - rule: public/uploads/rules/use-loggermessage-in-net/rule.mdx
+  - rule: public/uploads/rules/optimize-ef-core-queries/rule.mdx
+  - rule: public/uploads/rules/the-best-sample-applications/rule.mdx
+  - rule: public/uploads/rules/do-you-profile-your-code-when-optimising-performance/rule.mdx
+  - rule: public/uploads/rules/do-you-deploy-your-applications-correctly/rule.mdx
+  - rule: public/uploads/rules/do-you-distribute-a-product-in-release-mode/rule.mdx
+  - rule: public/uploads/rules/c-vb-net-configuration-do-you-know-not-to-use-debug-compilation-in-production-applications/rule.mdx
+  - rule: public/uploads/rules/do-you-keep-your-nuget-packages-small/rule.mdx
+  - rule: public/uploads/rules/do-you-keep-your-assembly-version-consistent/rule.mdx
+  - rule: public/uploads/rules/use-a-project-portal-for-your-team-and-client/rule.mdx
+  - rule: public/uploads/rules/do-you-know-the-best-criteria-for-evaluating-3rd-party-software/rule.mdx
+  - rule: public/uploads/rules/do-you-use-comments-not-exclusion-files-when-you-ignore-a-code-analysis-rule/rule.mdx
+  - rule: public/uploads/rules/do-you-use-one-class-per-file/rule.mdx
+  - rule: public/uploads/rules/do-you-use-more-meaningful-names-than-hungarian-short-form/rule.mdx
+  - rule: public/uploads/rules/do-you-reference-most-dlls-by-project/rule.mdx
+  - rule: public/uploads/rules/do-you-reference-very-calm-stable-dlls-by-assembly/rule.mdx
+  - rule: public/uploads/rules/do-you-make-your-projects-regenerated-easily/rule.mdx
+  - rule: public/uploads/rules/do-you-know-bak-files-must-not-exist/rule.mdx
+  - rule: public/uploads/rules/do-you-know-zz-ed-files-must-not-exist-in-source-control/rule.mdx
   - rule: public/uploads/rules/do-you-version-your-xml-files/rule.mdx
+  - rule: public/uploads/rules/do-you-know-how-to-track-down-permission-problems/rule.mdx
+  - rule: public/uploads/rules/do-you-highlight-strings-in-your-code-editor/rule.mdx
+  - rule: public/uploads/rules/do-you-always-make-file-paths-quoted/rule.mdx
+  - rule: public/uploads/rules/do-you-use-powershell-to-run-batch-files-in-visual-studio/rule.mdx
+  - rule: public/uploads/rules/do-you-put-all-images-in-the-images-folder/rule.mdx
+  - rule: public/uploads/rules/do-you-keep-images-folder-image-only/rule.mdx
+  - rule: public/uploads/rules/do-you-put-your-setup-file-in-your-a-setup-folder/rule.mdx
+  - rule: public/uploads/rules/do-you-create-different-app-config-for-different-environment/rule.mdx
+  - rule: public/uploads/rules/are-your-customizable-and-non-customizable-settings-in-different-files/rule.mdx
+  - rule: public/uploads/rules/do-you-use-windows-integrated-authentication-connection-string-in-web-config/rule.mdx
+  - rule: public/uploads/rules/do-you-avoid-using-duplicate-connection-string-in-web-config/rule.mdx
   - rule: public/uploads/rules/do-you-refer-to-images-the-correct-way-in-asp-net/rule.mdx
   - rule: public/uploads/rules/do-you-use-treeview-control-instead-of-xml-control/rule.mdx
+  - rule: public/uploads/rules/do-you-use-resource-file-for-storing-your-static-script/rule.mdx
+  - rule: public/uploads/rules/do-you-use-trace-fail-or-set-assertuienabled-true-in-your-web-config/rule.mdx
+  - rule: public/uploads/rules/do-you-use-asynchronous-method-and-callback-when-invoke-web-method/rule.mdx
+  - rule: public/uploads/rules/do-you-always-prefix-sql-stored-procedure-names-with-the-owner-in-ado-net-code/rule.mdx
+  - rule: public/uploads/rules/do-you-let-the-adapter-handle-the-connection-for-you/rule.mdx
+  - rule: public/uploads/rules/do-you-have-a-resetdefault-function-in-your-configuration-management-application-block/rule.mdx
+  - rule: public/uploads/rules/do-you-always-use-option-explicit/rule.mdx
+  - rule: public/uploads/rules/do-you-always-say-option-strict-on/rule.mdx
+  - rule: public/uploads/rules/do-you-use-the-designer-for-all-visual-elements/rule.mdx
+  - rule: public/uploads/rules/do-you-keep-clean-on-imports-of-project-property/rule.mdx
+  - rule: public/uploads/rules/do-you-publish-your-components-to-source-safe/rule.mdx
+  - rule: public/uploads/rules/do-you-create-your-own-process-template-to-fit-into-your-environment/rule.mdx
+  - rule: public/uploads/rules/do-you-add-the-necessary-code-so-you-can-always-sync-the-web-config-file/rule.mdx
   - rule: public/uploads/rules/do-you-add-ssw-code-auditor-nunit-and-microsoft-fxcop-project-files-to-your-solution/rule.mdx
   - rule: public/uploads/rules/do-you-use-slack-as-part-of-your-devops/rule.mdx
-  - rule: public/uploads/rules/do-you-always-prefix-sql-stored-procedure-names-with-the-owner-in-ado-net-code/rule.mdx
-  - rule: public/uploads/rules/do-you-deploy-your-applications-correctly/rule.mdx
-  - rule: public/uploads/rules/do-you-keep-your-assembly-version-consistent/rule.mdx
-  - rule: public/uploads/rules/do-you-keep-your-nuget-packages-small/rule.mdx
-  - rule: public/uploads/rules/do-you-always-use-option-explicit/rule.mdx
-  - rule: public/uploads/rules/do-you-use-solution-folders-to-neatly-structure-your-solution/rule.mdx
-  - rule: public/uploads/rules/do-you-know-the-best-criteria-for-evaluating-3rd-party-software/rule.mdx
-  - rule: public/uploads/rules/do-you-know-how-to-track-down-permission-problems/rule.mdx
   - rule: public/uploads/rules/do-you-turn-edit-and-continue-off/rule.mdx
-  - rule: public/uploads/rules/c-vb-net-configuration-do-you-know-not-to-use-debug-compilation-in-production-applications/rule.mdx
-  - rule: public/uploads/rules/do-you-know-bak-files-must-not-exist/rule.mdx
   - rule: public/uploads/rules/do-you-name-your-startup-form-consistently/rule.mdx
   - rule: public/uploads/rules/do-you-use-the-sharepoint-portal-in-vsts-2012/rule.mdx
   - rule: public/uploads/rules/do-you-know-the-right-methodology-to-choose-new-project-in-vs-2012/rule.mdx
-  - rule: public/uploads/rules/do-you-create-your-own-process-template-to-fit-into-your-environment/rule.mdx
   - rule: public/uploads/rules/do-you-use-ms-project-integration-with-tfs-2012/rule.mdx
   - rule: public/uploads/rules/do-you-use-tfs-2012-instead-of-tfs-2010/rule.mdx
-  - rule: public/uploads/rules/do-you-know-zz-ed-files-must-not-exist-in-source-control/rule.mdx
-  - rule: public/uploads/rules/do-you-use-comments-not-exclusion-files-when-you-ignore-a-code-analysis-rule/rule.mdx
-  - rule: public/uploads/rules/do-you-create-different-app-config-for-different-environment/rule.mdx
-  - rule: public/uploads/rules/do-you-make-your-projects-regenerated-easily/rule.mdx
-  - rule: public/uploads/rules/do-you-use-trace-fail-or-set-assertuienabled-true-in-your-web-config/rule.mdx
-  - rule: public/uploads/rules/do-you-highlight-strings-in-your-code-editor/rule.mdx
-  - rule: public/uploads/rules/do-you-always-make-file-paths-quoted/rule.mdx
-  - rule: public/uploads/rules/do-you-use-windows-integrated-authentication-connection-string-in-web-config/rule.mdx
-  - rule: public/uploads/rules/do-you-use-powershell-to-run-batch-files-in-visual-studio/rule.mdx
-  - rule: public/uploads/rules/do-you-use-asynchronous-method-and-callback-when-invoke-web-method/rule.mdx
   - rule: public/uploads/rules/do-you-know-what-files-not-to-put-into-vss/rule.mdx
-  - rule: public/uploads/rules/do-you-avoid-using-duplicate-connection-string-in-web-config/rule.mdx
   - rule: public/uploads/rules/do-you-know-changes-on-datetime-in-net-2-0-and-net-1-1-1-0/rule.mdx
-  - rule: public/uploads/rules/do-you-use-resource-file-for-storing-your-static-script/rule.mdx
-  - rule: public/uploads/rules/do-you-profile-your-code-when-optimising-performance/rule.mdx
-  - rule: public/uploads/rules/do-you-keep-images-folder-image-only/rule.mdx
-  - rule: public/uploads/rules/do-you-distribute-a-product-in-release-mode/rule.mdx
   - rule: public/uploads/rules/do-you-know-how-to-rename-files-that-under-sourcesafe-control/rule.mdx
-  - rule: public/uploads/rules/do-you-use-more-meaningful-names-than-hungarian-short-form/rule.mdx
   - rule: public/uploads/rules/do-you-use-a-dataadapter-to-insert-rows-into-your-database/rule.mdx
-  - rule: public/uploads/rules/do-you-let-the-adapter-handle-the-connection-for-you/rule.mdx
-  - rule: public/uploads/rules/do-you-put-your-setup-file-in-your-a-setup-folder/rule.mdx
-  - rule: public/uploads/rules/do-you-put-all-images-in-the-images-folder/rule.mdx
-  - rule: public/uploads/rules/do-you-use-one-class-per-file/rule.mdx
   - rule: public/uploads/rules/do-you-secure-your-web-services-using-wcf-over-wse3-and-ssl/rule.mdx
-  - rule: public/uploads/rules/do-you-have-a-resetdefault-function-in-your-configuration-management-application-block/rule.mdx
-  - rule: public/uploads/rules/are-your-customizable-and-non-customizable-settings-in-different-files/rule.mdx
   - rule: public/uploads/rules/do-you-use-configuration-management-application-block/rule.mdx
-  - rule: public/uploads/rules/do-you-reference-very-calm-stable-dlls-by-assembly/rule.mdx
-  - rule: public/uploads/rules/do-you-reference-most-dlls-by-project/rule.mdx
   - rule: public/uploads/rules/do-you-use-microsoft-visualbasic-dll-for-visual-basic-net-projects/rule.mdx
   - rule: public/uploads/rules/do-you-avoid-microsoft-visualbasic-compatibility-dll-for-visual-basic-net-projects/rule.mdx
-  - rule: public/uploads/rules/do-you-use-the-designer-for-all-visual-elements/rule.mdx
-  - rule: public/uploads/rules/do-you-keep-clean-on-imports-of-project-property/rule.mdx
-  - rule: public/uploads/rules/do-you-always-say-option-strict-on/rule.mdx
-  - rule: public/uploads/rules/project-setup/rule.mdx
 _template: category
 ---
 

--- a/categories/software-engineering/rules-to-better-net10-migrations.mdx
+++ b/categories/software-engineering/rules-to-better-net10-migrations.mdx
@@ -14,18 +14,18 @@ index:
   - rule: public/uploads/rules/migration-plans/rule.mdx
   - rule: public/uploads/rules/modernize-your-app/rule.mdx
   - rule: public/uploads/rules/dotnet-modernization-tools/rule.mdx
-  - rule: public/uploads/rules/migrating-web-apps-to-dotnet/rule.mdx
-  - rule: public/uploads/rules/migrate-from-system-web-to-modern-alternatives/rule.mdx
-  - rule: public/uploads/rules/migrate-from-edmx-to-ef-core/rule.mdx
-  - rule: public/uploads/rules/migrate-global-asax-to-asp-net-core/rule.mdx
-  - rule: public/uploads/rules/know-how-to-migrate-owin-to-asp-net-core/rule.mdx
-  - rule: public/uploads/rules/know-how-to-migrate-web-config-to-asp-net-core/rule.mdx
   - rule: public/uploads/rules/migrate-to-sdk-style-csproj/rule.mdx
   - rule: public/uploads/rules/manage-compatibility-for-different-tfms/rule.mdx
-  - rule: public/uploads/rules/dotnet-upgrade-for-complex-projects/rule.mdx
-  - rule: public/uploads/rules/do-you-check-your-api-serialisation-format/rule.mdx
+  - rule: public/uploads/rules/migrating-web-apps-to-dotnet/rule.mdx
+  - rule: public/uploads/rules/migrate-from-system-web-to-modern-alternatives/rule.mdx
+  - rule: public/uploads/rules/know-how-to-migrate-web-config-to-asp-net-core/rule.mdx
+  - rule: public/uploads/rules/migrate-global-asax-to-asp-net-core/rule.mdx
+  - rule: public/uploads/rules/know-how-to-migrate-owin-to-asp-net-core/rule.mdx
+  - rule: public/uploads/rules/migrate-from-edmx-to-ef-core/rule.mdx
   - rule: public/uploads/rules/migrating-frontend-to-net10/rule.mdx
+  - rule: public/uploads/rules/do-you-check-your-api-serialisation-format/rule.mdx
   - rule: public/uploads/rules/use-banned-api-analyzers/rule.mdx
+  - rule: public/uploads/rules/dotnet-upgrade-for-complex-projects/rule.mdx
 ---
 
 Ready to migrate to .NET 10? Check [SSW's .NET 10 Migration consulting page](https://www.ssw.com.au/consulting/net-upgrade).


### PR DESCRIPTION
Reorders the rules within two category index files by **relevance and must-know priority**, so the most useful modern guidance appears first and dated/archived rules sink to the bottom. **No rules were added, removed, or duplicated** — this is purely a resequencing of the existing `index:` lists.

### Changes

**`Rules to Better .NET Projects`** (85 rules) — previously had recent additions up top with 2005-era rules scattered through the middle. Now ordered in four bands:

1. **Modern must-knows (1–26)** — reads as a natural setup journey: why .NET / LTS targeting → project & solution structure (SLNX, solution folders) → build & NuGet management (global.json, Directory.Build.props, Central Package Management, package sources, lock files, binlogs) → secrets & config → dev environment (dev containers, containerized SQL Server) → code practices (testing, Minimal APIs, result pattern, LoggerMessage, EF Core) → sample apps
2. **Still-useful general practices (27–50)** — profiling, deployment, NuGet hygiene, evaluating 3rd-party software, naming, project references, source-control hygiene
3. **Dated but still-active legacy rules (51–68)** — web.config-era config, WebForms, ADO.NET, VB.NET Option Strict/Explicit
4. **Archived rules last (69–85)** — all 17 rules with an `archivedreason` (TFS 2012, VSS, WSE3, .NET 2.0, etc.) now grouped at the bottom instead of mixed through the list

**`Rules to Better .NET 10 Migrations`** (16 rules) — already close; surgical changes only:

- Moved **migrate to SDK-style csproj** and **multi-target TFMs** up to positions 5–6 (foundational first step before web-specific migrations)
- Ordered the web migration sequence logically: web apps overview → System.Web → Web.config → Global.asax → OWIN → EDMX/EF Core → frontend
- Kept verification rules (API serialisation check, BannedApiAnalyzers) near the end
- Moved the archived "complex .NET migrations" rule to last

### Files changed

| File | Change |
|------|--------|
| `categories/software-engineering/rules-to-better-net-projects.mdx` | Reordered 85 rules |
| `categories/software-engineering/rules-to-better-net10-migrations.mdx` | Reordered 16 rules |

### Verification

- ✅ Both files: entry count and unique count match (85/85, 16/16) — **no duplicates**
- ✅ Set comparison against pre-reorder `HEAD` is **identical** — nothing added or removed, only order changed
