### PR TITLE
Link the GitHub Plans rule, and correct the required-reviewers plan claim

### DIFF
--- a/public/uploads/rules/use-branch-protection/rule.mdx
+++ b/public/uploads/rules/use-branch-protection/rule.mdx
@@ -30,7 +30,7 @@ Using force push is dangerous and should be used with extreme caution, as it wil
 
 <boxEmbed
   body={<>
-    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
+    Without GitHub Enterprise Cloud you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/use-branch-protection/rule.mdx
+++ b/public/uploads/rules/use-branch-protection/rule.mdx
@@ -30,7 +30,7 @@ Using force push is dangerous and should be used with extreme caution, as it wil
 
 <boxEmbed
   body={<>
-    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing.
+    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/use-gated-deployments/rule.mdx
+++ b/public/uploads/rules/use-gated-deployments/rule.mdx
@@ -32,13 +32,13 @@ GitHub enables us to add manual approval steps in our workflow via the [environm
 Environments also allow us to add per-environment secrets, timers, and protection rules. To use environments we have to consider if our repository is:
 
 * **Public** - awesome! all public repo's have the environments feature enabled
-* **Private** - environments are available, but protection rules (e.g. Required reviewers) require a paid plan
+* **Private** - environments are available. Environment secrets and deployment branch policies need a paid plan; **Required reviewers need GitHub Enterprise Cloud**
 
 Only repository administrators can configure environments reviewers, timers, and secrets.
 
 <boxEmbed
   body={<>
-    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
+    Without GitHub Enterprise Cloud you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/use-gated-deployments/rule.mdx
+++ b/public/uploads/rules/use-gated-deployments/rule.mdx
@@ -38,7 +38,7 @@ Only repository administrators can configure environments reviewers, timers, and
 
 <boxEmbed
   body={<>
-    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing.
+    Without a paid plan (GitHub Team or Enterprise) you can't configure Required reviewers on private repos — so anyone with write access can release straight to prod. This matters more in the age of AI, where a junior can ship to prod without proper testing. See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -9,7 +9,7 @@ authors:
     url: 'https://www.ssw.com.au/people/ben-neoh'
 related:
 - rule: public/uploads/rules/use-gated-deployments/rule.mdx
-- rule: public/uploads/rules/use-branch-protection/rule.mdx
+- rule: public/uploads/rules/do-you-use-branch-protection/rule.mdx
 redirects: null
 guid: 4af3e658-1c6d-47ee-a174-b55aa6c1e8e8
 seoDescription: 'GitHub is generous on public repos, but private repos lose features - branch protection is not enforced on Free and deployment approvals need Enterprise. Know which plan you need.'
@@ -52,7 +52,7 @@ Two things are worth picking a plan for. Both are free on public repos. On priva
 
 **1. Enforced branch protection.** You need this. Nobody should push straight to `main`.
 
-Be careful on Free. You can create a ruleset, and it looks saved. But GitHub does not enforce it, so the branch is not protected. You need **Team** for this to work. See [Do you use branch protection?](/rules/use-branch-protection/)
+Be careful on Free. You can create a ruleset, and it looks saved. But GitHub does not enforce it, so the branch is not protected. You need **Team** for this to work. See [Do you use branch protection?](/rules/do-you-use-branch-protection/)
 
 **2. A deployment approval gate.** Highly recommended for enterprise apps. Someone should approve a release before it goes live. It is one more layer of protection.
 

--- a/public/uploads/rules/which-github-plan/rule.mdx
+++ b/public/uploads/rules/which-github-plan/rule.mdx
@@ -9,7 +9,7 @@ authors:
     url: 'https://www.ssw.com.au/people/ben-neoh'
 related:
 - rule: public/uploads/rules/use-gated-deployments/rule.mdx
-- rule: public/uploads/rules/do-you-use-branch-protection/rule.mdx
+- rule: public/uploads/rules/use-branch-protection/rule.mdx
 redirects: null
 guid: 4af3e658-1c6d-47ee-a174-b55aa6c1e8e8
 seoDescription: 'GitHub is generous on public repos, but private repos lose features - branch protection is not enforced on Free and deployment approvals need Enterprise. Know which plan you need.'
@@ -52,7 +52,7 @@ Two things are worth picking a plan for. Both are free on public repos. On priva
 
 **1. Enforced branch protection.** You need this. Nobody should push straight to `main`.
 
-Be careful on Free. You can create a ruleset, and it looks saved. But GitHub does not enforce it, so the branch is not protected. You need **Team** for this to work. See [Do you use branch protection?](/rules/do-you-use-branch-protection/)
+Be careful on Free. You can create a ruleset, and it looks saved. But GitHub does not enforce it, so the branch is not protected. You need **Team** for this to work. See [Do you use branch protection?](/rules/use-branch-protection/)
 
 **2. A deployment approval gate.** Highly recommended for enterprise apps. Someone should approve a release before it goes live. It is one more layer of protection.
 


### PR DESCRIPTION
Follow-up to #13077.

## 1. Corrects a factual error in two rules

Both **Do you use branch protection?** and **Do you use gated deployments?** said:

> Without a paid plan (**GitHub Team or Enterprise**) you can't configure Required reviewers on private repos

That is wrong about Team. Per [GitHub's documentation](https://docs.github.com/en/actions/reference/deployments-and-environments):

> "If you are on a GitHub Free, GitHub Pro, **or GitHub Team** plan, required reviewers are only available for public repositories."

Required reviewers on private repos need **Enterprise Cloud**. A reader following the old wording could buy Team and still not get the feature.

Changed to: *"Without **GitHub Enterprise Cloud** you can't configure Required reviewers on private repos…"*

**Also fixed the Private bullet** in gated deployments, which had the same error but lumped all protection rules together:

- Before: *"environments are available, but protection rules (e.g. Required reviewers) require a paid plan"*
- After: *"environments are available. Environment secrets and deployment branch policies need a paid plan; **Required reviewers need GitHub Enterprise Cloud**"*

That split matters — environment secrets and deployment branch policies *do* work on Team; only required reviewers need Enterprise.

## 2. Links the new GitHub Plans rule

Adds to the warning box in both rules:

> See [GitHub Plans - Do you know which plan you need?](/rules/which-github-plan/) for what each plan includes.

The broken link inside `which-github-plan` is handled separately in #13080; this PR does not touch that file.