### PR TITLE
Add reciprocal related-rule link from use-emojis to prefixes

### DIFF
--- a/public/uploads/rules/use-emojis/rule.mdx
+++ b/public/uploads/rules/use-emojis/rule.mdx
@@ -20,6 +20,7 @@ related:
   - rule: public/uploads/rules/write-a-good-pull-request/rule.mdx
   - rule: public/uploads/rules/indicate-ai-helped/rule.mdx
   - rule: public/uploads/rules/have-good-and-bad-bullet-points/rule.mdx
+  - rule: public/uploads/rules/prefixes/rule.mdx
 redirects:
   - team-names-do-you-use-emojis-in-your-teams-channel-names
   - teams-emojis


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Noticed the related-rule link between [Do you use emojis to help give context?](https://www.ssw.com.au/rules/use-emojis) and [Prefixes - Do you know why they are awesome?](https://www.ssw.com.au/rules/prefixes) was one-sided — `prefixes` already listed `use-emojis` in its `related` array, but not the other way around. Both rules cover giving readers context up front, so the link makes sense in both directions.

> 2. What was changed?

* Added `public/uploads/rules/prefixes/rule.mdx` to the `related` array in `public/uploads/rules/use-emojis/rule.mdx`

No change was needed in `prefixes/rule.mdx` — it already had the link.

**Validation run:**

* ✅ Frontmatter validator — no errors
* ✅ `check-mdx` — OK
* ✅ `find-rules-missing-endintro` — passes
* ✅ `git diff --check` — clean
* ⚠️ markdownlint — 3 errors at lines 96, 106 and 119, all pre-existing in untouched content (spaces inside emphasis markers, trailing spaces). Left alone to keep this PR to a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
