### PR TITLE
Rename ASP.NET category and move it to Software Engineering

### DIFF
--- a/categories/software-engineering/index.mdx
+++ b/categories/software-engineering/index.mdx
@@ -9,6 +9,7 @@ index:
   - category: categories/software-engineering/rules-to-better-architecture-and-code-review.mdx
   - category: categories/software-engineering/rules-to-better-blazor.mdx
   - category: categories/software-engineering/rules-to-better-mvc.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/software-engineering/rules-to-better-bots.mdx
   - category: categories/software-engineering/rules-to-better-clean-architecture.mdx
   - category: categories/software-engineering/rules-to-better-vertical-slice-architecture.mdx

--- a/categories/software-engineering/rules-to-better-asp-net.mdx
+++ b/categories/software-engineering/rules-to-better-asp-net.mdx
@@ -1,9 +1,11 @@
 ---
 _template: category
 type: category
-title: Rules to Better Website Development - ASP.NET
+title: Rules to Better ASP.NET
 guid: e3e75b67-96d8-43fe-859d-ce05f447f9ae
-uri: rules-to-better-website-development-asp-net
+uri: rules-to-better-asp-net
+redirects:
+- rules-to-better-website-development-asp-net
 seoDescription: Best practices for ASP.NET web development. Learn how to build, structure, and deploy professional web applications with ASP.NET.
 index:
   - rule: public/uploads/rules/do-you-know-how-to-create-nice-urls-using-asp-net-4/rule.mdx

--- a/categories/websites-and-cms/index.mdx
+++ b/categories/websites-and-cms/index.mdx
@@ -5,7 +5,6 @@ title: Websites and CMS
 uri: websites-and-cms
 index:
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-tuning-and-maintenance.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-deployment.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-graphics.mdx

--- a/public/uploads/rules/404-useful-error-page/rule.mdx
+++ b/public/uploads/rules/404-useful-error-page/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: Enhance your ASP.NET site's user experience with a custom 404 er
   page that redirects visitors effectively.
 title: Do you have a useful 404 error page?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: 404-useful-error-page

--- a/public/uploads/rules/always-put-javascript-in-a-separate-file/rule.mdx
+++ b/public/uploads/rules/always-put-javascript-in-a-separate-file/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Always put JavaScript in a separate file to maintain consistent 
   numbers during debugging and improve performance through browser caching
 title: Do you always put JavaScript in a separate file?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: always-put-javascript-in-a-separate-file

--- a/public/uploads/rules/avoid-deploying-source-code-on-the-production-server/rule.mdx
+++ b/public/uploads/rules/avoid-deploying-source-code-on-the-production-server/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Avoid deploying source code on production servers by using tools
   and identifying potential errors.
 title: Do you avoid deploying source code on the production server?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: avoid-deploying-source-code-on-the-production-server

--- a/public/uploads/rules/avoid-using-asp-asp-net-tags-in-plain-html/rule.mdx
+++ b/public/uploads/rules/avoid-using-asp-asp-net-tags-in-plain-html/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using ASP/ASP.NET tags in plain HTML pages to prevent unne
   file size increase and browser confusion.
 title: Do you avoid using ASP/ASP.NET tags in plain HTML?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: avoid-using-asp-asp-net-tags-in-plain-html
 ---

--- a/public/uploads/rules/avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element/rule.mdx
+++ b/public/uploads/rules/avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element/rule.mdx
@@ -20,7 +20,7 @@ title: Do you avoid using document.getElementById(id) and document.all(id) to ge
   a single element, instead use selector $(#id)?
 categories:
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: avoid-using-documentgetelementbyid-and-documentall-to-get-a-single-element
 ---

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: 'Do you avoid using mailto: on your website?'
 uri: avoid-using-mailto-on-your-website
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/design/rules-to-better-interfaces-forms.mdx
   - category: categories/design/rules-to-better-accessibility.mdx
   - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx

--- a/public/uploads/rules/avoid-using-reportviewer-local-processing-mode/rule.mdx
+++ b/public/uploads/rules/avoid-using-reportviewer-local-processing-mode/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using ReportViewer local processing mode to improve applic
   performance and reduce server load.
 title: Do you avoid using ReportViewer local processing mode?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: avoid-using-reportviewer-local-processing-mode
 ---

--- a/public/uploads/rules/avoid-using-web-site-projects/rule.mdx
+++ b/public/uploads/rules/avoid-using-web-site-projects/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Avoid using website projects and instead opt for web application
   which provide a single assembly compilation and improved project management.
 title: Do you avoid using Website Projects?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: avoid-using-web-site-projects
 ---

--- a/public/uploads/rules/build-criteria-by-using-a-where-clause/rule.mdx
+++ b/public/uploads/rules/build-criteria-by-using-a-where-clause/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Build criteria by using a WHERE clause, allowing for more comple
   filtering and similar matches with LIKE statements.
 title: Do you build criteria by using a where clause?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: build-criteria-by-using-a-where-clause
 ---

--- a/public/uploads/rules/do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero/rule.mdx
+++ b/public/uploads/rules/do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero/rule.mdx
@@ -20,7 +20,7 @@ title: Data - Do you not allow NULLs in number fields if it has the same meaning
   zero?
 categories:
   - category: categories/software-engineering/rules-to-better-sql-databases-developers.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-not-allow-nulls-in-number-fields-if-it-has-the-same-meaning-as-zero
 ---

--- a/public/uploads/rules/do-not-use-linkbutton/rule.mdx
+++ b/public/uploads/rules/do-not-use-linkbutton/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Learn why not to use LinkButton for postback and implement corre
   in ASP.NET
 title: Do you know not to use LinkButton?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: do-not-use-linkbutton

--- a/public/uploads/rules/do-you-have-a-cookie-banner/rule.mdx
+++ b/public/uploads/rules/do-you-have-a-cookie-banner/rule.mdx
@@ -11,7 +11,7 @@ seoDescription: Discover how to craft a cookie consent banner and why you must b
   careful about how you collect user data
 title: Do you have a cookie consent banner?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-have-a-cookie-banner
 ---

--- a/public/uploads/rules/do-you-know-how-to-create-nice-urls-using-asp-net-4/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-create-nice-urls-using-asp-net-4/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Create nice URLs with ASP.NET 4 using routing features, improvin
   user experience and search engine ranking.
 title: Do you know how to create nice URLs using ASP.NET 4?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-know-how-to-create-nice-urls-using-asp-net-4
 ---

--- a/public/uploads/rules/do-you-know-how-to-filter-data/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-filter-data/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Learn how to filter data effectively and efficiently in DataGrid
   ASP.NET and RadGrid features.
 title: Do you know how to filter data?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-know-how-to-filter-data
 ---

--- a/public/uploads/rules/do-you-know-how-to-render-html-strings/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-render-html-strings/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Prevent cross-site scripting (XSS) attacks and double encoding i
 type: rule
 title: Do you know how to render HTML strings?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 uri: do-you-know-how-to-render-html-strings
 authors:
   - title: Charles Vionnet

--- a/public/uploads/rules/do-you-log-usage/rule.mdx
+++ b/public/uploads/rules/do-you-log-usage/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Track usage patterns and optimize functionality with Redgate's F
   layouts.
 title: Do you log usage?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-log-usage
 ---

--- a/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-for-making-a-site-come-alive/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: To keep your website fresh and engaging, add interactivity with 
   to make it come alive when users hover or click on elements.
 title: Do you use jQuery for making a site come alive?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-use-jquery-for-making-a-site-come-alive
 ---

--- a/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
+++ b/public/uploads/rules/do-you-use-jquery-tooltips-to-save-drilling-through/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Improve page loading by providing instant details through jQuery
   saving users time and effort.
 title: Do you use jQuery Tooltips to save drilling through?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-use-jquery-tooltips-to-save-drilling-through
 ---

--- a/public/uploads/rules/do-you-use-msajax-for-live-data-binding-which-saves-round-trips/rule.mdx
+++ b/public/uploads/rules/do-you-use-msajax-for-live-data-binding-which-saves-round-trips/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Do you use MSAjax for live data binding which saves round trips 
   enhances user experience in ASP.NET AJAX applications.
 title: Do you use MSAjax for Live Data Binding which saves round trips?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: do-you-use-msajax-for-live-data-binding-which-saves-round-trips
 ---

--- a/public/uploads/rules/do-your-controls-autopostback/rule.mdx
+++ b/public/uploads/rules/do-your-controls-autopostback/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you use AutoPostBack when a selection can be applied immediately?
 uri: do-your-controls-autopostback
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 authors: []
 redirects: []
 guid: 33476bc6-1ef0-4173-b4bd-477f9c90675e

--- a/public/uploads/rules/fix-ugly-urls/rule.mdx
+++ b/public/uploads/rules/fix-ugly-urls/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Discover how to fix ugly URLs using IIS7 Rewrite for cleaner, SE
   links
 title: Do you use IIS7 Rewrite to fix ugly URLs?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: fix-ugly-urls
 ---

--- a/public/uploads/rules/have-a-validation-page-for-your-web-server/rule.mdx
+++ b/public/uploads/rules/have-a-validation-page-for-your-web-server/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Ensure your website's health by validating dependencies with a '
   Check' page, verifying server, services, databases, and more.
 title: Do you have a Validation page (the /zsValidate) for your web server?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: have-a-validation-page-for-your-web-server
 ---

--- a/public/uploads/rules/have-generic-exception-handler-in-your-global-asax/rule.mdx
+++ b/public/uploads/rules/have-generic-exception-handler-in-your-global-asax/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Handle exceptions in your ASP.NET application effectively with a
   exception handler in Global.asax, ensuring unhandled errors are logged and notified.
 title: Do you have generic exception handler in your Global.asax?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: have-generic-exception-handler-in-your-global-asax
 ---

--- a/public/uploads/rules/how-to-generate-maintenance-pages/rule.mdx
+++ b/public/uploads/rules/how-to-generate-maintenance-pages/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Discover how to generate maintenance pages efficiently using top
   code generators like NetTiers, AspDB, BLinQ, and ASP.NET Dynamic Data.
 title: Do you know how to generate maintenance pages?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: how-to-generate-maintenance-pages
 ---

--- a/public/uploads/rules/httphandlers-sections-in-webconfig-must-contain-a-clear-element/rule.mdx
+++ b/public/uploads/rules/httphandlers-sections-in-webconfig-must-contain-a-clear-element/rule.mdx
@@ -23,7 +23,7 @@ seoDescription: If web.config contains a `<httpHandlers>` or `<httpModules>` sec
 title: Do you know 'httpHandlers' or 'httpModules' sections in web.config must contain
   a 'remove' or 'clear' element?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: httphandlers-sections-in-webconfig-must-contain-a-clear-element
 ---

--- a/public/uploads/rules/keep-your-databinder-eval-clean/rule.mdx
+++ b/public/uploads/rules/keep-your-databinder-eval-clean/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Keep your "DataBinder.Eval" clean by avoiding inline processing 
   the form or use the ItemDataBound event for more complex logic.
 title: Do you keep your "DataBinder.Eval" clean?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: keep-your-databinder-eval-clean
 ---

--- a/public/uploads/rules/management-do-you-use-xp-scrum-wisely/rule.mdx
+++ b/public/uploads/rules/management-do-you-use-xp-scrum-wisely/rule.mdx
@@ -42,7 +42,7 @@ Scrum is a big concept which we try to use here. I don't adhere to every idea, b
 
 3. **Metaphors/User Stories** - client's description of a task. Aim to take down the main points
 
-4. **Validation Tests** - To find out more about Validation Tests see [Rules To Better Website Development](/rules-to-better-website-development-asp-net).
+4. **Validation Tests** - To find out more about Validation Tests see [Rules to Better ASP.NET](/rules-to-better-asp-net).
 
 5. **[The 2 key reports](/reports-do-you-schedule-the-burndown-and-stories-overview-reports-to-be-emailed-to-the-team-every-day)**
     * Burndown

--- a/public/uploads/rules/packages-to-add-to-your-mvc-project/rule.mdx
+++ b/public/uploads/rules/packages-to-add-to-your-mvc-project/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: New MVC projects require specific packages to ensure efficiency 
   scalability.
 title: Do you know which packages to add to new MVC projects?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: packages-to-add-to-your-mvc-project
 ---

--- a/public/uploads/rules/release-build-your-web-applications-before-you-deploy-them/rule.mdx
+++ b/public/uploads/rules/release-build-your-web-applications-before-you-deploy-them/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Release build your web applications before deployment to optimiz
   resource caching.
 title: Do you release build your web applications before you deploy them?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: release-build-your-web-applications-before-you-deploy-them
 ---

--- a/public/uploads/rules/the-best-sample-applications/rule.mdx
+++ b/public/uploads/rules/the-best-sample-applications/rule.mdx
@@ -28,7 +28,7 @@ categories:
   - category: categories/software-engineering/rules-to-better-angular.mdx
   - category: categories/software-engineering/rules-to-better-mvc.mdx
   - category: categories/software-engineering/rules-to-better-net-projects.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: the-best-sample-applications
 ---

--- a/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
+++ b/public/uploads/rules/use-301-redirect-on-renamed-or-moved-pages/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Boost SEO by using 301 redirects to redirect renamed or moved pa
 title: Technical - Do you use "301" code to redirect renamed or moved pages?
 categories:
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-wordpress.mdx
 type: rule
 uri: use-301-redirect-on-renamed-or-moved-pages

--- a/public/uploads/rules/use-css-validation-service-to-check-your-css-file/rule.mdx
+++ b/public/uploads/rules/use-css-validation-service-to-check-your-css-file/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Check your CSS files against W3C recommendations and ensure a va
   and clean webpage with CSS Validation Service.
 title: Do you use CSS Validation Service to check your CSS file?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-css-validation-service-to-check-your-css-file

--- a/public/uploads/rules/use-markup-validation-service-to-check-your-html-code/rule.mdx
+++ b/public/uploads/rules/use-markup-validation-service-to-check-your-html-code/rule.mdx
@@ -16,7 +16,7 @@ redirects:
 seoDescription: Use Markup Validation Service to check your HTML and XHTML code.
 title: Do you use Markup Validation Service to check your HTML and XHTML code?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-markup-validation-service-to-check-your-html-code

--- a/public/uploads/rules/use-server-side-comments/rule.mdx
+++ b/public/uploads/rules/use-server-side-comments/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Server-side commenting in ASP.NET allows efficient comment usage
   preserving page performance and reducing kilobytes.
 title: Do you use server side comments?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: use-server-side-comments

--- a/public/uploads/rules/use-sso-for-your-websites/rule.mdx
+++ b/public/uploads/rules/use-sso-for-your-websites/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Many companies benefit from Single Sign-On (SSO) technology, all
   users to log in once and stay authenticated across multiple web applications.
 title: Do you use SSO (Single sign-on) for your websites?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: use-sso-for-your-websites
 ---

--- a/public/uploads/rules/use-windows-integrated-authentication/rule.mdx
+++ b/public/uploads/rules/use-windows-integrated-authentication/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Windows Integrated Authentication streamlines sign-ins by levera
   existing domain credentials, eliminating manual login requirements.
 title: Do you use Windows Integrated Authentication?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: use-windows-integrated-authentication
 ---

--- a/public/uploads/rules/web-ui-libraries/rule.mdx
+++ b/public/uploads/rules/web-ui-libraries/rule.mdx
@@ -21,7 +21,7 @@ title: Do you use the best Web UI libraries?
 categories:
   - category: categories/software-engineering/rules-to-better-architecture-and-code-review.mdx
   - category: categories/software-engineering/rules-to-better-javascript-and-jquery.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: web-ui-libraries
 ---

--- a/public/uploads/rules/when-anchor-should-run-at-server/rule.mdx
+++ b/public/uploads/rules/when-anchor-should-run-at-server/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Anchor tags should run at server only when needed to change targ
   at runtime, avoiding unnecessary overhead.
 title: Do you know when anchor should "run at server"?
 categories:
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
 type: rule
 uri: when-anchor-should-run-at-server
 ---

--- a/public/uploads/rules/why-choose-dot-net-core/rule.mdx
+++ b/public/uploads/rules/why-choose-dot-net-core/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Develop a cross-platform .NET Core application that runs on macO
 title: Do you know why you choose .NET Core?
 categories:
   - category: categories/software-engineering/rules-to-better-net-projects.mdx
-  - category: categories/websites-and-cms/rules-to-better-website-development-asp-net.mdx
+  - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/websites-and-cms/rules-to-better-websites-development.mdx
 type: rule
 uri: why-choose-dot-net-core


### PR DESCRIPTION
Rename the category to **Rules to Better ASP.NET** and move it from **Websites and CMS** to **Software Engineering**, as its rules are primarily about application development rather than website content management.

## Details

- **Title:** `Rules to Better Website Development - ASP.NET` → **`Rules to Better ASP.NET`**
- **URI + file:** `rules-to-better-website-development-asp-net` → `rules-to-better-asp-net`, with a redirect from the old URI so existing links keep working
- **Moved** the category file `categories/websites-and-cms/` → `categories/software-engineering/`
- **Top-category indexes:** removed from `Websites and CMS`, added to `Software Engineering` (placed just after *Rules to Better MVC*)
- Updated the category path in **38 member rules** and repointed one prose link (`management-do-you-use-xp-scrum-wisely`)

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues (reciprocal category ↔ rule references agree)

No references to the old category URI/path remain except the intentional redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
