### PR TITLE
Add rule: GitHub Plans - Do you know which plan you need?

### DIFF
--- a/categories/project-delivery/rules-to-better-github.mdx
+++ b/categories/project-delivery/rules-to-better-github.mdx
@@ -60,6 +60,7 @@ index:
   - rule: public/uploads/rules/find-your-license/rule.mdx
   - rule: public/uploads/rules/pr-suggest-changes/rule.mdx
   - rule: public/uploads/rules/view-file-changes-in-github/rule.mdx
+  - rule: public/uploads/rules/which-github-plan/rule.mdx
 ---
 
 [GitHub](https://github.com) is a code hosting platform for version control and collaboration. It lets you and others work together on projects from anywhere.

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -44,6 +44,8 @@ Know which gate you will hit before you rely on a feature you do not have.
 
 Everything above is free on public repositories, whatever plan you are on.
 
+**More GitHub Actions capacity is a reason to go paid on its own.** Free includes 2,000 minutes a month, which real CI/CD burns through quickly. A paid plan raises the allowance and lets you buy more as you go — enough headroom for automation, testing, deployments and AI-driven workflows without constantly worrying about limits.
+
 ## Protections every repository should have
 
 Two features are worth choosing a plan around. Both are free on public repos — on private repos, each has a price.

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -87,5 +87,5 @@ Move to Enterprise Cloud when several of these apply. One feature on its own is 
     GitHub moves features between plans often. Check [GitHub's pricing page](https://github.com/pricing) before you upgrade.
   </>}
   figurePrefix="none"
-  figure="Tip - Check the current pricing before you upgrade"
+  figure=""
 />

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -17,11 +17,11 @@ created: 2026-07-28T00:00:00.000Z
 archivedreason: null
 ---
 
-GitHub is remarkably generous with **public** repositories. Branch protection, wikis, GitHub Pages and deployment approvals are all free on open source — you can run a serious project without paying a cent.
+GitHub is generous with **public** repositories. Branch protection, wikis, GitHub Pages and deployment approvals are all free on open source.
 
-Most commercial work cannot be public. The moment a repository is private, features start disappearing — and some of them appear to work while being silently ignored.
+Most work at a company cannot be public. When a repo is private, you lose some of these features. Worse, a few of them look like they work, but do nothing.
 
-Know which gate you will hit before you rely on a feature you do not have.
+Check what your plan includes before you rely on a feature.
 
 <endIntro />
 
@@ -42,45 +42,49 @@ Know which gate you will hit before you rely on a feature you do not have.
 | Audit log via API and streaming | ❌ | ❌ | ✅ |
 | IP allow list | ❌ | ❌ | ✅ |
 
-Everything above is free on public repositories, whatever plan you are on.
+All of these are free on public repositories, on any plan.
 
-**More GitHub Actions capacity is a reason to go paid on its own.** Free includes 2,000 minutes a month, which real CI/CD burns through quickly. A paid plan raises the allowance and lets you buy more as you go — enough headroom for automation, testing, deployments and AI-driven workflows without constantly worrying about limits.
+**More build minutes is a good reason to pay.** Free gives you 2,000 GitHub Actions minutes a month. Real projects use that up fast. A paid plan gives you more, and lets you buy extra when you need it. That leaves room for automation, testing, deployments and AI workflows.
 
 ## Protections every repository should have
 
-Two features are worth choosing a plan around. Both are free on public repos — on private repos, each has a price.
+Two things are worth picking a plan for. Both are free on public repos. On private repos, you have to pay.
 
-**1. Enforced branch protection** — required. Nobody should be able to push straight to `main` or force-push over it. Watch out on Free: GitHub lets you create the ruleset, it saves, and it appears in the list — it is simply never enforced, so the branch you believe is protected is not. Needs **Team**. See [Do you use branch protection?](/rules/do-you-use-branch-protection/)
+**1. Enforced branch protection.** You need this. Nobody should push straight to `main`.
 
-**2. A deployment approval gate** — highly recommended for enterprise applications. It adds another layer of protection before anything goes live: a named reviewer signs off on the release. On private repos this comes only with **Enterprise Cloud** — [required reviewers](https://docs.github.com/en/actions/reference/deployments-and-environments) work on public repos only for Free, Pro and Team. Without a gate, anyone with write access — or any AI agent running in your pipeline — can release straight to production. See [Do you use gated deployments?](/rules/use-gated-deployments/)
+Be careful on Free. You can create a ruleset, and it looks saved. But GitHub does not enforce it, so the branch is not protected. You need **Team** for this to work. See [Do you use branch protection?](/rules/do-you-use-branch-protection/)
+
+**2. A deployment approval gate.** Highly recommended for enterprise apps. Someone should approve a release before it goes live. It is one more layer of protection.
+
+On private repos you need **Enterprise Cloud**. On Free, Pro and Team, [required reviewers](https://docs.github.com/en/actions/reference/deployments-and-environments) only work on public repos. Without this gate, anyone with write access can deploy to production. So can an AI agent in your pipeline. See [Do you use gated deployments?](/rules/use-gated-deployments/)
 
 ## Team or Enterprise - which one?
 
 ### Team is enough for most teams
 
-1. You want branch protection actually enforced, plus wikis and Pages on private repos
-2. Your production deploys are approved outside GitHub, or you do not gate them yet
-3. You run a single organisation and manage access by hand
-4. The built-in repository roles — Read, Triage, Write, Maintain, Admin — fit how you work
-5. You are only short on build minutes. Buy the extra minutes instead of upgrading; capacity is far cheaper than the plan difference
+1. You want branch protection to actually work, plus wikis and Pages on private repos
+2. You approve production deploys outside GitHub, or you do not approve them yet
+3. You have one organisation, and you are happy to manage access by hand
+4. The built-in roles suit you: Read, Triage, Write, Maintain, Admin
+5. You only need more build minutes. Buy the minutes. That is much cheaper than upgrading
 
 ### Enterprise Cloud is for enterprise organisations
 
-Enterprise costs several times more per user than Team. It is built for large organisations with governance and compliance obligations — **not for small teams**. Consider it when:
+Enterprise costs several times more per user. It is built for large companies that need governance and compliance. It is not for small teams. Consider it when:
 
-1. **You need an approval gate before production.** This is the most common reason to upgrade, and the only one Team cannot work around
-2. **You have too many repos to configure one at a time.** Organisation-level rulesets apply one standard everywhere, instead of repeating it per repo
-3. **Joiners and leavers should come from your identity provider.** SAML SSO and SCIM remove the manual step where someone leaves and their access lingers
-4. **You need permissions between Write and Read.** Custom repository roles let you say "can review and merge, but cannot deploy or change settings" — without them, people who need a little access get full write
-5. **You want internal repos.** Code visible to everyone in the company without being public to the internet. Without them the alternative is to keep each repo private and add people or teams to it by hand — workable, but it becomes admin as the number of repos grows
-6. **You have compliance obligations.** Audit log API, IP allow list and a 99.9% uptime SLA are Enterprise only
+1. **You need approval before a production deploy.** This is the main reason to upgrade. It is also the only one you cannot work around on Team
+2. **You have too many repos to set up one by one.** Organisation-level rulesets apply one standard to every repo
+3. **You want joiners and leavers handled by your identity provider.** SAML SSO and SCIM remove the manual step. Today, when someone leaves, their access can stay behind
+4. **You need a role between Write and Read.** Custom roles let you say "can review and merge, but cannot deploy". Without them, anyone who needs a little access gets full write
+5. **You want internal repos.** Everyone in the company can read the code, but the public cannot. Without this, you add people to each private repo by hand. That works, but it is more admin as you add repos
+6. **You have compliance requirements.** Audit log API, IP allow list and a 99.9% uptime SLA are Enterprise only
 
-Only move to Enterprise Cloud when several of these apply at once. One feature on its own rarely justifies the jump in per-user cost.
+Move to Enterprise Cloud when several of these apply. One feature on its own is rarely worth the extra cost per user.
 
 <boxEmbed
   style="info"
   body={<>
-    GitHub moves features between tiers regularly. Check [GitHub's pricing page](https://github.com/pricing) before you commit to an upgrade.
+    GitHub moves features between plans often. Check [GitHub's pricing page](https://github.com/pricing) before you upgrade.
   </>}
   figurePrefix="none"
   figure="Tip - Check the current pricing before you upgrade"

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -1,0 +1,85 @@
+---
+type: rule
+title: GitHub Plans - Do you know which plan you need?
+uri: which-github-plan
+categories:
+  - category: categories/project-delivery/rules-to-better-github.mdx
+authors:
+  - title: Ben Neoh
+    url: 'https://www.ssw.com.au/people/ben-neoh'
+related:
+- rule: public/uploads/rules/use-gated-deployments/rule.mdx
+- rule: public/uploads/rules/do-you-use-branch-protection/rule.mdx
+redirects: null
+guid: 4af3e658-1c6d-47ee-a174-b55aa6c1e8e8
+seoDescription: 'GitHub is generous on public repos, but private repos lose features - branch protection is not enforced on Free and deployment approvals need Enterprise. Know which plan you need.'
+created: 2026-07-28T00:00:00.000Z
+archivedreason: null
+---
+
+GitHub is remarkably generous with **public** repositories. Branch protection, wikis, GitHub Pages and deployment approvals are all free on open source — you can run a serious project without paying a cent.
+
+Most commercial work cannot be public. The moment a repository is private, features start disappearing — and some of them appear to work while being silently ignored.
+
+Know which gate you will hit before you rely on a feature you do not have.
+
+<endIntro />
+
+## What each plan gives you on private repos
+
+| Feature (on private repos) | Free | Team | Enterprise |
+| --- | --- | --- | --- |
+| Branch protection / rulesets **enforced** | ❌ | ✅ | ✅ |
+| Wikis | ❌ | ✅ | ✅ |
+| GitHub Pages | ❌ | ✅ | ✅ |
+| GitHub Actions minutes per month | 2,000 | 3,000 | 50,000 |
+| **Required reviewers** (deployment approval) | ❌ | ❌ | ✅ |
+| Organisation-level rulesets | ❌ | ❌ | ✅ |
+| Custom repository roles | ❌ | ❌ | ✅ |
+| Internal repositories | ❌ | ❌ | ✅ |
+| SAML SSO and SCIM provisioning | ❌ | ❌ | ✅ |
+| Publish a GitHub Pages site privately | ❌ | ❌ | ✅ |
+| Audit log via API and streaming | ❌ | ❌ | ✅ |
+| IP allow list | ❌ | ❌ | ✅ |
+
+Everything above is free on public repositories, whatever plan you are on.
+
+## Protections every repository should have
+
+Two features are worth choosing a plan around. Both are free on public repos — on private repos, each has a price.
+
+**1. Enforced branch protection** — required. Nobody should be able to push straight to `main` or force-push over it. Watch out on Free: GitHub lets you create the ruleset, it saves, and it appears in the list — it is simply never enforced, so the branch you believe is protected is not. Needs **Team**. See [Do you use branch protection?](/rules/do-you-use-branch-protection/)
+
+**2. A deployment approval gate** — highly recommended for enterprise applications. It adds another layer of protection before anything goes live: a named reviewer signs off on the release. On private repos this comes only with **Enterprise Cloud** — [required reviewers](https://docs.github.com/en/actions/reference/deployments-and-environments) work on public repos only for Free, Pro and Team. Without a gate, anyone with write access — or any AI agent running in your pipeline — can release straight to production. See [Do you use gated deployments?](/rules/use-gated-deployments/)
+
+## Team or Enterprise - which one?
+
+### Team is enough for most teams
+
+1. You want branch protection actually enforced, plus wikis and Pages on private repos
+2. Your production deploys are approved outside GitHub, or you do not gate them yet
+3. You run a single organisation and manage access by hand
+4. The built-in repository roles — Read, Triage, Write, Maintain, Admin — fit how you work
+5. You are only short on build minutes. Buy the extra minutes instead of upgrading; capacity is far cheaper than the plan difference
+
+### Enterprise Cloud is for enterprise organisations
+
+Enterprise costs several times more per user than Team. It is built for large organisations with governance and compliance obligations — **not for small teams**. Consider it when:
+
+1. **You need an approval gate before production.** This is the most common reason to upgrade, and the only one Team cannot work around
+2. **You have too many repos to configure one at a time.** Organisation-level rulesets apply one standard everywhere, instead of repeating it per repo
+3. **Joiners and leavers should come from your identity provider.** SAML SSO and SCIM remove the manual step where someone leaves and their access lingers
+4. **You need permissions between Write and Read.** Custom repository roles let you say "can review and merge, but cannot deploy or change settings" — without them, people who need a little access get full write
+5. **You want internal repos.** Code visible to everyone in the company without being public to the internet. Without them the alternative is to keep each repo private and add people or teams to it by hand — workable, but it becomes admin as the number of repos grows
+6. **You have compliance obligations.** Audit log API, IP allow list and a 99.9% uptime SLA are Enterprise only
+
+Only move to Enterprise Cloud when several of these apply at once. One feature on its own rarely justifies the jump in per-user cost.
+
+<boxEmbed
+  style="info"
+  body={<>
+    GitHub moves features between tiers regularly. Check [GitHub's pricing page](https://github.com/pricing) before you commit to an upgrade.
+  </>}
+  figurePrefix="none"
+  figure="Tip - Check the current pricing before you upgrade"
+/>


### PR DESCRIPTION
New rule explaining which GitHub plan a team actually needs, and what each plan unlocks on **private** repositories.

## Why

The feature gates are easy to misread — most notably, **required reviewers on private repos need Enterprise Cloud, not Team**. This rule sets out the gates plainly so nobody upgrades to the wrong plan.

## What's in it

- A Free / Team / Enterprise table of what each plan gives you on private repos
- Two protections every repo should have (enforced branch protection, deployment approval gate)
- Guidance on when Team is enough vs when Enterprise Cloud is justified

## Verification

Every plan claim is taken from GitHub's own documentation, checked 28 Jul 2026:

- [Deployments and environments](https://docs.github.com/en/actions/reference/deployments-and-environments) — required reviewers gate
- [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) — repo vs org rulesets
- [Custom repository roles](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/about-custom-repository-roles)
- [Pages site visibility](https://docs.github.com/en/enterprise-cloud@latest/pages/getting-started-with-github-pages/changing-the-visibility-of-your-github-pages-site)
- [GitHub's plans](https://docs.github.com/en/get-started/learning-about-github/githubs-plans) — Actions minutes, SSO/SCIM, IP allow list, SLA

Figures that could not be sourced from GitHub docs were left out rather than guessed.

## Checks run

- `frontmatter-validator.js` — no errors
- `markdownlint` with repo config — clean

## Note for reviewers

[Do you use gated deployments?](https://www.ssw.com.au/rules/use-gated-deployments) currently states that required reviewers need "a paid plan (GitHub Team or Enterprise)". Per GitHub's docs that is not correct — Team does not include them on private repos. Worth a follow-up fix so the two rules agree.

Draft — not ready to merge until reviewed.