### PR TITLE
Rename Navigation category to Rules to Better Navigation and Links

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -9,7 +9,7 @@ index:
 - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
 - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
 - category: categories/design/rules-to-better-interfaces-mobile.mdx
-- category: categories/design/rules-to-better-websites-navigation.mdx
+- category: categories/design/rules-to-better-navigation-and-links.mdx
 - category: categories/design/rules-to-better-user-authentication.mdx
 - category: categories/design/rules-to-better-accessibility.mdx
 - category: categories/design/rules-to-better-interfaces-forms.mdx

--- a/categories/design/rules-to-better-navigation-and-links.mdx
+++ b/categories/design/rules-to-better-navigation-and-links.mdx
@@ -1,9 +1,11 @@
 ---
 _template: category
 type: category
-title: Rules to Better Websites - Navigation
+title: Rules to Better Navigation and Links
 guid: e59c536d-ed09-46ab-8a7d-eeea93caa6c6
-uri: rules-to-better-websites-navigation
+uri: rules-to-better-navigation-and-links
+redirects:
+- rules-to-better-websites-navigation
 seoDescription: Best practices for website navigation design. Learn how to create clear menus, breadcrumbs, and information architecture for your site.
 index:
 - rule: public/uploads/rules/underlined-links/rule.mdx
@@ -38,7 +40,6 @@ index:
 - rule: public/uploads/rules/do-you-avoid-email-harvesting-or-spamming-by-using-images/rule.mdx
 - rule: public/uploads/rules/do-you-avoid-linking-users-to-the-sign-in-page-directly/rule.mdx
 - rule: public/uploads/rules/does-your-menu-use-an-icon-to-indicate-if-there-is-a-sub-menu/rule.mdx
-- rule: public/uploads/rules/login-security-do-you-know-the-correct-error-message-for-an-incorrect-user-name-or-password/rule.mdx
 - rule: public/uploads/rules/do-you-give-option-to-widen-a-search/rule.mdx
 - rule: public/uploads/rules/urls-must-not-have-unc-paths/rule.mdx
 - rule: public/uploads/rules/no-full-stop-or-slash-at-the-end-of-urls/rule.mdx

--- a/public/uploads/rules/active-menu-item/rule.mdx
+++ b/public/uploads/rules/active-menu-item/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Visually indicate the page you are at on the menu to make it eas
   for users to know where they are within a website.
 title: Do you have an active state for the current menu item?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: active-menu-item
 ---

--- a/public/uploads/rules/add-callable-link/rule.mdx
+++ b/public/uploads/rules/add-callable-link/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Learn how to enhance customer experience on your website by addi
 tips: ''
 title: Do you add 'call-able' links to your website?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: add-callable-link
 ---

--- a/public/uploads/rules/anchor-links/rule.mdx
+++ b/public/uploads/rules/anchor-links/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Learn how to use named anchor links to link to specific places w
   a page, providing "jump-to" functionality and customizable URLs
 title: Do you know how to use anchor links?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: anchor-links
 ---

--- a/public/uploads/rules/avoid-absolute-internal-links/rule.mdx
+++ b/public/uploads/rules/avoid-absolute-internal-links/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Avoid using absolute internal links to prevent issues during web
 type: rule
 title: Do you avoid absolute internal links?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 uri: avoid-absolute-internal-links
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/avoid-redundant-links/rule.mdx
+++ b/public/uploads/rules/avoid-redundant-links/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Avoid redundant linking (aka single link to a single location) b
   leading to the same place.
 title: Do you avoid redundant linking (aka have a single link to a single location)?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: avoid-redundant-links
 ---

--- a/public/uploads/rules/continually-improve-ui/rule.mdx
+++ b/public/uploads/rules/continually-improve-ui/rule.mdx
@@ -25,4 +25,4 @@ As the web development industry matures, best practices of website usability are
 
 <endIntro />
 
-For a more detailed analysis on Website UI, read [Rules to Better Websites - Navigation](/rules-to-better-websites-navigation), [Rules to Better Websites - Layout](/rules-to-better-websites-layout-and-formatting) and [Rules to Better Websites - Graphics](/rules-to-better-websites-graphics).
+For a more detailed analysis on Website UI, read [Rules to Better Navigation and Links](/rules-to-better-navigation-and-links), [Rules to Better Websites - Layout](/rules-to-better-websites-layout-and-formatting) and [Rules to Better Websites - Graphics](/rules-to-better-websites-graphics).

--- a/public/uploads/rules/descriptive-links/rule.mdx
+++ b/public/uploads/rules/descriptive-links/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: Descriptive links improve website SEO and provide a friendly exp
 title: Do you make your links descriptive?
 categories:
   - category: categories/communication/rules-to-better-technical-documentation.mdx
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 type: rule
 uri: descriptive-links

--- a/public/uploads/rules/display-information-consistently/rule.mdx
+++ b/public/uploads/rules/display-information-consistently/rule.mdx
@@ -22,7 +22,7 @@ seoDescription: When linking pages together, display consistent information to p
   a seamless user experience and enhance site navigation.
 title: Do you display information consistently between linked pages?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
   - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 type: rule
 uri: display-information-consistently

--- a/public/uploads/rules/do-you-add-breadcrumb-to-every-page/rule.mdx
+++ b/public/uploads/rules/do-you-add-breadcrumb-to-every-page/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Enhance user navigation and improve website usability with a cle
   and backtrack to previous pages.
 title: Do you add breadcrumb to every webpage?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-add-breadcrumb-to-every-page
 ---

--- a/public/uploads/rules/do-you-avoid-email-harvesting-or-spamming-by-using-images/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-email-harvesting-or-spamming-by-using-images/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Avoid email harvesting and spamming by using images or JavaScrip
   functions to conceal email addresses and prevent unwanted contacts.
 title: Do you avoid email harvesting or spamming by using images?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-avoid-email-harvesting-or-spamming-by-using-images
 ---

--- a/public/uploads/rules/do-you-avoid-linking-a-page-to-itself/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-linking-a-page-to-itself/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: A link on a page that takes you to the very same page is a weird
   Don't include a link to the page you are on
 title: Do you avoid linking a page to itself?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-avoid-linking-a-page-to-itself
 ---

--- a/public/uploads/rules/do-you-avoid-linking-users-to-the-sign-in-page-directly/rule.mdx
+++ b/public/uploads/rules/do-you-avoid-linking-users-to-the-sign-in-page-directly/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Prevent unnecessary login prompts by linking to default pages in
   logged in.
 title: Do you avoid linking users to the sign in page directly?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-avoid-linking-users-to-the-sign-in-page-directly
 ---

--- a/public/uploads/rules/do-you-distinguish-visited-links/rule.mdx
+++ b/public/uploads/rules/do-you-distinguish-visited-links/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Visiting links can be marked differently from unvisited ones wit
   a less saturated color to give that "used" look.
 title: Do you distinguish visited links?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-distinguish-visited-links
 ---

--- a/public/uploads/rules/do-you-give-option-to-widen-a-search/rule.mdx
+++ b/public/uploads/rules/do-you-give-option-to-widen-a-search/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: When combining search and filtering functionality, ensure users 
   widen their search to avoid unexpected results.
 title: Do you give an option to widen a search?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-give-option-to-widen-a-search
 ---

--- a/public/uploads/rules/do-you-have-a-related-links-section/rule.mdx
+++ b/public/uploads/rules/do-you-have-a-related-links-section/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Boost your website's navigation and user experience by incorpora
   a 'Related Links' section at the bottom of each page.
 title: Do you have a section for related links?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-have-a-related-links-section
 ---

--- a/public/uploads/rules/do-you-make-external-links-clear/rule.mdx
+++ b/public/uploads/rules/do-you-make-external-links-clear/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: Visually indicate when a link is external to avoid surprises and
   internal ones.
 title: Do you visually indicate when a link is external?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-make-external-links-clear
 ---

--- a/public/uploads/rules/do-you-make-sure-your-page-name-is-consistent-in-three-places/rule.mdx
+++ b/public/uploads/rules/do-you-make-sure-your-page-name-is-consistent-in-three-places/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Ensure consistent page names across URLs, page titles, and navig
   menus to optimize user experience and search engine rankings.
 title: Do you make sure page names are consistently reffered to?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-make-sure-your-page-name-is-consistent-in-three-places
 ---

--- a/public/uploads/rules/do-you-make-your-links-intuitive/rule.mdx
+++ b/public/uploads/rules/do-you-make-your-links-intuitive/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Make your links intuitive by providing clear navigation and expl
   the destination of each hyperlink.
 title: Do you make your links intuitive?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-make-your-links-intuitive
 ---

--- a/public/uploads/rules/do-you-make-your-pages-easy-to-access/rule.mdx
+++ b/public/uploads/rules/do-you-make-your-pages-easy-to-access/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Optimize your site's navigation by keeping pages 4 levels deep o
   less, using dropdown menus for faster access.
 title: Do you make your pages easy to access?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-make-your-pages-easy-to-access
 ---

--- a/public/uploads/rules/do-you-put-all-essential-links-in-your-website-on-your-navigation-bar/rule.mdx
+++ b/public/uploads/rules/do-you-put-all-essential-links-in-your-website-on-your-navigation-bar/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Find essential links easily accessible from every page on your w
   including home, contact us, news, and directions.
 title: Do you put all essential links in your website on your navigation bar?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-put-all-essential-links-in-your-website-on-your-navigation-bar
 ---

--- a/public/uploads/rules/do-you-save-clicking-through/rule.mdx
+++ b/public/uploads/rules/do-you-save-clicking-through/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Avoid forcing users to click through by providing information on
   or using inline editing instead.
 title: Do you save clicking through?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-save-clicking-through
 ---

--- a/public/uploads/rules/do-you-use-an-icon-so-a-password-prompt-should-never-be-a-surprise/rule.mdx
+++ b/public/uploads/rules/do-you-use-an-icon-so-a-password-prompt-should-never-be-a-surprise/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid password prompts by indicating a login requirement with a 
   icon, ensuring users are prepared for secure access.
 title: Do you use an icon so a password prompt should never be a surprise?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-use-an-icon-so-a-password-prompt-should-never-be-a-surprise
 ---

--- a/public/uploads/rules/do-you-use-mega-menu-navigation-to-improve-usability/rule.mdx
+++ b/public/uploads/rules/do-you-use-mega-menu-navigation-to-improve-usability/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Improve website usability with mega-menus that group links into 
   providing a clear site structure and meaningful choices.
 title: Do you use Mega-menu navigation to improve usability?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-use-mega-menu-navigation-to-improve-usability
 ---

--- a/public/uploads/rules/do-you-use-the-right-anchor-names/rule.mdx
+++ b/public/uploads/rules/do-you-use-the-right-anchor-names/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Mastering anchor names is crucial for effective web development.
   names to avoid common mistakes.
 title: Do you use the right anchor names?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: do-you-use-the-right-anchor-names
 ---

--- a/public/uploads/rules/does-your-menu-use-an-icon-to-indicate-if-there-is-a-sub-menu/rule.mdx
+++ b/public/uploads/rules/does-your-menu-use-an-icon-to-indicate-if-there-is-a-sub-menu/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Using an icon to indicate menu items with submenus helps users n
   efficiently and avoid unexpected surprises.
 title: Do you indicate menu items that have a sub menu?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: does-your-menu-use-an-icon-to-indicate-if-there-is-a-sub-menu
 ---

--- a/public/uploads/rules/effective-breadcrumbs/rule.mdx
+++ b/public/uploads/rules/effective-breadcrumbs/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you use breadcrumbs effectively?
 uri: effective-breadcrumbs
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 authors:
   - title: Micaela Blank
     url: 'https://www.ssw.com.au/people/micaela-blank'

--- a/public/uploads/rules/efficient-anchor-names/rule.mdx
+++ b/public/uploads/rules/efficient-anchor-names/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Choose effective anchor names by considering these key points - 
   with a
 title: Do you choose effective anchor names?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: efficient-anchor-names
 ---

--- a/public/uploads/rules/external-links-open-on-a-new-tab/rule.mdx
+++ b/public/uploads/rules/external-links-open-on-a-new-tab/rule.mdx
@@ -21,7 +21,7 @@ seoDescription: Open external links on a new tab to avoid "Back-Button Fatigue",
   user flow and track analytics effectively.
 title: Do you make external links open on a new tab?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: external-links-open-on-a-new-tab
 ---

--- a/public/uploads/rules/hamburger-menu/rule.mdx
+++ b/public/uploads/rules/hamburger-menu/rule.mdx
@@ -4,7 +4,7 @@ type: rule
 title: Do you use the hamburger menu icon wisely?
 categories:
   - category: categories/design/rules-to-better-interfaces-mobile.mdx
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 uri: hamburger-menu
 authors:
   - title: Micaela Blank

--- a/public/uploads/rules/heading-to-anchor-targets/rule.mdx
+++ b/public/uploads/rules/heading-to-anchor-targets/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Make your headings linkable so people can jump straight to the r
 tips: ''
 title: Do you turn your headings into anchor links?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: heading-to-anchor-targets

--- a/public/uploads/rules/hyperlink-phone-numbers/rule.mdx
+++ b/public/uploads/rules/hyperlink-phone-numbers/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Hyperlink phone numbers to enhance mobile user experience and in
 title: Do you add hyperlinks to phone numbers?
 categories:
   - category: categories/design/rules-to-better-interfaces-mobile.mdx
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: hyperlink-phone-numbers
 ---

--- a/public/uploads/rules/no-full-stop-or-slash-at-the-end-of-urls/rule.mdx
+++ b/public/uploads/rules/no-full-stop-or-slash-at-the-end-of-urls/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Avoid unnecessary characters at the end of URLs to ensure compat
 type: rule
 title: Do you avoid including full stop or slash at the end of URLs?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 uri: no-full-stop-or-slash-at-the-end-of-urls
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/simplify-breadcrumbs/rule.mdx
+++ b/public/uploads/rules/simplify-breadcrumbs/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Simplify breadcrumbs to improve website navigation and user expe
   by reducing information overload and emphasizing primary categories.
 title: Do you simplify breadcrumbs?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: simplify-breadcrumbs
 ---

--- a/public/uploads/rules/underlined-links/rule.mdx
+++ b/public/uploads/rules/underlined-links/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you underline links and have a rollover (aka hover effect)?
 uri: underlined-links
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/urls-must-not-have-unc-paths/rule.mdx
+++ b/public/uploads/rules/urls-must-not-have-unc-paths/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Avoid including UNC paths in URLs as they can lead to errors and
 type: rule
 title: Do you know to not include UNC paths in URLs?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 uri: urls-must-not-have-unc-paths
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/use-icons-to-not-surprise-users/rule.mdx
+++ b/public/uploads/rules/use-icons-to-not-surprise-users/rule.mdx
@@ -28,7 +28,7 @@ seoDescription: Improve user experience by using icons on file links to avoid su
   users with unexpected downloads or applications opening in the background.
 title: Do you use icons on files' links to not to surprise users?
 categories:
-  - category: categories/design/rules-to-better-websites-navigation.mdx
+  - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: use-icons-to-not-surprise-users
 ---


### PR DESCRIPTION
Related to https://github.com/SSWConsulting/SSW.Rules.Content/issues/8217#issuecomment-2019292426

## Rename category

`Rules to Better Websites - Navigation` → **`Rules to Better Navigation and Links`**

- `title`, `uri`, and filename renamed `rules-to-better-websites-navigation` → `rules-to-better-navigation-and-links`
- Added a redirect from the old `uri` so existing links keep working
- Updated the category path in **35 member rules**, `categories/design/index.mdx`, and a prose link in `continually-improve-ui`

## login-security cleanup

The login-security error-message rule had **already been moved** to *Rules to Better User Authentication* (its frontmatter and the Authentication index already reference it on `main`), but a **stale entry was left behind in the Navigation index**. This PR removes that stale entry. No change was made to the rule's frontmatter or the Authentication category — they were already correct.

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues (reciprocal category ↔ rule references agree)

No references to the old category URI/path remain except the intentional redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
