### PR TITLE
Freshen modern rules in Rules to Better .NET Projects

### DIFF
--- a/public/uploads/rules/do-you-know-how-to-use-connection-strings/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-use-connection-strings/rule.mdx
@@ -14,6 +14,8 @@ authors:
     url: 'https://www.ssw.com.au/people/bryden-oliver'
   - title: Calum Simpson
     url: 'https://www.ssw.com.au/people/calum-simpson'
+  - title: Kosta Madorsky
+    url: 'https://www.ssw.com.au/people/kosta-madorsky'
 redirects:
   - do-you-know-how-to-use-connection-string-in-net-2-0
   - do-you-hard-code-your-connectionstring
@@ -49,11 +51,11 @@ Take a look at [Do you store your secrets securely](/store-your-secrets-securely
 
 #### Example - Integrating Azure Key Vault into your ASP.NET Core application
 
-In .NET 5 we can use **Azure Key Vault** to securely store our connection strings away from prying eyes.
+In .NET we can use **Azure Key Vault** to securely store our connection strings away from prying eyes.
 
 Azure Key Vault is great for keeping your secrets secret because you can control access to the vault via Access Policies. The access policies allows you to add Users and Applications with customized permissions. Make sure you enable the System assigned identity for your App Service, this is required for adding it to Key Vault via Access Policies.
 
-You can integrate Key Vault directly into your [ASP.NET Core application configuration](https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0\&WT.mc_id=ES-MVP-33518). This allows you to access Key Vault secrets via `IConfiguration`.
+You can integrate Key Vault directly into your [ASP.NET Core application configuration](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-10.0\&WT.mc_id=ES-MVP-33518). This allows you to access Key Vault secrets via `IConfiguration`.
 
 ```cs
 public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/public/uploads/rules/the-best-sample-applications/rule.mdx
+++ b/public/uploads/rules/the-best-sample-applications/rule.mdx
@@ -9,6 +9,8 @@ authors:
   url: https://www.ssw.com.au/people/jason-taylor
 - title: Gabriel George
   url: https://www.ssw.com.au/people/gabriel-george
+- title: Kosta Madorsky
+  url: https://www.ssw.com.au/people/kosta-madorsky
 created: 2016-03-15 18:31:51+00:00
 createdBy: Tiago Araujo
 createdByEmail: TiagoAraujo@ssw.com.au
@@ -51,7 +53,7 @@ Before starting a software project and evaluating a new technology, it is import
 ### .NET Core
 
 - **[SSW Clean Architecture Solution Template](https://github.com/SSWConsulting/SSW.CleanArchitecture)**
-  An example REST API build with .NET 7 following the principles of Clean Architecture.
+  An example REST API built with .NET 10 following the principles of Clean Architecture.
 - **[SSW Northwind Traders](https://github.com/SSWConsulting/Northwind365)**
   A reference application built using Clean Architecture, Angular 8, EF Core 7, ASP.NET Core 7, Duende Identity Server 6.
 - **[eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb)**

--- a/public/uploads/rules/use-global-json/rule.mdx
+++ b/public/uploads/rules/use-global-json/rule.mdx
@@ -61,7 +61,7 @@ Make your pipeline read the same file instead of duplicating the version:
 ```yaml
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: 9.0.x
+    dotnet-version: 10.0.x
 ```
 
 **❌ Bad example - CI hardcodes an SDK that will drift from what developers use**

--- a/public/uploads/rules/use-loggermessage-in-net/rule.mdx
+++ b/public/uploads/rules/use-loggermessage-in-net/rule.mdx
@@ -3,6 +3,8 @@ archivedreason: null
 authors:
 - title: Tom Iwainski
   url: https://www.ssw.com.au/people/thomas-iwainski
+- title: Kosta Madorsky
+  url: https://www.ssw.com.au/people/kosta-madorsky
 created: 2024-11-05 12:52:08+00:00
 guid: 2feb782f-0cee-4022-95d9-f44b9f739b90
 seoDescription: Learn how to optimize logging in .NET applications using the LoggerMessage
@@ -58,15 +60,15 @@ public partial class InstanceLoggingExample(ILogger logger)
 ```
 
 Using `LoggerMessageAttribute` with `JsonConsole` formatter can produce structured logs.
-In our log messages we can specify custom event names as well as utelize string formatters:
+In our log messages we can specify custom event names as well as utilize string formatters:
 
 ```csharp
 [LoggerMessage(
-        EventId = 9,
-        Level = LogLevel.Trace,
-        EventName = "PropertyValueEvent")]
-        Message = "In {City} the average property value is {Value:E}")]
-public static partial void PropertyValueInAustralia(ILogger logger, string city double value);
+    EventId = 9,
+    Level = LogLevel.Trace,
+    EventName = "PropertyValueEvent",
+    Message = "In {City} the average property value is {Value:E}")]
+public static partial void PropertyValueInAustralia(ILogger logger, string city, double value);
 ```
 
 ## Constraints


### PR DESCRIPTION
## Overview

Follow-up review of the **Rules to Better .NET Projects** category. Ran a mechanical pass over the non-archived rules (internal links all resolve; no invalid TFMs) and fixed concrete version-staleness in the modern rules. **Archived rules were deliberately left untouched.**

## Changes

- **use-global-json** — the "Keep CI on the same SDK" bad-example used `dotnet-version: 9.0.x` while the rest of this (brand-new, .NET 10) rule pins `10.0.100`. Bumped to `10.0.x` for consistency.
- **do-you-know-how-to-use-connection-strings** — dropped the stale "In .NET 5 we can use…" version anchor (Key Vault integration isn't .NET 5-specific) and refreshed the Key Vault docs link from `docs.microsoft.com/...?view=aspnetcore-5.0` to `learn.microsoft.com/...?view=aspnetcore-10.0`.
- **the-best-sample-applications** — the SSW Clean Architecture template now targets **.NET 10** (verified via its `global.json` = `10.0.100` and README), not .NET 7. Also fixed "build" → "built".

All changed/added URLs verified returning **HTTP 200**.

Per repo convention, added **Kosta Madorsky** as an author on the changed rules that didn't already list him (`connection-strings`, `the-best-sample-applications`).

## Noted but not changed (needs a decision / bigger rewrite)
- **do-you-know-how-to-use-connection-strings** still shows the Key Vault wiring using the legacy Generic Host / `Startup.cs` pattern (`Host.CreateDefaultBuilder().ConfigureWebHostDefaults()`). Modernising it to minimal hosting (`WebApplication.CreateBuilder` + `builder.Configuration.AddAzureKeyVault`) would be a good follow-up.
- **when-to-target-lts-versions** uses 2020-era .NET 5 / .NET Core 3.1 scenarios. The decision framework is still valid; refreshing the examples to current versions is a larger editorial change left for author review.
