### PR TITLE
Add rule: Do you follow Microsoft Teams meeting etiquette?

### DIFF
--- a/categories/communication/rules-to-better-meetings.mdx
+++ b/categories/communication/rules-to-better-meetings.mdx
@@ -14,6 +14,7 @@ index:
   - rule: public/uploads/rules/teams-meetings-vs-group-chats/rule.mdx
   - rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
   - rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
+  - rule: public/uploads/rules/teams-meeting-etiquette/rule.mdx
   - rule: public/uploads/rules/meetings-in-english/rule.mdx
   - rule: public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
   - rule: public/uploads/rules/keep-track-of-a-parking-lot-for-topics/rule.mdx

--- a/categories/communication/rules-to-better-microsoft-teams.mdx
+++ b/categories/communication/rules-to-better-microsoft-teams.mdx
@@ -10,6 +10,7 @@ index:
   - rule: public/uploads/rules/use-emojis/rule.mdx
   - rule: public/uploads/rules/teams-group-chat/rule.mdx
   - rule: public/uploads/rules/warn-when-leaving-a-call/rule.mdx
+  - rule: public/uploads/rules/teams-meeting-etiquette/rule.mdx
   - rule: public/uploads/rules/when-to-use-meet-now/rule.mdx
   - rule: public/uploads/rules/send-appointment-or-teams-meeting/rule.mdx
   - rule: public/uploads/rules/do-you-make-your-team-meetings-easy-to-find/rule.mdx

--- a/public/uploads/rules/teams-meeting-etiquette/rule.mdx
+++ b/public/uploads/rules/teams-meeting-etiquette/rule.mdx
@@ -1,0 +1,100 @@
+---
+type: rule
+title: Do you follow Microsoft Teams meeting etiquette?
+seoDescription: Simple Microsoft Teams meeting habits - introduce people in the room, announce yourself when joining, share your screen considerately, and finish with a recorded summary.
+guid: 7f5b87a7-7559-42a7-9e67-609c32a30910
+uri: teams-meeting-etiquette
+created: 2026-07-31T00:00:00.000Z
+authors:
+  - title: Adam Cogan
+    url: https://www.ssw.com.au/people/adam-cogan
+related:
+  - rule: public/uploads/rules/warn-when-leaving-a-call/rule.mdx
+  - rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
+  - rule: public/uploads/rules/do-you-share-screens-when-working-remotely/rule.mdx
+  - rule: public/uploads/rules/use-ai-for-meeting-notes/rule.mdx
+  - rule: public/uploads/rules/consent-to-record/rule.mdx
+categories:
+  - category: categories/communication/rules-to-better-microsoft-teams.mdx
+  - category: categories/communication/rules-to-better-meetings.mdx
+archivedreason: null
+isArchived: false
+---
+
+Hybrid meetings quietly disadvantage the people who are not in the room. Someone walks in and the remote attendees never learn who it is, a person joins a call and says nothing for 10 minutes, a screen gets shared with 40 browser tabs and a 9pt font, and the meeting ends with no record of what was agreed.
+
+None of these are big failures on their own, but together they add up to confusion, repeated conversations, and decisions nobody can find later. A handful of small habits fixes all of them.
+
+<endIntro />
+
+<youtubeEmbed url="https://www.youtube.com/watch?v=aVwT934Xi-U" description={"Video: Microsoft Teams Etiquette - Simple Habits That Make Meetings Better | Adam Cogan | SSW Rules (3 mins)"} />
+
+## Introduce the people in the room
+
+When some attendees are physically together and others are remote, the remote people cannot see who is present. Anyone speaking is just a disembodied voice.
+
+Whenever someone joins the physical room, say who they are and why they are there. If a person walks in halfway through, pause and introduce them.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Letting an unnamed voice contribute for 20 minutes while remote attendees try to work out who is talking.
+  </>}
+  figurePrefix="bad"
+  figure="Remote attendees are excluded and are reluctant to disagree with someone they cannot identify"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    *"Just so everyone online knows, Bob has joined us in the room - he owns the payment gateway integration."*
+  </>}
+  figurePrefix="good"
+  figure="Everyone knows who is in the conversation and what they are responsible for"
+/>
+
+## Announce yourself when you join a call
+
+Joining silently is disruptive. People either keep talking to an audience they have misjudged, or the meeting stalls while everyone works out who just appeared.
+
+Say hello as soon as you join. If the discussion is mid-flow and interrupting would be rude, drop a quick message in the meeting chat instead so people know you are there.
+
+The same applies in reverse - let people know before you [leave a group call](/rules/warn-when-leaving-a-call).
+
+## Share your screen considerately
+
+The person sharing has full context. Everybody else is seeing the screen for the first time, often on a laptop or a phone.
+
+* Share a single window rather than your whole desktop - it avoids leaking notifications and private content
+* Increase the zoom level so text is readable on a small screen
+* Say what you are about to show before you show it
+* Close unrelated tabs and applications
+* Give people a few seconds to read before you scroll
+
+For more on this, see [Do you share screens when working remotely?](/rules/do-you-share-screens-when-working-remotely).
+
+## Finish with a recorded summary
+
+The most valuable 60 seconds of a meeting are the last 60. Before anyone drops off, record a short verbal summary of what was decided and who is doing what.
+
+Because the summary is spoken while the meeting is still recording, it becomes part of the transcript. AI meeting tools can then turn it into notes, and tools like [YakShaver](https://www.yakshaver.ai/) can turn it straight into a Product Backlog Item (PBI) - so the action item exists in the backlog before anyone has left the call.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Ending the meeting with *"great, thanks everyone"* and relying on people to remember their actions.
+  </>}
+  figurePrefix="bad"
+  figure="Actions are forgotten and the same discussion happens again next week"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    *"To summarize - we are going with Option B, Bob is raising the PBI for the API change, and Jane is confirming the budget with the client by Friday."*
+  </>}
+  figurePrefix="good"
+  figure="The decision and the owners are captured in the recording and can become PBIs automatically"
+/>
+
+See [Do you use AI for meeting notes?](/rules/use-ai-for-meeting-notes) and remember to [ask for consent to record](/rules/consent-to-record).


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

New SSW TV video published 29 Jul 2026 - [Microsoft Teams Etiquette: Simple Habits That Make Meetings Better | Adam Cogan](https://www.youtube.com/watch?v=aVwT934Xi-U) - was not embedded on any existing rule. Checked all 3,825 `rule.mdx` files; no match for the video ID.

The video covers four distinct habits, so it did not fit cleanly onto any one existing rule. This adds a dedicated rule as its home.

> 2. What was changed?

* Added new rule `public/uploads/rules/teams-meeting-etiquette/rule.mdx` - **Do you follow Microsoft Teams meeting etiquette?**
  * Embeds the video via `<youtubeEmbed>`
  * Sections follow the video's chapters: introduce people in the room, announce yourself when joining, screen sharing etiquette, finish with a recorded summary that can become a PBI
  * Cross-links to `warn-when-leaving-a-call`, `do-you-share-screens-when-working-remotely`, `use-ai-for-meeting-notes`, and `consent-to-record`
* Added reciprocal index entries to `categories/communication/rules-to-better-microsoft-teams.mdx` and `categories/communication/rules-to-better-meetings.mdx`

Validators run and passing: `frontmatter-validator`, `check-mdx`, `category-sync-validator`, `find-rules-missing-endintro`. (markdownlint reports the usual pre-existing `MD034` false positive on the `<youtubeEmbed>` URL, same as every other rule with a video.)

> 3. I paired or mob programmed with:

Written with Claude.