### PR TITLE
Strengthen stacked PRs rule intro with review-effectiveness stats

### DIFF
--- a/public/uploads/rules/stacked-pull-requests/rule.mdx
+++ b/public/uploads/rules/stacked-pull-requests/rule.mdx
@@ -21,7 +21,7 @@ createdBy: Luke Cook
 createdByEmail: LukeCook@ssw.com.au
 ---
 
-You open a Pull Request with 50 changed files. Your reviewer scrolls for a minute, skims the parts they recognise, and approves with a single "LGTM". Nobody can hold 50 files in their head, so bugs go straight through review.
+Big Pull Requests don't get reviewed - they get skimmed and "LGTM"-ed, and the data backs it up. [SmartBear's study of 2,500 code reviews at Cisco](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/) found reviewers' ability to catch defects drops sharply beyond ~400 lines of code, [Microsoft Research](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/bosu2015useful.pdf) found the density of useful review comments falls as changes get bigger, and [Graphite's analysis of millions of PRs](https://graphite.com/blog/the-ideal-pr-is-50-lines-long) found 50-line changes are ~15% less likely to be reverted than 250-line ones.
 
 Stacked Pull Requests fix this by splitting one big change into a chain of small PRs, where each PR targets the branch below it instead of `main`. Reviewers see a handful of focused files per PR, and each one gets a real review.
 


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Intro was thin.

> 2. What was changed?

Added more data-driven facts behind why large PRs are bad

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
✏️
<!-- E.g. I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
