### PR TITLE
Add rule - Incidents - Do you know the 4 R's of incident communication?

### DIFF
--- a/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
+++ b/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
@@ -25,6 +25,7 @@ index:
   - rule: public/uploads/rules/do-you-repeat-back-the-specifics-of-a-request/rule.mdx
   - rule: public/uploads/rules/send-done-videos/rule.mdx
   - rule: public/uploads/rules/how-to-take-feedback-or-criticism/rule.mdx
+  - rule: public/uploads/rules/communicate-during-an-incident/rule.mdx
   - rule: public/uploads/rules/understand-the-power-of-empathy/rule.mdx
   - rule: public/uploads/rules/handle-passive-aggressive-comments/rule.mdx
   - rule: public/uploads/rules/go-the-extra-mile/rule.mdx

--- a/categories/communication/rules-to-better-communication.mdx
+++ b/categories/communication/rules-to-better-communication.mdx
@@ -30,6 +30,7 @@ index:
   - rule: public/uploads/rules/the-happiness-equation/rule.mdx
   - rule: public/uploads/rules/take-effective-notes/rule.mdx
   - rule: public/uploads/rules/escalate-key-updates/rule.mdx
+  - rule: public/uploads/rules/communicate-during-an-incident/rule.mdx
   - rule: public/uploads/rules/corridor-conversations/rule.mdx
   - rule: public/uploads/rules/tofu/rule.mdx
   - rule: public/uploads/rules/attention-to-detail/rule.mdx

--- a/categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
+++ b/categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
@@ -11,6 +11,7 @@ index:
 - rule: public/uploads/rules/disaster-recovery-plan/rule.mdx
 - rule: public/uploads/rules/planned-outage-process/rule.mdx
 - rule: public/uploads/rules/unplanned-outage-process/rule.mdx
+- rule: public/uploads/rules/communicate-during-an-incident/rule.mdx
 - rule: public/uploads/rules/know-the-right-notification-for-backups/rule.mdx
 - rule: public/uploads/rules/have-a-strict-password-security-policy/rule.mdx
 - rule: public/uploads/rules/multi-factor-authentication-enabled/rule.mdx

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -60,7 +60,7 @@ The severity is set by the impact on the stakeholder. It is not set by how hard 
 
 ### 1. Respond - as soon as you see it
 
-There is no on-call roster here, and nobody expects you to be watching chat after hours. This step is about what you do **when you do see it**. Once the message is in front of you, act on it straight away rather than reading it and coming back to it later.
+If your team has an on-call roster or agreed response times, follow those. Otherwise, the clock starts **when you see it**. Once the message is in front of you, act on it straight away rather than reading it and coming back to it later.
 
 **📞 Call, don't chat**
 

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -58,13 +58,26 @@ The severity is set by the impact on the stakeholder. It is not set by how hard 
 
 ## The 4 R's: Respond, Reinforce, Report, Resolve
 
-### 1. Respond - within 5 minutes
+### 1. Respond - as soon as you see it
+
+There is no on-call roster here, and nobody expects you to be watching chat after hours. This step is about what you do **when you do see it**. Once the message is in front of you, act on it straight away rather than reading it and coming back to it later.
 
 **📞 Call, don't chat**
 
 Chat is the wrong tool for an incident. It is slow, it is easy to misread, and a long back and forth reads as a lack of urgency.
 
-Pick up the phone, even if you are nowhere near your computer. You can often still help verbally. If you truly can't help, say so straight away. That lets the other person escalate to someone else instead of waiting on you.
+Send one quick line so they know the message has landed, then call.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Seen it, calling you now."
+  </>}
+  figurePrefix="good"
+  figure="Takes 2 seconds, and it stops them chasing other people while your phone is ringing"
+/>
+
+Pick up the phone even if you are nowhere near your computer. You can often still help verbally. If you truly can't help, say so straight away. That lets the other person escalate to someone else instead of waiting on you.
 
 **🙏 Use the 3 A's**
 

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -255,3 +255,16 @@ An incident over a weekend is not over when the service comes back up. On the ne
 1. Make it the team's **top priority**, above whatever was already planned
 2. Brief everyone who was not around during the incident, especially anyone who was off
 3. Start the investigation immediately. Don't let it drift into "we'll look next sprint"
+
+## 🎯 Cheatsheet
+
+* **Respond** - "Seen it, calling you now", then call. Acknowledge, apologize, act
+* **Reinforce** - get a second person in early. One person fixes, one person talks
+* **Report** - an update every 15 to 30 minutes, even when there is nothing new to say
+* **Resolve** - make it the top priority on the next business day
+
+## 💡 Final word
+
+Nobody can see you working. From the outside, an hour of careful troubleshooting looks exactly the same as an hour of doing nothing.
+
+The fix earns you the outcome. The updates earn you the trust. You need both, and only one of them is free.

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -30,22 +30,11 @@ You know this rule applies when **someone reaches out about a critical issue**. 
 
 They may sound stressed, frustrated, or upset. That is a fair reaction when something important is broken, so take it as a signal of how much this matters to them.
 
+The severity is set by the impact on them. It is not set by how hard the fix looks to you, so don't spend time deciding whether it really counts. If it is urgent to them, treat it as urgent.
+
 Most incidents go pear-shaped for one reason. It is rarely that the fix took too long. It is that the person who raised it was left wondering whether anyone cared.
 
 <endIntro />
-
-## 🔥 What counts as an incident?
-
-Anything critical that is broken **right now** and that someone is relying on you to sort out:
-
-* A server or network is down
-* A web app or product is unavailable, or a core feature is broken in production
-* A release has broken something for real users
-* Customer data is missing, wrong, or exposed
-* A payment, integration, or scheduled job has quietly stopped working
-* A demo, launch, or deadline is about to be missed because of a technical failure
-
-The severity is set by the impact on the stakeholder. It is not set by how hard the fix looks to you.
 
 <boxEmbed
   style="info"

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -166,6 +166,19 @@ Never leave someone guessing when you will be back. A vague answer forces the st
 
 A second person is not a luxury during an incident. They halve the stress. They spot the thing you are staring straight past. Best of all, one of you can keep the stakeholder informed while the other investigates.
 
+That split protects the person doing the fixing. Troubleshooting needs concentration, and a constant stream of "any update?" calls and messages breaks it every few minutes. Losing your place in a set of debugging steps is frustrating, and it makes the fix take longer.
+
+A second person becomes a shield. They absorb the questions, keep everyone informed, and let you work uninterrupted. Just make sure the stakeholder knows who to contact so they aren't left guessing.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Rick is on the phone with me now and is taking over updates. He'll message you every 20 minutes so I can stay heads down on the fix. Call him if you need anything."
+  </>}
+  figurePrefix="good"
+  figure="Everyone knows who to talk to, so the person fixing it gets a clear run"
+/>
+
 Call someone from the team if you can. If nobody from the team is free, grab any co-worker who is.
 
 **🚨 Escalate early if progress has stalled**

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -77,7 +77,29 @@ Send one quick line so they know the message has landed, then call.
   figure="Takes 2 seconds, and it stops them chasing other people while your phone is ringing"
 />
 
-Pick up the phone even if you are nowhere near your computer. You can often still help verbally. If you truly can't help, say so straight away. That lets the other person escalate to someone else instead of waiting on you.
+Pick up the phone even if you are nowhere near your computer. You can often still help verbally.
+
+**🤝 If you can't help, still point the way**
+
+If you truly can't help, say so straight away so nobody is left waiting on you. Then keep going. "Sorry, I can't help" on its own leaves the person exactly where they started, and it reads as though you have handed the problem back.
+
+Even when you are the wrong person, you can still move things forward:
+
+* **Name someone who might know**, even if you are not certain. A maybe is far more useful than nothing.
+* **Split the chasing.** Offer to call one person while they try another. It halves the time and shows you are in this with them.
+* **Say what you can still do.** Perhaps you can't debug it, but you can check the monitoring on your phone or find a phone number for them.
+* **Come back either way.** Tell them you will report back once you have tried, even if the answer is that you got nowhere.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I can't get to a computer for the next 2 hours, so I can't look at the database myself. Rick knows this system best, so it's worth trying him. I'm not sure he's around, so I'll call Kiki at the same time and let you know either way."
+  </>}
+  figurePrefix="good"
+  figure="Wrong person, but still helpful. It gives a name to try, takes on part of the chasing, and promises to come back"
+/>
+
+This costs you very little, and it is the difference between the stakeholder feeling passed over and feeling helped.
 
 **🙏 Use the 3 A's**
 
@@ -115,7 +137,7 @@ Never leave someone guessing when you will be back. A vague answer forces the st
     "I won't be home for the next 2 hours. Are you able to get hold of Tom or Rick?"
   </>}
   figurePrefix="good"
-  figure="Best when you genuinely can't help. It hands over a path forward instead of a dead end"
+  figure="Pairs a clear timeframe with a name to try, so the gap in your availability doesn't stall the incident"
 />
 
 ### 2. Reinforce - don't go solo

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -16,7 +16,7 @@ categories:
   - category: categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
   - category: categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
 guid: 8d13b07c-04b9-4d85-b191-106ff1c86fd8
-seoDescription: The 4 R's of incident communication - Respond, Reinforce, Report, and Resolve. How to keep a panicking stakeholder calm and informed when something critical breaks.
+seoDescription: The 4 R's of incident communication - Respond, Reinforce, Report, and Resolve. How to keep stakeholders informed and confident when something critical breaks.
 created: 2026-07-28T00:00:00.000Z
 isArchived: false
 archivedreason: null
@@ -26,15 +26,17 @@ Sooner or later something will go badly wrong. A server dies, the product breaks
 
 The technical fix is only half the job. The other half is communication, and that is usually the half that damages the relationship.
 
-You know this rule applies when **a stakeholder is panicking**. It might be the CEO, a client, or a Product Owner. Someone important is anxious, something they rely on is broken, and they are looking to you.
+You know this rule applies when **someone reaches out about a critical issue**. It might be the CEO, a client, or a Product Owner. Something they rely on is broken, and they are looking to you.
 
-Most incidents go pear-shaped for one reason. It is rarely that the fix took too long. It is that the person who was panicking was left wondering whether anyone cared.
+They may sound stressed, frustrated, or upset. That is a fair reaction when something important is broken, so take it as a signal of how much this matters to them.
+
+Most incidents go pear-shaped for one reason. It is rarely that the fix took too long. It is that the person who raised it was left wondering whether anyone cared.
 
 <endIntro />
 
 ## 🔥 What counts as an incident?
 
-Anything critical that is broken **right now** and has someone important worried about it:
+Anything critical that is broken **right now** and that someone is relying on you to sort out:
 
 * A server or network is down
 * A web app or product is unavailable, or a core feature is broken in production

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -255,13 +255,3 @@ An incident over a weekend is not over when the service comes back up. On the ne
 1. Make it the team's **top priority**, above whatever was already planned
 2. Brief everyone who was not around during the incident, especially anyone who was off
 3. Start the investigation immediately. Don't let it drift into "we'll look next sprint"
-4. [Record the incident and perform a root cause analysis with clear actions](/record-incidents-and-perform-root-cause-analysis-with-clear-actions)
-
-<boxEmbed
-  style="info"
-  body={<>
-    **Tip:** The 4 R's run in order, but they are not one way. If you reach step 3 and the issue is still live, go back to step 2 and pull in more people.
-  </>}
-  figurePrefix="none"
-  figure=""
-/>

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -16,22 +16,39 @@ categories:
   - category: categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
   - category: categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
 guid: 8d13b07c-04b9-4d85-b191-106ff1c86fd8
-seoDescription: The 4 R's of incident communication - Respond, Reinforce, Report, and Resolve. How to keep stakeholders calm and informed when a server goes down.
+seoDescription: The 4 R's of incident communication - Respond, Reinforce, Report, and Resolve. How to keep a panicking stakeholder calm and informed when something critical breaks.
 created: 2026-07-28T00:00:00.000Z
 isArchived: false
 archivedreason: null
 ---
 
-When a production system goes down, the technical fix is only half the job. The other half is communication - and it is usually the half that damages the relationship.
+Sooner or later something will go badly wrong. A server dies, the product breaks in production, customer data goes missing, or a release takes the site down.
 
-Most incidents go pear-shaped not because the fix took too long, but because the stakeholder was left wondering whether anyone cared.
+The technical fix is only half the job. The other half is communication, and that is usually the half that damages the relationship.
+
+You know this rule applies when **a stakeholder is panicking**. It might be the CEO, a client, or a Product Owner. Someone important is anxious, something they rely on is broken, and they are looking to you.
+
+Most incidents go pear-shaped for one reason. It is rarely that the fix took too long. It is that the person who was panicking was left wondering whether anyone cared.
 
 <endIntro />
+
+## 🔥 What counts as an incident?
+
+Anything critical that is broken **right now** and has someone important worried about it:
+
+* A server or network is down
+* A web app or product is unavailable, or a core feature is broken in production
+* A release has broken something for real users
+* Customer data is missing, wrong, or exposed
+* A payment, integration, or scheduled job has quietly stopped working
+* A demo, launch, or deadline is about to be missed because of a technical failure
+
+The severity is set by the impact on the stakeholder. It is not set by how hard the fix looks to you.
 
 <boxEmbed
   style="info"
   body={<>
-    This rule covers the **human** side of an incident. For the technical process, see [Outage - Do you have an unplanned outage process?](/unplanned-outage-process)
+    This rule covers the **human** side of an incident: what you say and when. For the technical steps of an infrastructure outage, see [Outage - Do you have an unplanned outage process?](/unplanned-outage-process)
   </>}
   figurePrefix="none"
   figure=""
@@ -43,21 +60,21 @@ Most incidents go pear-shaped not because the fix took too long, but because the
 
 **📞 Call, don't chat**
 
-Chat is the wrong tool for an incident. It is asynchronous, easy to misread, and a slow back-and-forth reads as a lack of urgency.
+Chat is the wrong tool for an incident. It is slow, it is easy to misread, and a long back and forth reads as a lack of urgency.
 
-Pick up the phone - even if you are nowhere near your computer. You can still assist verbally, or at minimum tell the other person you can't help right now so they can escalate to someone else immediately instead of waiting on you.
+Pick up the phone, even if you are nowhere near your computer. You can often still help verbally. If you truly can't help, say so straight away. That lets the other person escalate to someone else instead of waiting on you.
 
 **🙏 Use the 3 A's**
 
 Follow [Communication - Do you know the 3 A's for receiving feedback/criticism?](/how-to-take-feedback-or-criticism):
 
-1. **Acknowledge** the issue - "Yes, the server is down, I can see it too"
-2. **Apologize** for the impact - "Sorry, I know this is affecting the demo tomorrow"
-3. **Act** by saying exactly what you are doing next - "I'm heading home now and will be online in 30 minutes"
+1. **Acknowledge** the issue. *"Yes, the site is down, I can see it too"*
+2. **Apologize** for the impact. *"Sorry, I know this is affecting the demo tomorrow"*
+3. **Act** by saying what you are doing next. *"I'm heading home now and will be online in 30 minutes"*
 
 **⏰ Be specific about your availability**
 
-Never leave someone guessing when you will be back. Vague answers force the stakeholder to either wait and hope, or chase you.
+Never leave someone guessing when you will be back. A vague answer forces the stakeholder to either wait and hope, or chase you.
 
 <boxEmbed
   style="greybox"
@@ -65,7 +82,7 @@ Never leave someone guessing when you will be back. Vague answers force the stak
     "I'll look when I'm home."
   </>}
   figurePrefix="bad"
-  figure="Vague - no timeframe, no fallback, so the stakeholder has no idea whether to wait or escalate"
+  figure="Vague. There is no timeframe and no fallback, so the stakeholder can't tell whether to wait or escalate"
 />
 
 <boxEmbed
@@ -74,7 +91,7 @@ Never leave someone guessing when you will be back. Vague answers force the stak
     "I'll be home in 30 minutes and will look into it."
   </>}
   figurePrefix="good"
-  figure="Specific - the stakeholder knows exactly when to expect the next update"
+  figure="Specific. The stakeholder knows exactly when to expect the next update"
 />
 
 <boxEmbed
@@ -83,41 +100,50 @@ Never leave someone guessing when you will be back. Vague answers force the stak
     "I won't be home for the next 2 hours. Are you able to get hold of Tom or Rick?"
   </>}
   figurePrefix="good"
-  figure="Even better when you genuinely can't help - it hands over a path forward instead of a dead end"
+  figure="Best when you genuinely can't help. It hands over a path forward instead of a dead end"
 />
 
 ### 2. Reinforce - don't go solo
 
 **👥 Bring in a second person early**
 
-A second person is not a luxury during an incident. They halve the stress, spot the thing you're staring straight past, and - most importantly - one person can keep the stakeholder informed while the other investigates.
+A second person is not a luxury during an incident. They halve the stress. They spot the thing you are staring straight past. Best of all, one of you can keep the stakeholder informed while the other investigates.
 
-Call someone from the team if you can. If nobody from the team is available, grab any co-worker who is.
+Call someone from the team if you can. If nobody from the team is free, grab any co-worker who is.
 
 **🚨 Escalate early if progress has stalled**
 
-It is always better to involve more people sooner than to sit blocked, quietly burning the stakeholder's confidence. Escalate as soon as you hit a dead end, and tell the stakeholder you are doing it.
+It is always better to involve people too early than to sit blocked. Every quiet minute burns the stakeholder's confidence. Escalate as soon as you hit a dead end, and tell the stakeholder you are doing it.
 
 <boxEmbed
   style="greybox"
   body={<>
-    "I've hit a wall - I need more OpenRouter credits but I don't have access to the account. I've called Chris and I'm trying Kiki now as a backup."
+    "I've hit a wall. I need more OpenRouter credits and I don't have access to the account. I've called Chris and I'm trying Kiki now as a backup."
   </>}
   figurePrefix="good"
-  figure="The blocker, the person who can unblock it, and the fallback - all in one message"
+  figure="The blocker, the person who can unblock it, and the fallback, all in one message"
 />
 
 ### 3. Report - while you work
 
 **🔄 Give regular status updates, even when there is no progress**
 
-Silence is the single biggest cause of "they don't care about this". Short updates every **15-30 minutes** during a major incident keep everyone calm.
+Silence is the single biggest cause of "they don't care about this". Short updates every **15-30 minutes** keep everyone calm during a major incident.
 
-If you need a longer uninterrupted block to investigate, say so upfront so nobody is left waiting: *"I need 30 minutes to get home, then about an hour to dig into the database logs. I'll update you at 8pm either way."*
+If you need a longer block of time to investigate, say so upfront so nobody is left waiting.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I need 30 minutes to get home, then about an hour to dig into the logs. I'll update you at 8pm either way."
+  </>}
+  figurePrefix="good"
+  figure="Sets expectations for a quiet period, so silence doesn't get read as neglect"
+/>
 
 **🔓 Surface blockers loudly**
 
-If you are waiting on another person, actively chase them - call, message, whatever it takes. If you still can't reach them, don't sit in silence. Tell everyone that you tried, what is blocking you, and what happens next.
+If you are waiting on another person, chase them actively. Call, message, use whatever works. If you still can't reach them, don't go quiet. Tell everyone that you tried, what is blocking you, and what happens next.
 
 <boxEmbed
   style="greybox"
@@ -130,7 +156,7 @@ If you are waiting on another person, actively chase them - call, message, whate
 
 **🔥 Never downplay the urgency**
 
-Statements that push the problem into the future tell the stakeholder you have mentally clocked off.
+A statement that pushes the problem into the future tells the stakeholder you have mentally clocked off.
 
 <boxEmbed
   style="greybox"
@@ -138,13 +164,13 @@ Statements that push the problem into the future tell the stakeholder you have m
     "They can look at it on Monday."
   </>}
   figurePrefix="bad"
-  figure="Signals the incident isn't urgent to you - even when it's critical to them"
+  figure="Signals the incident isn't urgent to you, even when it is critical to them"
 />
 
 <boxEmbed
   style="greybox"
   body={<>
-    "I'm restoring from last night's backup now. If that doesn't work, I'll call Rob to help me rebuild the VM tonight."
+    "I'm rolling back to the last good release now. If that doesn't fix it, I'll call Rob tonight to help me restore the database."
   </>}
   figurePrefix="good"
   figure="Explains what is happening right now and what the next option is"
@@ -156,15 +182,15 @@ Statements that push the problem into the future tell the stakeholder you have m
 
 An incident over a weekend is not over when the service comes back up. On the next business day:
 
-1. Make it the team's **top priority** - above whatever was already planned
+1. Make it the team's **top priority**, above whatever was already planned
 2. Brief everyone who was not around during the incident, especially anyone who was off
-3. Coordinate the investigation immediately - don't let it drift into "we'll look next sprint"
+3. Start the investigation immediately. Don't let it drift into "we'll look next sprint"
 4. [Record the incident and perform a root cause analysis with clear actions](/record-incidents-and-perform-root-cause-analysis-with-clear-actions)
 
 <boxEmbed
   style="info"
   body={<>
-    **Tip:** The 4 R's work in order, but they are not one-way. If you finish step 3 and the issue is still live, loop back to step 2 and pull in more people.
+    **Tip:** The 4 R's run in order, but they are not one way. If you reach step 3 and the issue is still live, go back to step 2 and pull in more people.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -256,4 +256,4 @@ An incident over a weekend is not over when the service comes back up. On the ne
 
 Nobody can see you working. From the outside, an hour of careful troubleshooting looks exactly the same as an hour of doing nothing.
 
-The fix earns you the outcome. The updates earn you the trust. You need both, and only one of them is free.
+The fix earns you the outcome. The updates earn you the trust.

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -105,9 +105,29 @@ This costs you very little, and it is the difference between the stakeholder fee
 
 Follow [Communication - Do you know the 3 A's for receiving feedback/criticism?](/how-to-take-feedback-or-criticism):
 
-1. **Acknowledge** the issue. *"Yes, the site is down, I can see it too"*
+1. **Acknowledge** the issue. *"Yes, the site is down, I can see it too. That's a problem."*
 2. **Apologize** for the impact. *"Sorry, I know this is affecting the demo tomorrow"*
 3. **Act** by saying what you are doing next. *"I'm heading home now and will be online in 30 minutes"*
+
+Acknowledging is not just confirming the facts. Agree that it is a problem and that it is bad. The person needs to hear that you are on the same side of it, not that you have simply logged what they said.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Yep, I can see the errors."
+  </>}
+  figurePrefix="bad"
+  figure="Confirms the facts but says nothing about whether it matters, so it reads as detached"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Yes, the site is down, I can see it too. That's a problem, we need to get this sorted tonight."
+  </>}
+  figurePrefix="good"
+  figure="Agrees it is bad, so the person knows you are taking it as seriously as they are"
+/>
 
 **⏰ Be specific about your availability**
 

--- a/public/uploads/rules/communicate-during-an-incident/rule.mdx
+++ b/public/uploads/rules/communicate-during-an-incident/rule.mdx
@@ -1,0 +1,171 @@
+---
+type: rule
+title: Incidents - Do you know the 4 R's of incident communication?
+uri: communicate-during-an-incident
+authors:
+  - title: Tom Iwainski
+    url: https://www.ssw.com.au/people/thomas-iwainski
+related:
+  - rule: public/uploads/rules/how-to-take-feedback-or-criticism/rule.mdx
+  - rule: public/uploads/rules/unplanned-outage-process/rule.mdx
+  - rule: public/uploads/rules/record-incidents-and-perform-root-cause-analysis-with-clear-actions/rule.mdx
+  - rule: public/uploads/rules/call-first-before-emailing/rule.mdx
+  - rule: public/uploads/rules/escalate-key-updates/rule.mdx
+categories:
+  - category: categories/communication/rules-to-better-communication.mdx
+  - category: categories/infrastructure-and-networking/rules-to-better-system-administrators.mdx
+  - category: categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
+guid: 8d13b07c-04b9-4d85-b191-106ff1c86fd8
+seoDescription: The 4 R's of incident communication - Respond, Reinforce, Report, and Resolve. How to keep stakeholders calm and informed when a server goes down.
+created: 2026-07-28T00:00:00.000Z
+isArchived: false
+archivedreason: null
+---
+
+When a production system goes down, the technical fix is only half the job. The other half is communication - and it is usually the half that damages the relationship.
+
+Most incidents go pear-shaped not because the fix took too long, but because the stakeholder was left wondering whether anyone cared.
+
+<endIntro />
+
+<boxEmbed
+  style="info"
+  body={<>
+    This rule covers the **human** side of an incident. For the technical process, see [Outage - Do you have an unplanned outage process?](/unplanned-outage-process)
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+## The 4 R's: Respond, Reinforce, Report, Resolve
+
+### 1. Respond - within 5 minutes
+
+**📞 Call, don't chat**
+
+Chat is the wrong tool for an incident. It is asynchronous, easy to misread, and a slow back-and-forth reads as a lack of urgency.
+
+Pick up the phone - even if you are nowhere near your computer. You can still assist verbally, or at minimum tell the other person you can't help right now so they can escalate to someone else immediately instead of waiting on you.
+
+**🙏 Use the 3 A's**
+
+Follow [Communication - Do you know the 3 A's for receiving feedback/criticism?](/how-to-take-feedback-or-criticism):
+
+1. **Acknowledge** the issue - "Yes, the server is down, I can see it too"
+2. **Apologize** for the impact - "Sorry, I know this is affecting the demo tomorrow"
+3. **Act** by saying exactly what you are doing next - "I'm heading home now and will be online in 30 minutes"
+
+**⏰ Be specific about your availability**
+
+Never leave someone guessing when you will be back. Vague answers force the stakeholder to either wait and hope, or chase you.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I'll look when I'm home."
+  </>}
+  figurePrefix="bad"
+  figure="Vague - no timeframe, no fallback, so the stakeholder has no idea whether to wait or escalate"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I'll be home in 30 minutes and will look into it."
+  </>}
+  figurePrefix="good"
+  figure="Specific - the stakeholder knows exactly when to expect the next update"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I won't be home for the next 2 hours. Are you able to get hold of Tom or Rick?"
+  </>}
+  figurePrefix="good"
+  figure="Even better when you genuinely can't help - it hands over a path forward instead of a dead end"
+/>
+
+### 2. Reinforce - don't go solo
+
+**👥 Bring in a second person early**
+
+A second person is not a luxury during an incident. They halve the stress, spot the thing you're staring straight past, and - most importantly - one person can keep the stakeholder informed while the other investigates.
+
+Call someone from the team if you can. If nobody from the team is available, grab any co-worker who is.
+
+**🚨 Escalate early if progress has stalled**
+
+It is always better to involve more people sooner than to sit blocked, quietly burning the stakeholder's confidence. Escalate as soon as you hit a dead end, and tell the stakeholder you are doing it.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I've hit a wall - I need more OpenRouter credits but I don't have access to the account. I've called Chris and I'm trying Kiki now as a backup."
+  </>}
+  figurePrefix="good"
+  figure="The blocker, the person who can unblock it, and the fallback - all in one message"
+/>
+
+### 3. Report - while you work
+
+**🔄 Give regular status updates, even when there is no progress**
+
+Silence is the single biggest cause of "they don't care about this". Short updates every **15-30 minutes** during a major incident keep everyone calm.
+
+If you need a longer uninterrupted block to investigate, say so upfront so nobody is left waiting: *"I need 30 minutes to get home, then about an hour to dig into the database logs. I'll update you at 8pm either way."*
+
+**🔓 Surface blockers loudly**
+
+If you are waiting on another person, actively chase them - call, message, whatever it takes. If you still can't reach them, don't sit in silence. Tell everyone that you tried, what is blocking you, and what happens next.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Sent a message to Kiki. If I don't hear back in 15 minutes I'll call him, then try Rob."
+  </>}
+  figurePrefix="good"
+  figure="Shows the chase is active and timeboxed, not a passive wait"
+/>
+
+**🔥 Never downplay the urgency**
+
+Statements that push the problem into the future tell the stakeholder you have mentally clocked off.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "They can look at it on Monday."
+  </>}
+  figurePrefix="bad"
+  figure="Signals the incident isn't urgent to you - even when it's critical to them"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I'm restoring from last night's backup now. If that doesn't work, I'll call Rob to help me rebuild the VM tonight."
+  </>}
+  figurePrefix="good"
+  figure="Explains what is happening right now and what the next option is"
+/>
+
+### 4. Resolve - and follow through
+
+**📌 Make the incident the highest priority on the next business day**
+
+An incident over a weekend is not over when the service comes back up. On the next business day:
+
+1. Make it the team's **top priority** - above whatever was already planned
+2. Brief everyone who was not around during the incident, especially anyone who was off
+3. Coordinate the investigation immediately - don't let it drift into "we'll look next sprint"
+4. [Record the incident and perform a root cause analysis with clear actions](/record-incidents-and-perform-root-cause-analysis-with-clear-actions)
+
+<boxEmbed
+  style="info"
+  body={<>
+    **Tip:** The 4 R's work in order, but they are not one-way. If you finish step 3 and the issue is still live, loop back to step 2 and pull in more people.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>

--- a/public/uploads/rules/how-to-take-feedback-or-criticism/rule.mdx
+++ b/public/uploads/rules/how-to-take-feedback-or-criticism/rule.mdx
@@ -20,6 +20,7 @@ redirects:
 - do-you-know-how-to-take-feedback-criticism-even-if-its-not-your-fault
 related:
 - rule: public/uploads/rules/feedback-avoid-chopping-down-every-example/rule.mdx
+- rule: public/uploads/rules/communicate-during-an-incident/rule.mdx
 - rule: public/uploads/rules/make-complaints-a-positive-experience/rule.mdx
 - rule: public/uploads/rules/being-a-good-consultant/rule.mdx
 seoDescription: How to take feedback or criticism effectively, even if it's not your

--- a/public/uploads/rules/unplanned-outage-process/rule.mdx
+++ b/public/uploads/rules/unplanned-outage-process/rule.mdx
@@ -13,6 +13,7 @@ authors:
     url: 'https://www.ssw.com.au/people/Rob-Thomlinson'
 related:
   - rule: public/uploads/rules/planned-outage-process/rule.mdx
+  - rule: public/uploads/rules/communicate-during-an-incident/rule.mdx
 redirects:
   - do-you-have-an-unplanned-outage-process
 guid: d96278bc-f927-4079-ba6c-c0b3c9a49b0d
@@ -35,6 +36,8 @@ During your course of being a SysAdmin, you will come across many unplanned outa
   style="info"
   body={<>
     For planned outages, see [Outage - Do you have a planned outage process?](/planned-outage-process)
+
+    For how to communicate with stakeholders while the outage is live, see [Incidents - Do you know the 4 R's of incident communication?](/communicate-during-an-incident)
   </>}
   figurePrefix="none"
   figure=""


### PR DESCRIPTION
## Purpose

Adds a new rule on the **human** side of a live incident, prompted by a weekend outage where the fix was fine but the communication went pear-shaped and the stakeholder felt there wasn't enough care about the issue.

The trigger for the rule is not "a server is down". It is **someone reaching out about a critical issue**. That could be a server, a web app, a broken release, missing customer data, or a payment integration that has quietly stopped working.

## The gap

We already have rules for the surrounding pieces, but nothing for how a person behaves *while* an incident is running:

| Existing rule | Covers | Gap |
|---|---|---|
| `unplanned-outage-process` | The SysAdmin technical process, monitoring, conference call, outage emails | Internal/SysAdmin-facing and email-driven. Assumes you're already at a keyboard, and only covers infrastructure |
| `how-to-take-feedback-or-criticism` | The 3 A's | Generic feedback, not a live incident |
| `record-incidents-and-perform-root-cause-analysis-with-clear-actions` | RCA | After the fact |
| `call-first-before-emailing` / `warn-then-call` | Channel choice generally | No urgency or update-cadence guidance |

## The rule - 4 R's

1. **Respond** (as soon as you see it) - reply "Seen it, calling you now", then call. Use the 3 A's and be specific about your availability
2. **Reinforce** - bring in a second person early, escalate early when stalled
3. **Report** - status updates every 15-30 min even with no progress, surface blockers loudly, never downplay urgency
4. **Resolve** - make it top priority next business day, brief anyone who was off, then RCA

There is also a "What counts as an incident?" section up front, which makes the point that severity is set by the impact on the stakeholder rather than by how hard the fix looks to you.

**Note on expectations:** the rule sets no response-time target of its own. It defers to whatever the reader's team already has (on-call roster, agreed response times), and otherwise starts the clock when you see the message. This keeps it applicable to teams with and without formal after-hours arrangements.

## Changes

- **New:** `public/uploads/rules/communicate-during-an-incident/rule.mdx`
- Added to 3 category indexes: Communication (primary), System Administrators, Software Consultants Working in a Team
- `unplanned-outage-process` - linked from the existing info box + `related`
- `how-to-take-feedback-or-criticism` - added to `related`

## Draft - open questions

- **No images or video yet.** A pair of redacted Teams screenshots (the vague back and forth vs. what good looks like) would land much harder than the current greybox quotes.
- **"Call, don't chat" overlaps slightly** with `call-first-before-emailing`. Kept because the incident framing differs (unavailability handoff, not just channel choice) and cross-linked. Happy to trim if that's the wrong call.
- Are 3 categories too many? Now that the rule is not infrastructure-specific, System Administrators is arguably the weakest of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Neq6zBKEwCyXY1HHacrPfd
