### PR TITLE
Move Windows Applications category to Software Engineering and rename

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -15,7 +15,6 @@ index:
 - category: categories/design/rules-to-better-interfaces-forms.mdx
 - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
 - category: categories/design/rules-to-better-data-visualization.mdx
-- category: categories/design/rules-to-better-interfaces-windows-applications.mdx
 - category: categories/design/rules-to-better-interfaces-wizards.mdx
 - category: categories/design/rules-to-better-figma.mdx
 - category: categories/design/rules-to-better-logos.mdx

--- a/categories/software-engineering/index.mdx
+++ b/categories/software-engineering/index.mdx
@@ -70,6 +70,7 @@ index:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
   - category: categories/software-engineering/rules-to-better-connection-strings.mdx
   - category: categories/software-engineering/rules-to-better-regular-expressions.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
   - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
   - category: categories/software-engineering/rules-to-better-windows-forms-controls.mdx
   - category: categories/software-engineering/rules-to-better-large-builds-in-visual-studionet.mdx

--- a/categories/software-engineering/rules-to-better-windows-applications.mdx
+++ b/categories/software-engineering/rules-to-better-windows-applications.mdx
@@ -1,9 +1,11 @@
 ---
 _template: category
 type: category
-title: Rules to Better Interfaces (Windows Applications)
+title: Rules to Better Windows Applications
 guid: dca8e9b8-6b39-4daa-ab46-3c6aaba92e2b
-uri: rules-to-better-interfaces-windows-applications
+uri: rules-to-better-windows-applications
+redirects:
+- rules-to-better-interfaces-windows-applications
 seoDescription: How to design great Windows application interfaces. SSW's rules for menus, toolbars, and consistent Windows UX patterns.
 index:
 - rule: public/uploads/rules/title-bar-do-you-put-the-current-document-project-name-as-the-first-word-of-your-title-bar/rule.mdx

--- a/categories/software-engineering/rules-to-better-windows-applications.mdx
+++ b/categories/software-engineering/rules-to-better-windows-applications.mdx
@@ -11,24 +11,24 @@ index:
 - rule: public/uploads/rules/title-bar-do-you-put-the-current-document-project-name-as-the-first-word-of-your-title-bar/rule.mdx
 - rule: public/uploads/rules/title-bar-do-you-put-your-company-url-in-the-title-bar/rule.mdx
 - rule: public/uploads/rules/menu-do-you-use-icons-in-menu/rule.mdx
+- rule: public/uploads/rules/menu-do-you-include-a-tools-validate-data/rule.mdx
+- rule: public/uploads/rules/menu-do-you-know-the-8-items-every-help-menu-needs/rule.mdx
+- rule: public/uploads/rules/menu-do-you-have-a-standard-help-about-form/rule.mdx
+- rule: public/uploads/rules/menu-do-you-have-your-help-user-guide-online/rule.mdx
+- rule: public/uploads/rules/menu-do-you-have-a-help-training-videos-item/rule.mdx
 - rule: public/uploads/rules/sound-do-you-realize-the-importance-of-sounds-to-user-interface/rule.mdx
 - rule: public/uploads/rules/sound-message-box/rule.mdx
 - rule: public/uploads/rules/long-process-do-you-know-how-to-make-long-running-processes-user-friendly/rule.mdx
-- rule: public/uploads/rules/long-process-do-you-show-the-status-of-progress-bar-on-winforms-title/rule.mdx
-- rule: public/uploads/rules/allow-skip-in-long-processes/rule.mdx
-- rule: public/uploads/rules/long-process-do-you-use-the-word-cancel-instead-of-stop-to-halt-processes/rule.mdx
 - rule: public/uploads/rules/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel/rule.mdx
+- rule: public/uploads/rules/long-process-do-you-show-the-status-of-progress-bar-on-winforms-title/rule.mdx
+- rule: public/uploads/rules/long-process-do-you-use-the-word-cancel-instead-of-stop-to-halt-processes/rule.mdx
+- rule: public/uploads/rules/allow-skip-in-long-processes/rule.mdx
 - rule: public/uploads/rules/very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup/rule.mdx
 - rule: public/uploads/rules/long-process-end-user-feedback/rule.mdx
+- rule: public/uploads/rules/do-you-provide-a-warning-before-the-program-exits/rule.mdx
 - rule: public/uploads/rules/sample-do-you-supply-a-sample-database/rule.mdx
 - rule: public/uploads/rules/sample-do-your-sample-databases-have-good-naming-conventions/rule.mdx
 - rule: public/uploads/rules/sample-do-you-avoid-dropping-a-users-database-when-you-attempt-to-create-a-database/rule.mdx
-- rule: public/uploads/rules/do-you-provide-a-warning-before-the-program-exits/rule.mdx
-- rule: public/uploads/rules/menu-do-you-have-a-help-training-videos-item/rule.mdx
-- rule: public/uploads/rules/menu-do-you-have-a-standard-help-about-form/rule.mdx
-- rule: public/uploads/rules/menu-do-you-have-your-help-user-guide-online/rule.mdx
-- rule: public/uploads/rules/menu-do-you-include-a-tools-validate-data/rule.mdx
-- rule: public/uploads/rules/menu-do-you-know-the-8-items-every-help-menu-needs/rule.mdx
 
 ---
 Since 1990, SSW has supported the developer community by publishing all our best practices and rules for everyone to see.

--- a/public/uploads/rules/allow-skip-in-long-processes/rule.mdx
+++ b/public/uploads/rules/allow-skip-in-long-processes/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Allow users to skip lengthy processes and view previous results 
 title: Long Process - Do you know that long-running processes should allow to 'Skip'
   the processing (when appropriate)?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: allow-skip-in-long-processes
 ---

--- a/public/uploads/rules/do-you-know-windows-forms-should-have-a-minimum-size-to-avoid-unexpected-ui-behavior/rule.mdx
+++ b/public/uploads/rules/do-you-know-windows-forms-should-have-a-minimum-size-to-avoid-unexpected-ui-behavior/rule.mdx
@@ -15,7 +15,7 @@ redirects: []
 seoDescription: Windows Forms require a minimum size to prevent unpredictable UI behavior
   and ensure user-friendly experiences.
 title: Do you know Windows Forms should have a minimum size to avoid unexpected UI
-  behavior
+  behavior?
 categories:
   - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 type: rule

--- a/public/uploads/rules/do-you-provide-a-warning-before-the-program-exits/rule.mdx
+++ b/public/uploads/rules/do-you-provide-a-warning-before-the-program-exits/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Programs should provide a warning before exiting to prevent unex
   closures.
 title: Do you provide a warning before the program exits?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: do-you-provide-a-warning-before-the-program-exits
 ---

--- a/public/uploads/rules/long-process-do-you-know-how-to-make-long-running-processes-user-friendly/rule.mdx
+++ b/public/uploads/rules/long-process-do-you-know-how-to-make-long-running-processes-user-friendly/rule.mdx
@@ -1,11 +1,11 @@
 ---
-archivedreason: null
+archivedreason: Replaced by [Long Process - Do you know that you should show a progress bar and allow users to cancel?](/rules/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel)
 authors: []
 created: 2012-11-27 02:59:38+00:00
 createdBy: Rebecca Liu
 createdByEmail: RebeccaLiu@ssw.com.au
 guid: 21933de8-4361-42f6-927e-ad1fc816cc3a
-isArchived: false
+isArchived: true
 lastUpdated: 2012-11-27 02:59:38+00:00
 lastUpdatedBy: Rebecca Liu
 lastUpdatedByEmail: RebeccaLiu@ssw.com.au

--- a/public/uploads/rules/long-process-do-you-know-how-to-make-long-running-processes-user-friendly/rule.mdx
+++ b/public/uploads/rules/long-process-do-you-know-how-to-make-long-running-processes-user-friendly/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Long-running processes can be made user-friendly by providing in
   feedback and options to manage their execution.
 title: Long Process - Do you know how to make long-running processes user-friendly?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: long-process-do-you-know-how-to-make-long-running-processes-user-friendly
 ---

--- a/public/uploads/rules/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel/rule.mdx
+++ b/public/uploads/rules/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Long-running processes should be accompanied by a progress bar a
 title: Long Process - Do you know that you should show a progress bar and allow users
   to cancel?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel
 ---

--- a/public/uploads/rules/long-process-do-you-show-the-status-of-progress-bar-on-winforms-title/rule.mdx
+++ b/public/uploads/rules/long-process-do-you-show-the-status-of-progress-bar-on-winforms-title/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Long processes displayed on Windows Forms titles enhance user ex
   by providing clear progress updates and taskbar visibility even when minimized.
 title: Long Process - Do you show the status of progress bar on winform's title?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: long-process-do-you-show-the-status-of-progress-bar-on-winforms-title
 ---

--- a/public/uploads/rules/long-process-do-you-use-the-word-cancel-instead-of-stop-to-halt-processes/rule.mdx
+++ b/public/uploads/rules/long-process-do-you-use-the-word-cancel-instead-of-stop-to-halt-processes/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: When stopping processes, use "Cancel" instead of "Stop" to clari
   intentions and avoid miscommunication.
 title: Long Process - Do you use the word 'Cancel' (instead of 'Stop') to halt processes?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: long-process-do-you-use-the-word-cancel-instead-of-stop-to-halt-processes
 ---

--- a/public/uploads/rules/long-process-end-user-feedback/rule.mdx
+++ b/public/uploads/rules/long-process-end-user-feedback/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Long-running processes should be user-friendly by playing a soun
   the end.
 title: Long Processes – Do you provide clear completion feedback?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: long-process-end-user-feedback
 ---

--- a/public/uploads/rules/long-process-end-user-feedback/rule.mdx
+++ b/public/uploads/rules/long-process-end-user-feedback/rule.mdx
@@ -31,7 +31,7 @@ Your application should remind the user to go back and check on it by:
 - Hiding the progress bar
 - Showing a message box at the end of the long process
 
-See rule on [Do you know how to make long-running processes user-friendly?](/long-process-do-you-know-how-to-make-long-running-processes-user-friendly)
+See rule on [Do you know that you should show a progress bar and allow users to cancel?](/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel)
 
 When using Message Box to indicate user a process is done, always includes detailed summary of the process. Don't just say "Process completed."
 

--- a/public/uploads/rules/long-process-end-user-feedback/rule.mdx
+++ b/public/uploads/rules/long-process-end-user-feedback/rule.mdx
@@ -14,7 +14,7 @@ redirects:
 seoDescription: Long-running processes should be user-friendly by playing a sound,
   hiding the progress bar, and displaying a message box with a detailed summary at
   the end.
-title: Long Processes – Do you provide clear completion feedback?
+title: Long Process - Do you provide clear completion feedback?
 categories:
   - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule

--- a/public/uploads/rules/menu-do-you-have-a-help-training-videos-item/rule.mdx
+++ b/public/uploads/rules/menu-do-you-have-a-help-training-videos-item/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Discover training videos that help you master your product and g
   a deeper understanding with ease.
 title: Menu - Do you have a "Help | Training Videos" item?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-have-a-help-training-videos-item
 ---

--- a/public/uploads/rules/menu-do-you-have-a-standard-help-about-form/rule.mdx
+++ b/public/uploads/rules/menu-do-you-have-a-standard-help-about-form/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: As a standard "Help | About" form, every application you build s
   description, contact details, and branding (logo).
 title: Menu - Do you have a standard "Help | About" form?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-have-a-standard-help-about-form
 ---

--- a/public/uploads/rules/menu-do-you-have-your-help-user-guide-online/rule.mdx
+++ b/public/uploads/rules/menu-do-you-have-your-help-user-guide-online/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Easy access to online user guides simplifies application usage a
   enhances user experience through up-to-date documentation and community engagement.
 title: Menu - Do you have your "Help | User Guide" online?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-have-your-help-user-guide-online
 ---

--- a/public/uploads/rules/menu-do-you-include-a-tools-validate-data/rule.mdx
+++ b/public/uploads/rules/menu-do-you-include-a-tools-validate-data/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Ensure data integrity by including a "Tools | Validate Data" fea
   in your application to prevent invalid data from entering the system.
 title: Menu - Do you include a "Tools | Validate Data"?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-include-a-tools-validate-data
 ---

--- a/public/uploads/rules/menu-do-you-know-the-8-items-every-help-menu-needs/rule.mdx
+++ b/public/uploads/rules/menu-do-you-know-the-8-items-every-help-menu-needs/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: A comprehensive help menu should include training videos, online
   guides, knowledge bases, suggestion tools, bug reporting features, and more.
 title: Menu - Do you know the 8 items every "Help" menu needs?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-know-the-8-items-every-help-menu-needs
 ---

--- a/public/uploads/rules/menu-do-you-use-icons-in-menu/rule.mdx
+++ b/public/uploads/rules/menu-do-you-use-icons-in-menu/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Menu items with icons enhance user experience and visual appeal,
   applications more expressive and engaging.
 title: Menu - Do you use icons in menu?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: menu-do-you-use-icons-in-menu
 ---

--- a/public/uploads/rules/sample-do-you-avoid-dropping-a-users-database-when-you-attempt-to-create-a-database/rule.mdx
+++ b/public/uploads/rules/sample-do-you-avoid-dropping-a-users-database-when-you-attempt-to-create-a-database/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Avoid dropping user databases during installation to prevent dat
 title: Sample - Do you avoid dropping a user's database when you attempt to create
   a database?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: sample-do-you-avoid-dropping-a-users-database-when-you-attempt-to-create-a-database
 ---

--- a/public/uploads/rules/sample-do-you-supply-a-sample-database/rule.mdx
+++ b/public/uploads/rules/sample-do-you-supply-a-sample-database/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Supplying sample database data helps showcase product functional
   and enhances user experience, especially with trial licenses.
 title: Sample - Do you supply a sample database?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: sample-do-you-supply-a-sample-database
 ---

--- a/public/uploads/rules/sample-do-your-sample-databases-have-good-naming-conventions/rule.mdx
+++ b/public/uploads/rules/sample-do-your-sample-databases-have-good-naming-conventions/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Sample databases from [Company] and products, such as Northwind,
   have good naming conventions to help users easily identify their purpose.
 title: Sample - Do your sample databases have good Naming Conventions?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: sample-do-your-sample-databases-have-good-naming-conventions
 ---

--- a/public/uploads/rules/sound-do-you-realize-the-importance-of-sounds-to-user-interface/rule.mdx
+++ b/public/uploads/rules/sound-do-you-realize-the-importance-of-sounds-to-user-interface/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Sounds play a crucial role in user interfaces, providing auditor
   feedback and enhancing the overall experience.
 title: Sound - Do you realize the importance of sounds to User Interface?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: sound-do-you-realize-the-importance-of-sounds-to-user-interface
 ---

--- a/public/uploads/rules/sound-message-box/rule.mdx
+++ b/public/uploads/rules/sound-message-box/rule.mdx
@@ -10,7 +10,7 @@ redirects:
 seoDescription: Did you know that a message box automatically plays a beep?
 title: Sound - Did you know that a message box automatically plays a beep?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: sound-message-box
 ---

--- a/public/uploads/rules/title-bar-do-you-put-the-current-document-project-name-as-the-first-word-of-your-title-bar/rule.mdx
+++ b/public/uploads/rules/title-bar-do-you-put-the-current-document-project-name-as-the-first-word-of-your-title-bar/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Title Bar should reflect the current document or project name, j
 title: Title Bar - Do you put the current document/project name as the first word
   of your title bar?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: title-bar-do-you-put-the-current-document-project-name-as-the-first-word-of-your-title-bar
 ---

--- a/public/uploads/rules/title-bar-do-you-put-your-company-url-in-the-title-bar/rule.mdx
+++ b/public/uploads/rules/title-bar-do-you-put-your-company-url-in-the-title-bar/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Display company URL in title bar to showcase your brand and driv
   free publicity through screenshots.
 title: Title Bar - Do you put your company URL in the title bar?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: title-bar-do-you-put-your-company-url-in-the-title-bar
 ---

--- a/public/uploads/rules/very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup/rule.mdx
+++ b/public/uploads/rules/very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Long-running processes should indicate a coffee cup to prepare u
 title: Very Long Process - Do you know that long-running processes should show a coffee
   cup?
 categories:
-  - category: categories/design/rules-to-better-interfaces-windows-applications.mdx
+  - category: categories/software-engineering/rules-to-better-windows-applications.mdx
 type: rule
 uri: very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup
 ---

--- a/public/uploads/rules/very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup/rule.mdx
+++ b/public/uploads/rules/very-long-process-do-you-know-that-long-running-processes-should-show-a-coffee-cup/rule.mdx
@@ -12,7 +12,7 @@ lastUpdatedByEmail: RebeccaLiu@ssw.com.au
 redirects: []
 seoDescription: Long-running processes should indicate a coffee cup to prepare users
   for extended wait times.
-title: Very Long Process - Do you know that long-running processes should show a coffee
+title: Long Process - Do you know that long-running processes should show a coffee
   cup?
 categories:
   - category: categories/software-engineering/rules-to-better-windows-applications.mdx


### PR DESCRIPTION
## Rename + move category

`Rules to Better Interfaces (Windows Applications)` → **`Rules to Better Windows Applications`**, moved from **Design** to **Software Engineering**.

- `title`, `uri`, and filename renamed `rules-to-better-interfaces-windows-applications` → `rules-to-better-windows-applications`
- Added a redirect from the old `uri` so existing links keep working
- Moved the file `categories/design/` → `categories/software-engineering/`
- **Top-category indexes:** removed from `categories/design/index.mdx`, added to `categories/software-engineering/index.mdx` **directly above _Rules to Better Windows Forms Applications_**
- Updated the category path in **21 member rules**

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues (reciprocal category ↔ rule references agree)

No references to the old category URI/path remain except the intentional redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Reorder + title standardization (commit 2)

Reordered the category index so related rules are grouped and the sequence is consistent: **Title Bar → Menu → Sound → Long Process → warning-before-exit → Sample**. Pure reorder — no rules added or removed (verified identical set).

Standardized the long-process title prefixes to **`Long Process -`**:

| Rule | Before | After |
|---|---|---|
| coffee-cup | `Very Long Process -` … | `Long Process -` … |
| completion-feedback | `Long Processes –` … | `Long Process -` … |

URIs, links, and rule body content are unchanged — only order and the two title prefixes.

---

## Question mark + archive (commit 3)

- **Added a trailing `?`** to the title of *Do you know Windows Forms should have a minimum size to avoid unexpected UI behavior?*
- **Archived** *Long Process - Do you know how to make long-running processes user-friendly?* — `isArchived: true` with `archivedreason: Replaced by [Long Process - Do you know that you should show a progress bar and allow users to cancel?](/rules/long-process-do-you-know-that-you-should-show-a-progress-bar-and-allow-users-to-cancel)`
- **Repointed** the cross-reference in `long-process-end-user-feedback` from the archived rule to its replacement (per the "remove links to archived rules" convention).

The archived rule is kept in the category index (matching the repo's existing precedent for archived rules); say the word if you'd prefer it removed from the index too.
