### PR TITLE
Rename Mobile category to Rules to Better Mobile UI/UX

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -8,7 +8,7 @@ index:
 - category: categories/design/rules-to-better-content-design.mdx
 - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
 - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
-- category: categories/design/rules-to-better-interfaces-mobile.mdx
+- category: categories/design/rules-to-better-mobile-ui-ux.mdx
 - category: categories/design/rules-to-better-navigation-and-links.mdx
 - category: categories/design/rules-to-better-user-authentication.mdx
 - category: categories/design/rules-to-better-accessibility.mdx

--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -1,7 +1,7 @@
 ---
 _template: top_category
 type: top-category
-title: Design
+title: Design and Usability
 uri: design
 index:
 - category: categories/design/rules-to-better-designers.mdx

--- a/categories/design/rules-to-better-mobile-ui-ux.mdx
+++ b/categories/design/rules-to-better-mobile-ui-ux.mdx
@@ -1,9 +1,11 @@
 ---
 _template: category
 type: category
-title: Rules to Better Interfaces (Mobile)
+title: Rules to Better Mobile UI/UX
 guid: 073cbcd8-c942-4a96-a54d-4682c4fc885e
-uri: rules-to-better-interfaces-mobile
+uri: rules-to-better-mobile-ui-ux
+redirects:
+- rules-to-better-interfaces-mobile
 seoDescription: Best practices for mobile UI design. Learn how to create touch-friendly, responsive interfaces that work great on any screen size.
 index:
 - rule: public/uploads/rules/do-you-design-for-touch-interfaces/rule.mdx

--- a/public/uploads/rules/do-you-design-for-touch-interfaces/rule.mdx
+++ b/public/uploads/rules/do-you-design-for-touch-interfaces/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Designing mobile interfaces that cater to touch screens and vary
   user experiences is crucial for a seamless user experience.
 title: Do you design for touch interfaces?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
 type: rule
 uri: do-you-design-for-touch-interfaces
 ---

--- a/public/uploads/rules/do-you-know-what-guidelines-to-follow-for-wp/rule.mdx
+++ b/public/uploads/rules/do-you-know-what-guidelines-to-follow-for-wp/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Learn Microsoft's extensive documentation on Windows Phone desig
   guidelines to create consistent and user-friendly experiences.
 title: Do you know what guidelines to follow for WP?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
 type: rule
 uri: do-you-know-what-guidelines-to-follow-for-wp
 ---

--- a/public/uploads/rules/do-you-know-when-to-build-a-wp-app-over-an-iphone-app/rule.mdx
+++ b/public/uploads/rules/do-you-know-when-to-build-a-wp-app-over-an-iphone-app/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Discover when building a Windows Phone app over an iPhone app sa
   code reuse.
 title: Do you know when to build a WP app over an iPhone app?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
 type: rule
 uri: do-you-know-when-to-build-a-wp-app-over-an-iphone-app
 ---

--- a/public/uploads/rules/do-you-use-chrome-devtools-device-mode-to-design-and-test-your-mobile-views/rule.mdx
+++ b/public/uploads/rules/do-you-use-chrome-devtools-device-mode-to-design-and-test-your-mobile-views/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Test a responsive website's layout and usability on various devi
   using Chrome DevTools' Device Mode and Mobile Emulation features.
 title: Do you use Chrome DevTools Device Mode to design and test your mobile views?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
 type: rule
 uri: do-you-use-chrome-devtools-device-mode-to-design-and-test-your-mobile-views
 ---

--- a/public/uploads/rules/hamburger-menu/rule.mdx
+++ b/public/uploads/rules/hamburger-menu/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Learn when and where to use the hamburger menu icon. Understand 
 type: rule
 title: Do you use the hamburger menu icon wisely?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
   - category: categories/design/rules-to-better-navigation-and-links.mdx
 uri: hamburger-menu
 authors:

--- a/public/uploads/rules/hyperlink-phone-numbers/rule.mdx
+++ b/public/uploads/rules/hyperlink-phone-numbers/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Hyperlink phone numbers to enhance mobile user experience and in
   conversion rates with a single click.
 title: Do you add hyperlinks to phone numbers?
 categories:
-  - category: categories/design/rules-to-better-interfaces-mobile.mdx
+  - category: categories/design/rules-to-better-mobile-ui-ux.mdx
   - category: categories/design/rules-to-better-navigation-and-links.mdx
 type: rule
 uri: hyperlink-phone-numbers


### PR DESCRIPTION
## Rename category

`Rules to Better Interfaces (Mobile)` → **`Rules to Better Mobile UI/UX`**

- `title`, `uri`, and filename renamed `rules-to-better-interfaces-mobile` → `rules-to-better-mobile-ui-ux`
- Added a redirect from the old `uri` so existing links keep working
- Updated the category path in **6 member rules** and `categories/design/index.mdx`

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues (reciprocal category ↔ rule references agree)

No references to the old category URI/path remain except the intentional redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rename Design top-level category (commit 2)

Changed the **Design** top-level category (shown on `/rules/categories`) to **Design and Usability**.

- `title: Design` → `title: Design and Usability` in `categories/design/index.mdx`
- **Kept `uri: design`** and the `categories/design/` folder unchanged, so the page URL and every sub-category / rule reference keep working with no redirect needed.

If you'd also like the slug changed to `design-and-usability` (new URL + redirect from the old one), that's a larger change touching the folder and all references — happy to do it in a separate PR.
