### PR TITLE
Add video upload handoff steps

### DIFF
--- a/categories/communication/rules-to-better-outsourcing.mdx
+++ b/categories/communication/rules-to-better-outsourcing.mdx
@@ -10,7 +10,6 @@ index:
 - rule: public/uploads/rules/make-sure-all-software-uses-english/rule.mdx
 - rule: public/uploads/rules/go-beyond-just-using-chat/rule.mdx
 - rule: public/uploads/rules/collaborate-across-timezones/rule.mdx
-- rule: public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
 - rule: public/uploads/rules/be-available-for-emergency-communication/rule.mdx
 - rule: public/uploads/rules/do-you-share-screens-when-working-remotely/rule.mdx
 - rule: public/uploads/rules/build-inter-office-interaction/rule.mdx

--- a/categories/marketing-and-video/rules-to-better-video-recording.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -32,6 +32,7 @@ index:
   - rule: public/uploads/rules/production-do-you-set-up-the-speaker-prior-to-recording/rule.mdx
   - rule: public/uploads/rules/easy-recording-space/rule.mdx
   - rule: public/uploads/rules/video-recordings/rule.mdx
+  - rule: public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
 created: 2021-05-17T02:16:52.000Z
 createdBy: 'Jayden Alchin [SSW]'
 createdByEmail: 75593567+jaydenalchin@users.noreply.github.com

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Do you know the best ways to transfer files to and from China?  \U0001F1E8\U0001F1F3"
+title: "Do you know the best ways to transfer files to and from China?  🇨🇳"
 uri: the-best-file-transfer-techniques-to-and-from-china
 categories:
   - category: categories/marketing-and-video/rules-to-better-video-recording.mdx
@@ -38,11 +38,23 @@ SharePoint (default at SSW) is heavily throttled or inconsistent for users in Ch
 
 ## What to do after uploading the video content
 
-Once the video content has been uploaded to Google Drive:
+Once the video content has been uploaded to Google Drive, send the following email to the SSW TV team:
 
-1. Email the preferred editor or the SSW TV team to confirm that the content is ready
-2. Assign the work item to the editor or SSW TV team
-3. Begin the editing process when the assigned editor is available
+```text
+Hi SSWTV Team,
+
+I have uploaded the video content to the Google Drive and it is now ready to be edited.
+
+Could you please:
+
+1. Create a work item for this video.
+2. Assign the work item to the appropriate editor.
+3. Begin the editing process when available.
+
+Please let me know if there are any issues accessing the files.
+
+Thanks!
+```
 
 <imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />
 

--- a/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
+++ b/public/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/rule.mdx
@@ -36,6 +36,14 @@ SharePoint (default at SSW) is heavily throttled or inconsistent for users in Ch
 
 💡 To get started, follow the official guide on [how to use Google Drive](https://support.google.com/drive/answer/2424384). 
 
+## What to do after uploading the video content
+
+Once the video content has been uploaded to Google Drive:
+
+1. Email the preferred editor or the SSW TV team to confirm that the content is ready
+2. Assign the work item to the editor or SSW TV team
+3. Begin the editing process when the assigned editor is available
+
 <imageEmbed alt="Sharepoint-takes-2-hours" size="large" showBorder={false} figurePrefix="bad" figure="238 MB files shared through Sharepoint takes 2 hours" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/Sharepoints-takes-3-hour.png" />
 
 <imageEmbed alt="Googledrive-takes-6-seconds" size="large" showBorder={false} figurePrefix="good" figure="353 MB files shared through GoogleDrive takes 6 seconds" src="/uploads/rules/the-best-file-transfer-techniques-to-and-from-china/googledrive-takes-6-seconds.png" />


### PR DESCRIPTION
## What changed

Added a post-upload handoff section to the China file-transfer rule covering:

- notifying the preferred editor or SSW TV team
- assigning the work item
- beginning editing when the assigned editor is available

## Why

This makes the workflow after uploading video content to Google Drive explicit and actionable.

## Validation

- Confirmed the updated MDX renders correctly in GitHub preview
- Confirmed the heading and all three workflow steps are present