### PR TITLE
Add Async support for the SoftDeleteInterceptor

### DIFF
--- a/public/uploads/rules/avoid-deleting-records-by-flagging-them-as-isdeleted/rule.mdx
+++ b/public/uploads/rules/avoid-deleting-records-by-flagging-them-as-isdeleted/rule.mdx
@@ -69,7 +69,27 @@ public class SoftDeleteInterceptor : SaveChangesInterceptor
 {
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        foreach (var entry in eventData.Context.ChangeTracker.Entries<ISoftDeleteEntity>())
+        UpdateEntities(eventData.Context);
+
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+    DbContextEventData eventData, 
+    InterceptionResult<int> result, 
+    CancellationToken ct)
+    {
+        UpdateEntities(eventData.Context);
+
+        return base.SavingChangesAsync(eventData, result, ct);
+    }
+
+    private static void UpdateEntities(DbContext? context)
+    {
+        if (context is null)
+            return;
+
+        foreach (var entry in context.ChangeTracker.Entries<ISoftDeleteEntity>())
         {
             if (entry.State == EntityState.Deleted)
             {
@@ -77,7 +97,6 @@ public class SoftDeleteInterceptor : SaveChangesInterceptor
                 entry.State = EntityState.Modified;
             }
         }
-        return base.SavingChanges(eventData, result);
     }
 }
 ```


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ When working on my FireBootCamp project I tried to use the Interceptor from this rule using an async remove, unfortunately that lead to my column being hard deleted instead of checking off the `IsDeleted` field. I believe it would be better to explicitly talk about needing an `SavingChangesAsync` since it isn't immediately clear.

> 2. What was changed?

✏️ `SoftDeleteInterceptor` now has a `SavingChangesAsync` method


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->

