### PR TITLE
Add Rules to Better AEO and GEO category

### DIFF
--- a/categories/artificial-intelligence/index.mdx
+++ b/categories/artificial-intelligence/index.mdx
@@ -9,5 +9,6 @@ index:
 - category: categories/artificial-intelligence/rules-to-better-ai-development.mdx
 - category: categories/artificial-intelligence/rules-to-better-ai-generated-media.mdx
 - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+- category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
 
 ---

--- a/categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
+++ b/categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
@@ -1,0 +1,25 @@
+---
+type: category
+title: Rules to Better AEO and GEO
+uri: rules-to-better-aeo-and-geo
+guid: 83f25688-9cb4-4d78-8010-0dee0ebb96b2
+seoDescription: SSW's rules for Answer Engine Optimisation (AEO) and Generative Engine Optimisation (GEO). Learn how to get your content found, understood and cited by ChatGPT, Claude, Perplexity and Google AI Overviews.
+index:
+  - rule: public/uploads/rules/ai-optimization-geo-aeo/rule.mdx
+  - rule: public/uploads/rules/page-indexed-by-google/rule.mdx
+  - rule: public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+  - rule: public/uploads/rules/cite-your-sources/rule.mdx
+  - rule: public/uploads/rules/back-claims-with-data/rule.mdx
+  - rule: public/uploads/rules/use-quotations/rule.mdx
+  - rule: public/uploads/rules/optimise-content-for-topical-authority/rule.mdx
+  - rule: public/uploads/rules/query-deserves-freshness/rule.mdx
+  - rule: public/uploads/rules/author-e-e-a-t/rule.mdx
+  - rule: public/uploads/rules/structured-data/rule.mdx
+_template: category
+---
+
+People now ask ChatGPT, Claude, Perplexity and Google AI Overviews a question and get an answer with a few sources cited underneath. Answer Engine Optimisation (AEO) and Generative Engine Optimisation (GEO) are two names for the same goal: be the source that gets quoted.
+
+Much of it is still SEO, so start with [Rules to Better Google Rankings and SEO](/rules-to-better-google-rankings-and-seo).
+
+Want to get found by AI? Check [SSW's Artificial Intelligence and Machine Learning consulting page](https://www.ssw.com.au/consulting/artificial-intelligence).

--- a/categories/artificial-intelligence/rules-to-better-ai-development.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai-development.mdx
@@ -21,7 +21,6 @@ index:
   - rule: public/uploads/rules/use-embeddings/rule.mdx
   - rule: public/uploads/rules/build-hallucination-proof-ai-assistants/rule.mdx
   - rule: public/uploads/rules/avoid-ai-hallucinations/rule.mdx
-  - rule: public/uploads/rules/make-your-website-llm-friendly/rule.mdx
   - rule: public/uploads/rules/dataverse-ai-options/rule.mdx
   - rule: public/uploads/rules/mcp-server/rule.mdx
   - rule: public/uploads/rules/use-mcp-to-standardize-llm-connections/rule.mdx

--- a/categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
+++ b/categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
@@ -53,7 +53,6 @@ index:
   - rule: public/uploads/rules/optimise-content-for-topical-authority/rule.mdx
   - rule: public/uploads/rules/on-page-seo-best-practice/rule.mdx
   - rule: public/uploads/rules/query-deserves-freshness/rule.mdx
-  - rule: public/uploads/rules/ai-optimization-geo-aeo/rule.mdx
   - rule: public/uploads/rules/html-lang-attribute/rule.mdx
   - rule: public/uploads/rules/back-claims-with-data/rule.mdx
   - rule: public/uploads/rules/author-e-e-a-t/rule.mdx

--- a/public/uploads/rules/ai-optimization-geo-aeo/rule.mdx
+++ b/public/uploads/rules/ai-optimization-geo-aeo/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you optimize your content for AI answers?
 uri: ai-optimization-geo-aeo
 categories:
-  - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
 authors:
   - title: Stef Telecki
     url: 'https://www.ssw.com.au/people/stef-starcevic'

--- a/public/uploads/rules/author-e-e-a-t/rule.mdx
+++ b/public/uploads/rules/author-e-e-a-t/rule.mdx
@@ -3,6 +3,7 @@ type: rule
 title: Do you show authorship and E-E-A-T signals?
 uri: author-e-e-a-t
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Isaac Lombard

--- a/public/uploads/rules/back-claims-with-data/rule.mdx
+++ b/public/uploads/rules/back-claims-with-data/rule.mdx
@@ -3,6 +3,7 @@ type: rule
 title: Do you replace vague claims with measurable facts?
 uri: back-claims-with-data
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
   - category: categories/marketing-and-video/rules-to-better-marketing.mdx
 authors:

--- a/public/uploads/rules/cite-your-sources/rule.mdx
+++ b/public/uploads/rules/cite-your-sources/rule.mdx
@@ -3,6 +3,7 @@ type: rule
 title: Do you cite authoritative sources?
 uri: cite-your-sources
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Isaac Lombard

--- a/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+++ b/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
@@ -2,7 +2,7 @@
 type: rule
 title: Do you provide an llms.txt file to make your website LLM-friendly?
 categories:
-  - category: categories/artificial-intelligence/rules-to-better-ai-development.mdx
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
 seoDescription: Learn how implementing an llms.txt file can enhance your
   website's accessibility and usability for large language models, ensuring
   accurate content interpretation and improved user interactions.

--- a/public/uploads/rules/optimise-content-for-topical-authority/rule.mdx
+++ b/public/uploads/rules/optimise-content-for-topical-authority/rule.mdx
@@ -2,6 +2,7 @@
 title: Do you optimise your content for topical authority? (Hub and spoke)
 uri: optimise-content-for-topical-authority
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Stef Starcevic

--- a/public/uploads/rules/page-indexed-by-google/rule.mdx
+++ b/public/uploads/rules/page-indexed-by-google/rule.mdx
@@ -3,6 +3,7 @@ type: rule
 title: Basics - Do you know if Google has indexed your page?
 uri: page-indexed-by-google
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Tiago Araujo

--- a/public/uploads/rules/query-deserves-freshness/rule.mdx
+++ b/public/uploads/rules/query-deserves-freshness/rule.mdx
@@ -2,6 +2,7 @@
 title: Do you apply the Query Deserves Freshness (QDF) Rule?
 uri: query-deserves-freshness
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Stef Telecki

--- a/public/uploads/rules/structured-data/rule.mdx
+++ b/public/uploads/rules/structured-data/rule.mdx
@@ -15,6 +15,7 @@ seoDescription: Structured data offers a solution by providing a standardized wa
   and display your information in rich and meaningful ways.
 title: Technical - Do you use structured data for data-driven websites?
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 type: rule
 uri: structured-data

--- a/public/uploads/rules/use-quotations/rule.mdx
+++ b/public/uploads/rules/use-quotations/rule.mdx
@@ -3,6 +3,7 @@ type: rule
 title: Do you include relevant quotations?
 uri: use-quotations
 categories:
+  - category: categories/artificial-intelligence/rules-to-better-aeo-and-geo.mdx
   - category: categories/marketing-and-video/rules-to-better-google-rankings-and-seo.mdx
 authors:
   - title: Isaac Lombard


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ AEO/GEO rules are multiplying and were scattered between Rules to Better Google Rankings and SEO and Rules to Better AI Development. They now warrant their own category.

> 2. What was changed?

✏️ New category `Rules to Better AEO and GEO` under Artificial Intelligence, indexing 10 rules.

**Moved out of their old category** (these are purely about AI answer engines):

* `ai-optimization-geo-aeo` (was in SEO)
* `make-your-website-llm-friendly` (was in AI Development)

**Dual-listed**, because they are genuinely both classic SEO and AEO/GEO, and removing them from SEO would leave gaps there:

* `page-indexed-by-google` - indexability is the eligibility gate for AI Overviews
* `structured-data` - reinforces entities
* `author-e-e-a-t` - trust signals
* `cite-your-sources`, `back-claims-with-data`, `use-quotations` - the three methods the GEO study measured
* `query-deserves-freshness` - recency
* `optimise-content-for-topical-authority` - depth

Left in SEO only: the technical fundamentals with no AI-specific angle (HTTPS, canonical, titles, meta, headings, responsive, alt text, Open Graph, sitemap, robots.txt).

Two follow-ups worth flagging:

1. `do-you-phrase-the-heading-as-a-question` looked like a good fit but is `isArchived: true`, so I left it alone. It may be worth unarchiving, since question-style headings matter more now than when it was retired in 2021.
2. `use-robots-txt-effectively` is from 2015 and only covers redirect folders. Its AI-crawler gap is filled by #13167, but the rule itself could use a refresh.

Validators run locally and passing: check-mdx, category-sync, lint-urls.

> 3. I paired or mob programmed with:

✏️ n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)