### PR TITLE
public/uploads/rules/make numbers more readable/rule improved title and category (PR from TinaCMS)

### DIFF
--- a/categories/design/rules-to-better-content-design.mdx
+++ b/categories/design/rules-to-better-content-design.mdx
@@ -31,6 +31,7 @@ index:
   - rule: public/uploads/rules/make-data-fields-obvious/rule.mdx
   - rule: public/uploads/rules/human-friendly-date-and-time/rule.mdx
   - rule: public/uploads/rules/address-formatting/rule.mdx
+  - rule: public/uploads/rules/make-numbers-more-readable/rule.mdx
 _template: category
 ---
 

--- a/categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+++ b/categories/design/rules-to-better-interfaces-general-usability-practices.mdx
@@ -18,7 +18,6 @@ index:
   - rule: public/uploads/rules/use-icons-to-reinforce-meaning/rule.mdx
   - rule: public/uploads/rules/add-a-spot-of-color-for-emphasis/rule.mdx
   - rule: public/uploads/rules/do-you-understand-the-importance-of-language-in-your-ui/rule.mdx
-  - rule: public/uploads/rules/make-numbers-more-readable/rule.mdx
   - rule: public/uploads/rules/do-you-know-how-to-use-storyboards/rule.mdx
   - rule: public/uploads/rules/do-you-consider-optical-alignment/rule.mdx
   - rule: public/uploads/rules/column-data-do-you-make-matrix-columns-as-simple-as-possible/rule.mdx

--- a/public/uploads/rules/make-numbers-more-readable/rule.mdx
+++ b/public/uploads/rules/make-numbers-more-readable/rule.mdx
@@ -1,70 +1,60 @@
 ---
-archivedreason: null
-authors:
-- title: Adam Cogan
-  url: https://www.ssw.com.au/people/adam-cogan
-created: 2016-03-22 05:56:01+00:00
-createdBy: Joanna Feely
-createdByEmail: JoannaFeely@ssw.com.au
-guid: 6e3f679d-832a-4b78-934d-8d459a42dc47
-isArchived: false
-lastUpdated: 2021-11-11 18:55:00.012000+00:00
-lastUpdatedBy: Tiago Araújo [SSW]
-lastUpdatedByEmail: tiagov8@gmail.com
-redirects:
-- do-you-make-numbers-more-readable
-related:
-- rule: public/uploads/rules/use-digits-instead-of-words/rule.mdx
-- rule: public/uploads/rules/right-format-to-show-phone-numbers/rule.mdx
-seoDescription: Use separators to improve numbers' readability and make large sums
-  or phone numbers easier to comprehend.
-title: Numbers - Do you use separators to improve numbers' readability?
+type: rule
+title: Do you use separators to make numbers more readable?
+uri: make-numbers-more-readable
 categories:
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
-type: rule
-uri: make-numbers-more-readable
+  - category: categories/design/rules-to-better-content-design.mdx
+authors:
+  - title: Adam Cogan
+    url: 'https://www.ssw.com.au/people/adam-cogan'
+related:
+  - rule: public/uploads/rules/use-digits-instead-of-words/rule.mdx
+  - rule: public/uploads/rules/right-format-to-show-phone-numbers/rule.mdx
+redirects:
+  - do-you-make-numbers-more-readable
+guid: 6e3f679d-832a-4b78-934d-8d459a42dc47
+seoDescription: Use separators to improve numbers' readability and make large sums or phone numbers easier to comprehend.
+created: 2016-03-22T05:56:01.000Z
+createdBy: Joanna Feely
+createdByEmail: JoannaFeely@ssw.com.au
+lastUpdated: 2026-08-04T20:13:01.607Z
+lastUpdatedBy: Tiago Araujo
+lastUpdatedByEmail: TiagoAraujo@ssw.com.au
+isArchived: false
+archivedreason: null
 ---
 
 Remember to use dividers when referring to large sums or phone numbers.
 
 <endIntro />
 
-
 <boxEmbed
   style="greybox"
   body={<>
-    
-* Total: $27216
-* Phone: 14XXXXXXXXX
-
+    * Total: $27216
+    * Phone: 14XXXXXXXXX
   </>}
   figurePrefix="bad"
   figure="These numbers are unwieldy and difficult to read"
 />
 
-
-
 <boxEmbed
   style="greybox"
   body={<>
-    
-* Total: $2,721.65
-* Phone: +1 XXX XXX XXXX
-
+    * Total: $2,721.65
+    * Phone: +1 XXX XXX XXXX
   </>}
   figurePrefix="good"
   figure="Symbols or some spaces make these large numbers easier to read"
 />
 
-
-
 <boxEmbed
   style="info"
   body={<>
     **Note:** For currency references, different countries use periods in place of commas and vice-versa.
-
-E.g. In the United States and Australia: **$2,367.48** / In France and Brazil: **$2.367,48**.
+    
+    E.g. In the United States and Australia: **$2,367.48** / In France and Brazil: **$2.367,48**.
   </>}
   figurePrefix="none"
   figure=""


### PR DESCRIPTION
Fixed title and category.

ChatGPT:

> Content Design is the better category.

> The rule is about formatting written information so numbers are easier to scan and understand. Its examples cover currency and phone numbers generally, without focusing on a specific interface component or interaction.

> I would classify it as:

> * Primary: Content Design
> * Optional secondary: Technical Documentation
> * Remove from: UI/UX