### PR TITLE
Fix malformed bold formatting caused by spaces + add validation (#13159)

### DIFF
--- a/.github/workflows/check-malformed-bold.yml
+++ b/.github/workflows/check-malformed-bold.yml
@@ -1,0 +1,106 @@
+name: Check-Malformed-Bold
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - ".github/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-malformed-bold:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Get changed Markdown/MDX files
+        id: changed_md
+        shell: bash
+        run: |
+          set -e
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed="$(git diff --name-only --diff-filter=ACMRT $(git merge-base origin/main HEAD) HEAD -- '*.md' '*.mdx' | paste -sd "," -)"
+          else
+            # For manual runs, check all tracked .md/.mdx files
+            changed="$(git ls-files '*.md' '*.mdx' | paste -sd "," -)"
+          fi
+
+          echo "changed=$changed" >> $GITHUB_ENV
+          echo "Changed Markdown/MDX: $changed"
+
+      - name: Run malformed-bold check
+        id: bold_check
+        if: ${{ env.changed != '' }}
+        continue-on-error: true
+        env:
+          BOLD_REPORT_PATH: ${{ runner.temp }}/malformed-bold-report.md
+        run: |
+          node scripts/check-malformed-bold/check-malformed-bold.js '${{ env.changed }}'
+
+      - name: Check report exists
+        id: bold_report
+        if: ${{ env.changed != '' }}
+        shell: bash
+        run: |
+          if [ -f "${{ runner.temp }}/malformed-bold-report.md" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR
+        if: ${{ env.changed != '' && steps.bold_report.outputs.exists == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v9
+        env:
+          BOLD_REPORT_PATH: ${{ runner.temp }}/malformed-bold-report.md
+        with:
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- malformed-bold-check -->';
+            const reportPath = process.env.BOLD_REPORT_PATH;
+
+            let body = fs.readFileSync(reportPath, 'utf8');
+            if (!body.includes(marker)) body = `${marker}\n` + body;
+
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            // Update existing bot comment to avoid spam
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100
+            });
+
+            const existing = comments.find(c =>
+              c.user && c.user.type === 'Bot' && typeof c.body === 'string' && c.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body
+              });
+            }
+
+      - name: Fail job if malformed bold was found
+        if: ${{ env.changed != '' && steps.bold_check.outcome == 'failure' }}
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Use the current schemas and scripts as the source of truth. Before introducing u
 * Explain why the practice matters. Link to product documentation for implementation details that will become stale.
 * Prefer concrete good/bad examples when they materially clarify the advice. Every image or example box needs a descriptive `figure`.
 * Use asterisks for unordered lists and specify a language on fenced code blocks.
+* Bold markdown must not contain whitespace immediately inside the `**` markers — the space leaks out as a literal `**` when rendered (a common Tina editing mistake). Write `**Note:**`, not `** Note: **`. `❌ ** Note: **` → `✅ **Note:**`. The `check-malformed-bold` validator enforces this.
 * Link to another rule as `[descriptive title](/[uri])`.
 * SSW URLs must use `https://www.ssw.com.au/...`; the URL linter flags the bare domain.
 * Put images in the rule folder, use descriptive kebab-case names and lowercase extensions, and embed them with `<imageEmbed>` rather than Markdown image syntax.
@@ -121,6 +122,12 @@ Markdown:
 
 ```bash
 npx --yes markdownlint-cli 'public/uploads/rules/[uri]/rule.mdx' --config .markdownlint/config.json
+```
+
+Malformed bold (whitespace inside `**` markers). Omit the file argument to scan the whole repository:
+
+```bash
+node scripts/check-malformed-bold/check-malformed-bold.js 'public/uploads/rules/[uri]/rule.mdx'
 ```
 
 For new, moved, or recategorized rules:

--- a/public/uploads/rules/aspire/rule.mdx
+++ b/public/uploads/rules/aspire/rule.mdx
@@ -113,7 +113,7 @@ Leverage predefined templates and tooling to:
       options.InstanceName = "SampleInstance";
   });
 ```
-**❌ Figure: Bad Example - Manually setting up Redis cache 🥱**  
+❌ **Figure: Bad Example - Manually setting up Redis cache 🥱**  
 
 ### The new way - with .NET Aspire
 
@@ -140,7 +140,7 @@ Aspire handles Redis setup and connection string injection for you:
       }
   }
   ```
-**✅ Figure: Good Example - Simple Redis setup with .NET Aspire 🚀**  
+✅ **Figure: Good Example - Simple Redis setup with .NET Aspire 🚀**  
 
 No need to write Docker Compose files.
 No need for yaml 🤮.

--- a/public/uploads/rules/aspire/rule.mdx
+++ b/public/uploads/rules/aspire/rule.mdx
@@ -140,7 +140,7 @@ Aspire handles Redis setup and connection string injection for you:
       }
   }
   ```
-**✅ **Figure: Good Example - Simple Redis setup with .NET Aspire 🚀****  
+**✅ Figure: Good Example - Simple Redis setup with .NET Aspire 🚀**  
 
 No need to write Docker Compose files.
 No need for yaml 🤮.

--- a/public/uploads/rules/best-practices-office-automation/rule.mdx
+++ b/public/uploads/rules/best-practices-office-automation/rule.mdx
@@ -89,6 +89,6 @@ Examples:
 
 * **Overusing programming -** Too much custom logic can complicate maintenance and troubleshooting
 * **Relying solely on macros or schedules -** These are useful for simplifying repetitive tasks but cannot handle conditional triggers efficiently
-* **Using unsupported drivers - **These can break during Control4 OS updates, creating unanticipated downtime
+* **Using unsupported drivers -** These can break during Control4 OS updates, creating unanticipated downtime
 
 By choosing the right combination of drivers, programming, macros, and schedules, you can design a robust and easily manageable automation system that enhances the office's usability and efficiency.

--- a/public/uploads/rules/copy-text-from-image/rule.mdx
+++ b/public/uploads/rules/copy-text-from-image/rule.mdx
@@ -46,7 +46,7 @@ Using OneNote is simple. All you do is paste your image into OneNote, right clic
 
 ### Method 2: Using Google Drive
 
-In Google Drive you need to upload your image as a new file. Then you need to right click on the image file and select ** Open with | Google Docs**.
+In Google Drive you need to upload your image as a new file. Then you need to right click on the image file and select **Open with | Google Docs**.
 
 <imageEmbed
   alt="Image"

--- a/public/uploads/rules/create-friendly-short-urls/rule.mdx
+++ b/public/uploads/rules/create-friendly-short-urls/rule.mdx
@@ -84,7 +84,7 @@ Sometimes you are not in control of the link. In those cases, use [Bitly](https:
 <boxEmbed
   style="greybox"
   body={<>
-    **Auto-shorten link: **
+    **Auto-shorten link:**
     
     bit.ly/3zTHz8b
   </>}
@@ -97,7 +97,7 @@ When have a Bitly account, you can customize links to a more readable option.
 <boxEmbed
   style="greybox"
   body={<>
-    **Custom shorten link: **
+    **Custom shorten link:**
     
     bit.ly/VS-2022-Sample
   </>}

--- a/public/uploads/rules/directory-build-props/rule.mdx
+++ b/public/uploads/rules/directory-build-props/rule.mdx
@@ -85,7 +85,7 @@ This can be used for:
   figurePrefix="bad"
   figure="Redundant configuration"
 />
-**✅ **Project1.csproj:**
+**✅ Project1.csproj:**
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Web">

--- a/public/uploads/rules/directory-build-props/rule.mdx
+++ b/public/uploads/rules/directory-build-props/rule.mdx
@@ -85,7 +85,7 @@ This can be used for:
   figurePrefix="bad"
   figure="Redundant configuration"
 />
-**✅ Project1.csproj:**
+✅ **Project1.csproj:**
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Web">
@@ -117,7 +117,7 @@ This can be used for:
     </PropertyGroup>
 </Project>
 ```**  
-**✅ Good example - Centralized configuration**  
+✅ **Good example - Centralized configuration**  
 
 ## What about Directory.Build.targets?
 
@@ -143,7 +143,7 @@ Rule of thumb: **defaults go in .props, overrides and custom targets go in .targ
 </Project>
 ```
 
-**✅ Good example - Directory.Build.targets reacting to per-project properties and defining a shared target**
+✅ **Good example - Directory.Build.targets reacting to per-project properties and defining a shared target**
 
 **Note:** MSBuild only auto-imports the **nearest** `Directory.Build.props`/`.targets` above each project. If you need multiple levels (e.g. one at the repo root plus one for the `tests` folder), the inner file must import the outer one explicitly:
 

--- a/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
+++ b/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
@@ -32,7 +32,7 @@ It is a good idea to run a pre-migration check on the SharePoint 2007 before sta
 2. Open up **cmd** with Administrator privileges
 3. Run the following command: \*\*stsadm –o preupgradecheck
 
-** ![](/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/preupgradecheck.png)**
+**![](/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/preupgradecheck.png)**
 Figure 3 - Check the pre-migration report. The only thing that is allowed to fail is “FeatureInfo”. This is because a custom feature won’t migrate and developers need to create a build targeted for SharePoint 2010 \*\* 4. Save the HTML file that was generated and email it to your companies SharePoint Master. (Don’t print it as its very large) 5. Have the [SharePoint Master](/do-you-have-a-sharepoint-master) sign off on the pre-migration check and inform you if there are any site collections or content sources that are no longer needed and can be ignored for migration
 
 <endIntro />

--- a/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
+++ b/public/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/rule.mdx
@@ -28,11 +28,14 @@ uri: do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server
 
 It is a good idea to run a pre-migration check on the SharePoint 2007 before starting the migration process.
 
+<endIntro />
+
 1. Check you have followed [Do you add stsadm to the environmental variables?](/do-you-add-stsadm-to-environmental-variables)
 2. Open up **cmd** with Administrator privileges
-3. Run the following command: \*\*stsadm –o preupgradecheck
+3. Run the following command: `stsadm –o preupgradecheck`
 
-**![](/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/preupgradecheck.png)**
-Figure 3 - Check the pre-migration report. The only thing that is allowed to fail is “FeatureInfo”. This is because a custom feature won’t migrate and developers need to create a build targeted for SharePoint 2010 \*\* 4. Save the HTML file that was generated and email it to your companies SharePoint Master. (Don’t print it as its very large) 5. Have the [SharePoint Master](/do-you-have-a-sharepoint-master) sign off on the pre-migration check and inform you if there are any site collections or content sources that are no longer needed and can be ignored for migration
+![Figure: Check the pre-migration report. The only thing that is allowed to fail is FeatureInfo. This is because a custom feature won’t migrate and developers need to create a build targeted for SharePoint 2010](/uploads/rules/do-you-do-a-pre-migration-check-on-the-sharepoint-2007-server/preupgradecheck.png)
 
-<endIntro />
+4. Save the HTML file that was generated and email it to your companies SharePoint Master. (Don’t print it as it is very large) 
+5. Have the [SharePoint Master](/do-you-have-a-sharepoint-master) sign off on the pre-migration check and inform you if there are any site collections or content sources that are no longer needed and can be ignored for migration
+

--- a/public/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/rule.mdx
@@ -29,7 +29,7 @@ Occasionally when you estimate the size of a VHD that you will be using in a ser
 2. Shutdown the virtual machine (only required for Gen1 VMs)
 3. Click **Edit Disk...** in the **Actions** pane of the **Hyper-V Manager
    ![You expand a VHD from the Actions Menu | Edit Disk](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/actions-expand.jpg)
-   ** **Figure: You expand a VHD from the Actions Menu | Edit Disk**
+   **Figure: You expand a VHD from the Actions Menu | Edit Disk**
 4. In the **Edit Virtual Hard Disk Wizard** window, choose the VHD you want to edit and choose **Next.**
 5. Select **Expand** and click **Next**
 6. Enter the new size of the VHD and click **Next**
@@ -40,7 +40,7 @@ You will now have a resized VHD. Next step is to boot up into the virtual machin
 2. Open **Computer Management** and choose **Disk Management**
 3. Right click on the partition sitting at the front of the newly resized disk and click on **Extend Volume...
    ![The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-freespace.jpg)
-   ** **Figure: The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD**
+   **Figure: The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD**
 4. You will have to use all the available space when you extend the volume as it is a Simple Volume. (See Rule: [Do you use Basic Volumes inside VHD’s?](/do-you-use-basic-volumes-inside-vhds)) When you are asked to select your disks just click **Next**
 5. Click **Finish
-   ![The disk is now using all the available space inside the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-fullspaceused.jpg)** **Figure: The disk is now using all the available space inside the VHD**
+   ![The disk is now using all the available space inside the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-fullspaceused.jpg)**Figure: The disk is now using all the available space inside the VHD**

--- a/public/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/rule.mdx
@@ -28,19 +28,24 @@ Occasionally when you estimate the size of a VHD that you will be using in a ser
 1. Open the **Hyper-V Manager** on the server hosting the Virtual Machine
 2. Shutdown the virtual machine (only required for Gen1 VMs)
 3. Click **Edit Disk...** in the **Actions** pane of the **Hyper-V Manager
-   ![You expand a VHD from the Actions Menu | Edit Disk](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/actions-expand.jpg)
-   **Figure: You expand a VHD from the Actions Menu | Edit Disk**
+   
+   ![Figure: You expand a VHD from the Actions Menu | Edit Disk](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/actions-expand.jpg)
+
 4. In the **Edit Virtual Hard Disk Wizard** window, choose the VHD you want to edit and choose **Next.**
 5. Select **Expand** and click **Next**
 6. Enter the new size of the VHD and click **Next**
+
+---
 
 You will now have a resized VHD. Next step is to boot up into the virtual machine and tell disk manager to resize the partition on the VHD to use the free space which has been added at the end of the VHD. Windows Server 2008 makes this very simple:
 
 1. Boot into the virtual machine
 2. Open **Computer Management** and choose **Disk Management**
 3. Right click on the partition sitting at the front of the newly resized disk and click on **Extend Volume...
-   ![The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-freespace.jpg)
-   **Figure: The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD**
+
+   ![Figure: The first partition on the disk needs to be expanded to use up the unallocated space created when expanding the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-freespace.jpg)
+
 4. You will have to use all the available space when you extend the volume as it is a Simple Volume. (See Rule: [Do you use Basic Volumes inside VHD’s?](/do-you-use-basic-volumes-inside-vhds)) When you are asked to select your disks just click **Next**
 5. Click **Finish
-   ![The disk is now using all the available space inside the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-fullspaceused.jpg)**Figure: The disk is now using all the available space inside the VHD**
+  
+   ![Figure: The disk is now using all the available space inside the VHD](/uploads/rules/do-you-know-how-to-expand-your-vhds-when-you-are-low-on-space/expand-fullspaceused.jpg)

--- a/public/uploads/rules/do-you-know-how-to-manage-nuget-packages-with-git/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-manage-nuget-packages-with-git/rule.mdx
@@ -27,7 +27,7 @@ Do you know the best way to manage NuGet packages with Git? You can get into all
 
 <endIntro />
 
-** Do not check packages into Git **
+**Do not check packages into Git**
 
 The following are a few issues that are related to having your NuGet packages in source control:
 

--- a/public/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/rule.mdx
@@ -33,7 +33,7 @@ bcdedit
 ```
 
 ![The list Boot entries after running bcdedit](/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/fig6-listbootentries.png)
-**Figure - The list Boot entries after running bcdedit
+
 3. Using the **identifier** from the previous step you can now run the following command to delete the entry:
 
 ```bash
@@ -41,6 +41,5 @@ bcdedit /delete  {identifier}
 ```
 
 ![The boot entry has now been deleted](/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/fig7-deletingthebootentry.png)
-**Figure - The boot entry has now been deleted**
 
 You can now delete or move your VHD file and you will not get any errors when booting your laptop.

--- a/public/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/rule.mdx
@@ -34,7 +34,7 @@ bcdedit
 
 ![The list Boot entries after running bcdedit](/uploads/rules/do-you-know-how-to-remove-old-boot-to-vhd-entries/fig6-listbootentries.png)
 **Figure - The list Boot entries after running bcdedit
-** 3. Using the **identifier** from the previous step you can now run the following command to delete the entry:
+3. Using the **identifier** from the previous step you can now run the following command to delete the entry:
 
 ```bash
 bcdedit /delete  {identifier}

--- a/public/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/rule.mdx
@@ -45,13 +45,13 @@ bcdedit /copy {default} /d “Demo-NameOfDemo”
 bcdedit /set <GUID>  device vhd=[D:]\VM-DEV-SharePoint_2010_Public_Beta.vhd
 ```
 
-**D:\*\* is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;\*\* with the GUID you got in the previous step. 5. Type:
+**D:** is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;** with the GUID you got in the previous step. 5. Type:
 
 ```bash
 bcdedit /set <GUID>  osdevice vhd=[D:]\VM-DEV-SharePoint_2010_Public_Beta.vhd
 ```
 
-**D:\*\* is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;\*\* with the GUID you got in the previous step. 6. Type:
+**D:** is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;** with the GUID you got in the previous step. 6. Type:
 
 ```bash
 bcdedit /set <GUID> detecthal on

--- a/public/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/rule.mdx
@@ -39,23 +39,21 @@ bcdedit /copy {default} /d “Demo-NameOfDemo”
 ```
 
 ![Creating the entry using BCDEdit shows your GUID](/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/fig1-creatingentry.png)
-**Figure - Creating the entry using BCDEdit shows your GUID** 4. Type:
+
+4. Type:
 
 ```bash
 bcdedit /set <GUID>  device vhd=[D:]\VM-DEV-SharePoint_2010_Public_Beta.vhd
 ```
 
-**D:** is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;** with the GUID you got in the previous step. 5. Type:
+**D:** is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you update with the GUID you got in the previous step. 
 
-```bash
-bcdedit /set <GUID>  osdevice vhd=[D:]\VM-DEV-SharePoint_2010_Public_Beta.vhd
-```
-
-**D:** is the drive the VHD is located and **VM-DEV-SharePoint_2010_Public_Beta.vhd** is the location of your VHD file. Make sure you replace **&lt;GUID&gt;** with the GUID you got in the previous step. 6. Type:
+5. Type:
 
 ```bash
 bcdedit /set <GUID> detecthal on
 ```
 
-![Each time you run a BCDEdit command it should return](/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/fig2-addguids.png)
-**Figure - Each time you run a BCDEdit command it should return "The operation completed successfully"** 7. Reboot the computer and now you will have the option to choose between Windows 7 and the new Boot to VHD image.
+![Figure - Each time you run a BCDEdit command it should return "The operation completed successfully"](/uploads/rules/do-you-know-how-to-setup-a-boot-to-vhd-image/fig2-addguids.png)
+
+6. Reboot the computer and now you will have the option to choose between Windows 7 and the new Boot to VHD image.

--- a/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
@@ -74,7 +74,7 @@ public class PrintServer
     // ...
 }
 ```
-**❌ Figure: Bad example - This class does two distinct jobs. It creates print jobs and manages printers**  
+❌ **Figure: Bad example - This class does two distinct jobs. It creates print jobs and manages printers**  
 
 ```csharp
 public class Printers {
@@ -96,6 +96,6 @@ public class PrinterManager {
     }
 }
 ```
-**✅ Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control and Dependency Injection patterns.**  
+✅ **Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control and Dependency Injection patterns.**  
 
 ### TODO: Piers - [GitHub Issue](https://github.com/SSWConsulting/SSW.Rules.Content/issues/1535)

--- a/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
@@ -96,6 +96,6 @@ public class PrinterManager {
     }
 }
 ```
-**✅ Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control \*and\* Dependency Injection patterns.**  
+**✅ Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control and Dependency Injection patterns.**  
 
 ### TODO: Piers - [GitHub Issue](https://github.com/SSWConsulting/SSW.Rules.Content/issues/1535)

--- a/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-common-design-principles-part-2-example/rule.mdx
@@ -96,6 +96,6 @@ public class PrinterManager {
     }
 }
 ```
-**✅ Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control **\*and\*** Dependency Injection patterns.**  
+**✅ Figure: Good Example - Each class has a single responsibility Additionally, code that has high coupling violates the Dependency Inversion principle. This makes code difficult to change but can be resolved by implementing the Inversion of Control \*and\* Dependency Injection patterns.**  
 
 ### TODO: Piers - [GitHub Issue](https://github.com/SSWConsulting/SSW.Rules.Content/issues/1535)

--- a/public/uploads/rules/do-you-make-batch-files-for-deployment-to-test-and-production-servers/rule.mdx
+++ b/public/uploads/rules/do-you-make-batch-files-for-deployment-to-test-and-production-servers/rule.mdx
@@ -24,7 +24,7 @@ type: rule
 uri: do-you-make-batch-files-for-deployment-to-test-and-production-servers
 ---
 
-The goal is that CRM developers **to not ** move from Dev to Test and to Production manually. Basically, we don't want a developer to touch Test or Production servers. The testers can run the .bat file. [See SSW rules to setup packages](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterSetups.aspx).
+The goal is that CRM developers **to not** move from Dev to Test and to Production manually. Basically, we don't want a developer to touch Test or Production servers. The testers can run the .bat file. [See SSW rules to setup packages](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterSetups.aspx).
 
 <endIntro />
 

--- a/public/uploads/rules/do-you-put-the-vhd-image-in-a-standard-folder-name-with-instructions/rule.mdx
+++ b/public/uploads/rules/do-you-put-the-vhd-image-in-a-standard-folder-name-with-instructions/rule.mdx
@@ -25,7 +25,7 @@ uri: do-you-put-the-vhd-image-in-a-standard-folder-name-with-instructions
 When you do a lot of presenting on your laptop it is good to have a standard location to keep your VHD and instructions.
 
 - Give the VHD the name of what the demo is for and a version number for the image.
-  **Example: ** SharePoint2010_v2.vhd
+  **Example:** SharePoint2010_v2.vhd
 - Use “RC” or “Beta” on the filename if your software is an RC or Beta Version
   **Example:** SharePoint2010RC_v1.vhd
 - Store the VHD Image in a folder called DataVMs\VHDName\VHDName.vhd

--- a/public/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/rule.mdx
+++ b/public/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/rule.mdx
@@ -30,4 +30,4 @@ Snapshots are a very easy way to back up a system before a big change is made. T
 3. The snapshot should run very quickly and you will notice the snapshot in the **Snapshots** area of the \*\*Hyper-V Manager
 
 ![You will see the snapshots associated with a Virtual Machine when you click on them](/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/snapshot-while-off.jpg)\*\*
-**✅ You will see the snapshots associated with a Virtual Machine when you click on them**
+✅ **You will see the snapshots associated with a Virtual Machine when you click on them**

--- a/public/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/rule.mdx
+++ b/public/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/rule.mdx
@@ -30,4 +30,4 @@ Snapshots are a very easy way to back up a system before a big change is made. T
 3. The snapshot should run very quickly and you will notice the snapshot in the **Snapshots** area of the \*\*Hyper-V Manager
 
 ![You will see the snapshots associated with a Virtual Machine when you click on them](/uploads/rules/do-you-shut-down-a-virtual-machine-before-running-a-snapshot/snapshot-while-off.jpg)\*\*
-**✅ **You will see the snapshots associated with a Virtual Machine when you click on them****
+**✅ You will see the snapshots associated with a Virtual Machine when you click on them**

--- a/public/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/rule.mdx
+++ b/public/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/rule.mdx
@@ -32,7 +32,7 @@ What happens when you leave all the testing to the end of the Sprint? You find t
 <endIntro />
 
 ![](/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/RuleBuildEverySprintBad.png)
-**❌ **Figure: Bad example - if you don’t complete all the tasks the customer will not receive a build in the Sprint**
+**❌ Figure: Bad example - if you don’t complete all the tasks the customer will not receive a build in the Sprint**
 
 <imageEmbed
   alt="Image"
@@ -50,7 +50,7 @@ It is preferable to conduct a **Smoke Test** to make sure that you are comfortab
 In this scenario the “ **test please** ” with the customer happens outside of the current Sprint.
 
 ![](/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/RuleBuildEverySprintGOOD.png)
-**✅ **Figure: Good example – Create a coded UI test for each story to prove that it is complete****  
+**✅ Figure: Good example – Create a coded UI test for each story to prove that it is complete**  
 
 If you are doing **Scrum** then you should have a **User Story** fleshed out with a set of **Acceptance Criteria** . These **Acceptance Criteria** are agreed with the **Product Owner** before **The Team** committed to the story, and define what the **Product Owner** will accept as complete. This makes it relatively easy to create some automated tests that test for these **Acceptance Criteria** and help your **Sprint Review** go as smoothly as possible.
 

--- a/public/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/rule.mdx
+++ b/public/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/rule.mdx
@@ -32,7 +32,7 @@ What happens when you leave all the testing to the end of the Sprint? You find t
 <endIntro />
 
 ![](/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/RuleBuildEverySprintBad.png)
-**❌ Figure: Bad example - if you don’t complete all the tasks the customer will not receive a build in the Sprint**
+❌ **Figure: Bad example - if you don’t complete all the tasks the customer will not receive a build in the Sprint**
 
 <imageEmbed
   alt="Image"
@@ -50,7 +50,7 @@ It is preferable to conduct a **Smoke Test** to make sure that you are comfortab
 In this scenario the “ **test please** ” with the customer happens outside of the current Sprint.
 
 ![](/uploads/rules/done-do-you-know-how-to-make-sure-you-deliver-a-build-thats-tested-every-sprint/RuleBuildEverySprintGOOD.png)
-**✅ Figure: Good example – Create a coded UI test for each story to prove that it is complete**  
+✅ **Figure: Good example – Create a coded UI test for each story to prove that it is complete**  
 
 If you are doing **Scrum** then you should have a **User Story** fleshed out with a set of **Acceptance Criteria** . These **Acceptance Criteria** are agreed with the **Product Owner** before **The Team** committed to the story, and define what the **Product Owner** will accept as complete. This makes it relatively easy to create some automated tests that test for these **Acceptance Criteria** and help your **Sprint Review** go as smoothly as possible.
 

--- a/public/uploads/rules/dones-do-you-include-relevant-info-from-attachments-in-the-body-of-the-email/rule.mdx
+++ b/public/uploads/rules/dones-do-you-include-relevant-info-from-attachments-in-the-body-of-the-email/rule.mdx
@@ -27,7 +27,7 @@ When someone sends you a .doc file or images that are attached when you reply 'd
 
 <endIntro />
 
-**Warning: ** iPhones strip inline images. If someone has replied to a beautifully crafted email (with inline images) with their iPhone, it will now be a clipped plain text email with your image as an attachment and would not be included in the "Reply All"...Grrrr
+**Warning:** iPhones strip inline images. If someone has replied to a beautifully crafted email (with inline images) with their iPhone, it will now be a clipped plain text email with your image as an attachment and would not be included in the "Reply All"...Grrrr
 
 So in such a case, you will want to skip that email and go back to the last HTML email and paste in the extra response. For clarity, add something like:
 

--- a/public/uploads/rules/event-roles/rule.mdx
+++ b/public/uploads/rules/event-roles/rule.mdx
@@ -38,10 +38,10 @@ The key responsibilities of an Event Organiser are:
 
 * **Event Approval** - get the event approved, & the budget locked in
 * **Define the event plan** - confirm the purpose, audience, date, venue, agenda, and success criteria.
-* **Coordinate speakers and content **- confirm speakers, topics, bios, slides, timings
+* **Coordinate speakers and content** - confirm speakers, topics, bios, slides, timings
 * **Manage promotion and registrations** – create the event page, promote the event, send reminders, and track attendee numbers
 * **Organise logistics** – confirm catering, AV, room setup, signage, name tags, accessibility needs, and any sponsor requirements
-* **Prepare the handover **– create a clear checklist/run sheet so the Event Master can confidently run the event on the day
+* **Prepare the handover** – create a clear checklist/run sheet so the Event Master can confidently run the event on the day
 * **Event Retrospective -** creating the Retro appointment, ROI reporting, and actioning feedback
 
 ## The Event Master
@@ -52,7 +52,7 @@ Their role is to turn the event plan into a smooth live experience. They keep th
 
 The key responsibilities of an Event Master are:
 
-* **Run the event checklist **– use the handover notes and run sheet to make sure everything is ready before attendees arrive
+* **Run the event checklist** – use the handover notes and run sheet to make sure everything is ready before attendees arrive
 * **Coordinate the team** – make sure staff and volunteers know their roles, timings, and responsibilities
 * **Support speakers and attendees** – welcome speakers, help with setup, answer attendee questions, and keep the room feeling organised
 * **Keep the event on time** – manage the agenda, introduce speakers, monitor session timing, and adjust if needed

--- a/public/uploads/rules/github-content-changes/rule.mdx
+++ b/public/uploads/rules/github-content-changes/rule.mdx
@@ -43,7 +43,7 @@ Open the Pull Request and examine the changes using the tabs:
 
 ## Approving / asking for extra changes
 
-Go to **Files changed | Review changes** and** **Select an option:
+Go to **Files changed | Review changes** and Select an option:
 
 1. Choose "Approve" to mark it as ready to go live
    Add a comment with feedback (if necessary)

--- a/public/uploads/rules/highlight-template-differences/rule.mdx
+++ b/public/uploads/rules/highlight-template-differences/rule.mdx
@@ -64,4 +64,4 @@ This email was completed a week later than normal because I didn't have a phone 
 Done - my voice message is "Hi, you've reached Jane Northwind from SSW. I don't use voice mail, so please send an SMS. Thanks!"
 
 :::
-**✅ Figure: Good example - The deviation from the standard template is clearly highlighted**  
+✅ **Figure: Good example - The deviation from the standard template is clearly highlighted**  

--- a/public/uploads/rules/highlight-template-differences/rule.mdx
+++ b/public/uploads/rules/highlight-template-differences/rule.mdx
@@ -64,4 +64,4 @@ This email was completed a week later than normal because I didn't have a phone 
 Done - my voice message is "Hi, you've reached Jane Northwind from SSW. I don't use voice mail, so please send an SMS. Thanks!"
 
 :::
-**✅ **Figure: Good example - The deviation from the standard template is clearly highlighted****  
+**✅ Figure: Good example - The deviation from the standard template is clearly highlighted**  

--- a/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
+++ b/public/uploads/rules/how-to-connect-multiple-homes-home-assistant/rule.mdx
@@ -31,7 +31,7 @@ This is the simplest approach. One app, multiple servers.
 #### Add your second (or third) server:
 
 1. Open the **Home Assistant** app
-2. Go to **Settings |** **Companion **app (or App Settings if you're not an administrator)
+2. Go to **Settings |** **Companion** app (or App Settings if you're not an administrator)
 3. Tap **Add Server**
 4. If your server is on the same network, it may appear automatically
 5. If not, tap **Enter address manually** and paste your Home Assistant URL

--- a/public/uploads/rules/manage-youtube-livestream-content/rule.mdx
+++ b/public/uploads/rules/manage-youtube-livestream-content/rule.mdx
@@ -46,12 +46,12 @@ With this in mind, there are several ways to manage your live stream content. Ea
 * After the livestream, take it down and upload it so it shows in the videos tab
 * Live is archived or zz'd
 
-**✅ Pros**
+✅ **Pros**
 
 - Consistent
 - Shows events on Videos tab
 
-**❌ Cons**
+❌ **Cons**
 
 - Lose views and engagement
 - Expensive
@@ -65,13 +65,13 @@ With this in mind, there are several ways to manage your live stream content. Ea
 
 * Add it to a playlist and make that playlist prominent on the YouTube home page
 
-**✅ Pros**
+✅ **Pros**
 
 - Engagement – Keeps views and comments
 - Cheap
 - Faster in outputting content
 
-**❌ Cons**
+❌ **Cons**
 
 - Less consistent
 - Stuck in the Live tab
@@ -85,12 +85,12 @@ With this in mind, there are several ways to manage your live stream content. Ea
 * Keep the unedited Live version online
 * Upload an edited version separately (cutting out all the fluff, fixing audio glitches, etc.)
 
-**✅ Pros**
+✅ **Pros**
 
 - Consistent and keep views
 - Shows your edited version on the videos tab
 
-**❌ Cons**
+❌ **Cons**
 
 - Could be viewed as repetitive content (debatable)
 - Expensive - more time spent in post-production

--- a/public/uploads/rules/manage-youtube-livestream-content/rule.mdx
+++ b/public/uploads/rules/manage-youtube-livestream-content/rule.mdx
@@ -29,7 +29,7 @@ Editing a livestream after it ends can be time-consuming and tedious. Raw footag
 
 ## Video type visibility 
 
-As of 27 Oct 2022, Shorts and live streams no longer appear in the videos tab. It’s now split into 3 categories: **Videos**, **Shorts**, and** Live**.
+As of 27 Oct 2022, Shorts and live streams no longer appear in the videos tab. It’s now split into 3 categories: **Videos**, **Shorts**, and **Live**.
 
 <imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Videos, Shorts, and Live tabs on your YouTube channel" src="/uploads/rules/manage-youtube-livestream-content/Videos-shorts-live__from_manage-youtube-livestream-content.jpg" />
 

--- a/public/uploads/rules/meeting-bookings/rule.mdx
+++ b/public/uploads/rules/meeting-bookings/rule.mdx
@@ -52,7 +52,7 @@ etc...
   figurePrefix="none"
   figure=""
 />
-**❌ **Figure: Bad example - It's hard to find a common time to book a meeting if you don't have scheduling automation****  
+**❌ Figure: Bad example - It's hard to find a common time to book a meeting if you don't have scheduling automation**  
 
 <imageEmbed
   alt="Image"

--- a/public/uploads/rules/meeting-bookings/rule.mdx
+++ b/public/uploads/rules/meeting-bookings/rule.mdx
@@ -52,7 +52,7 @@ etc...
   figurePrefix="none"
   figure=""
 />
-**❌ Figure: Bad example - It's hard to find a common time to book a meeting if you don't have scheduling automation**  
+❌ **Figure: Bad example - It's hard to find a common time to book a meeting if you don't have scheduling automation**  
 
 <imageEmbed
   alt="Image"

--- a/public/uploads/rules/optimize-ef-core-queries/rule.mdx
+++ b/public/uploads/rules/optimize-ef-core-queries/rule.mdx
@@ -167,7 +167,7 @@ catch
     await transaction.RollbackAsync();
 }
 ```
-**✅ Figure: Good example – Using an explicit transaction ensures all entities are added in a **single** transaction, reducing overhead and improving reliability**  
+**✅ Figure: Good example – Using an explicit transaction ensures all entities are added in a single transaction, reducing overhead and improving reliability**  
 
 ### Combining transactions with batching
 
@@ -193,7 +193,7 @@ catch
     await transaction.RollbackAsync();
 }
 ```
-**✅ Figure: Good example – Transactions combined with batching allow **efficient processing of large datasets** while keeping database transactions minimal**  
+**✅ Figure: Good example – Transactions combined with batching allow efficient processing of large datasets while keeping database transactions minimal**  
 
 ### When to use transactions
 

--- a/public/uploads/rules/optimize-ef-core-queries/rule.mdx
+++ b/public/uploads/rules/optimize-ef-core-queries/rule.mdx
@@ -27,7 +27,7 @@ foreach (var item in items)
     context.SaveChangesAsync();
 }
 ```
-**❌ Figure: Bad example – Calling `SaveChangesAsync()` inside a loop causes multiple database hits**  
+❌ **Figure: Bad example – Calling `SaveChangesAsync()` inside a loop causes multiple database hits**  
 
 Instead, use **bulk insertion** techniques like `AddRangeAsync()` and call `SaveChangesAsync()` once:
 
@@ -35,7 +35,7 @@ Instead, use **bulk insertion** techniques like `AddRangeAsync()` and call `Save
 context.MyEntities.AddRangeAsync(items);
 context.SaveChangesAsync();
 ```
-**✅ Figure: Good example – Using `AddRangeAsync()` minimizes database calls and improves performance**  
+✅ **Figure: Good example – Using `AddRangeAsync()` minimizes database calls and improves performance**  
 
 For **even larger datasets**, consider using external libraries like **EF Core Bulk Extensions** for optimized bulk insert performance.
 
@@ -52,7 +52,7 @@ foreach (var id in ids)
     ProcessEntity(entity);
 }
 ```
-**❌ Figure: Bad example – Each iteration performs a separate database query, leading to N queries**  
+❌ **Figure: Bad example – Each iteration performs a separate database query, leading to N queries**  
 
 If you know the approximate size of your dataset, and it is suitable for your database server, retrieve all records in a single query before processing:
 
@@ -63,7 +63,7 @@ foreach (var entity in entities)
     ProcessEntity(entity);
 }
 ```
-**✅ Figure: Good example – Fetches all required records in one query, reducing database load**  
+✅ **Figure: Good example – Fetches all required records in one query, reducing database load**  
 
 ### Handling large datasets
 
@@ -78,7 +78,7 @@ for (int i = 0; i < ids.Count; i += batchSize)
     ProcessEntities(entities);
 }
 ```
-**😐 Figure: OK example – Processes data in batches to balance efficiency and memory usage**  
+😐 **Figure: OK example – Processes data in batches to balance efficiency and memory usage**  
 
 The benefit of loading data into memory at once is that you can process it more efficiently without making multiple database calls. This opens up opportunities for parallel processing and other optimizations on the application side.
 
@@ -91,12 +91,12 @@ By default, EF Core tracks entities, which increases memory usage and slows down
 ```csharp
 var entities = context.MyEntities.ToListAsync();
 ```
-**❌ Figure: Bad example – Unnecessary tracking increases memory usage**  
+❌ **Figure: Bad example – Unnecessary tracking increases memory usage**  
 
 ```csharp
 var entities = context.MyEntities.AsNoTracking().ToListAsync();
 ```
-**✅ Figure: Good example – `AsNoTracking()` prevents EF Core from tracking entities, reducing memory usage**  
+✅ **Figure: Good example – `AsNoTracking()` prevents EF Core from tracking entities, reducing memory usage**  
 
 
 <boxEmbed
@@ -122,7 +122,7 @@ foreach (var entity in entities)
     context.SaveChangesAsync();
 }
 ```
-**❌ Figure: Bad example – Calling `SaveChangesAsync()` in a loop causes multiple transactions, slowing down performance**  
+❌ **Figure: Bad example – Calling `SaveChangesAsync()` in a loop causes multiple transactions, slowing down performance**  
 
 ```csharp
 foreach (var entity in entities)
@@ -131,7 +131,7 @@ foreach (var entity in entities)
 }
 context.SaveChangesAsync();
 ```
-**✅ Figure: Good example – Updates all entities in memory first, then commits changes in a single transaction**  
+✅ **Figure: Good example – Updates all entities in memory first, then commits changes in a single transaction**  
 
 Whenever possible, defer calling `SaveChangesAsync()` until after all modifications have been made.
 
@@ -148,7 +148,7 @@ foreach (var entity in entities)
     await context.SaveChangesAsync(); // Each iteration creates a separate transaction
 }
 ```
-**❌ Figure: Bad example – Each `SaveChangesAsync()` call inside the loop creates a separate transaction, leading to unnecessary database overhead**  
+❌ **Figure: Bad example – Each `SaveChangesAsync()` call inside the loop creates a separate transaction, leading to unnecessary database overhead**  
 
 ```csharp
 using var transaction = await context.Database.BeginTransactionAsync();
@@ -167,7 +167,7 @@ catch
     await transaction.RollbackAsync();
 }
 ```
-**✅ Figure: Good example – Using an explicit transaction ensures all entities are added in a single transaction, reducing overhead and improving reliability**  
+✅ **Figure: Good example – Using an explicit transaction ensures all entities are added in a single transaction, reducing overhead and improving reliability**  
 
 ### Combining transactions with batching
 
@@ -193,7 +193,7 @@ catch
     await transaction.RollbackAsync();
 }
 ```
-**✅ Figure: Good example – Transactions combined with batching allow efficient processing of large datasets while keeping database transactions minimal**  
+✅ **Figure: Good example – Transactions combined with batching allow efficient processing of large datasets while keeping database transactions minimal**  
 
 ### When to use transactions
 

--- a/public/uploads/rules/page-indexed-by-google/rule.mdx
+++ b/public/uploads/rules/page-indexed-by-google/rule.mdx
@@ -44,8 +44,8 @@ If you can't find it, go to [Google's Search Console](https://search.google.com/
 
 Benefits to using the Google Search Console:
 
-* **Shows exact crawl date **- is this out of date?
-* **Shows clear error message **- if your page didn't index, you'll know why
+* **Shows exact crawl date** - is this out of date?
+* **Shows clear error message** - if your page didn't index, you'll know why
 * Let's you force a re-crawl
 
 <imageEmbed alt="Image" size="medium" showBorder={false} figurePrefix="none" figure="Using Google Search Console to Check Index Status" src="/uploads/rules/page-indexed-by-google/google-search-console.png" />

--- a/public/uploads/rules/pbi-titles/rule.mdx
+++ b/public/uploads/rules/pbi-titles/rule.mdx
@@ -49,12 +49,12 @@ Usually, sticking to the business value is a good rule of thumb.
 ::: grey
 Fix broken dependency
 :::
-**❌ **Figure: Bad Example - Many Product Owners would have no idea what this means****  
+**❌ Figure: Bad Example - Many Product Owners would have no idea what this means**  
 
 ::: grey
 IDateTimeProvider - New 3rd party code breaks app
 :::
-**✅ **Figure: Good Example - The Product Owner can see that there is new code that has broken the app****  
+**✅ Figure: Good Example - The Product Owner can see that there is new code that has broken the app**  
 
 ### Importance
 
@@ -65,12 +65,12 @@ Adding a fire emoji to critical PBIs helps communicate that it should be actione
 ::: grey
 CI/CD - Deployment pipeline broken
 :::
-**❌ **Figure: Bad Example - The Product Owner might not realise this is a crucial PBI****  
+**❌ Figure: Bad Example - The Product Owner might not realise this is a crucial PBI**  
 
 ::: grey
 CI/CD - Deployment pipeline broken 🔥
 :::
-**✅ **Figure: Good Example - The Product Owner won't miss this PBI with the help of an emoji****  
+**✅ Figure: Good Example - The Product Owner won't miss this PBI with the help of an emoji**  
 
 ### Prefixes
 
@@ -79,12 +79,12 @@ Prefixes help the team understand the area a PBI is touching. For example, prefi
 ::: grey
 Add new profile picture
 :::
-**❌ **Figure: Bad Example - It isn't clear where the profile picture is going****  
+**❌ Figure: Bad Example - It isn't clear where the profile picture is going**  
 
 ::: grey
 Company Contacts - Add new profile picture
 :::
-**✅ **Figure: Good Example - It's immediately clear that company contacts will get a profile picture****  
+**✅ Figure: Good Example - It's immediately clear that company contacts will get a profile picture**  
 
 ### Type of PBI
 
@@ -95,12 +95,12 @@ Adding an emoji at the start of the PBI communicates the type at a glance.
 ::: grey
 Company Details - Cannot save changes
 :::
-**❌ **Figure: Bad Example - The Product Owner needs to read and process the whole title to realise it is a bug****  
+**❌ Figure: Bad Example - The Product Owner needs to read and process the whole title to realise it is a bug**  
 
 ::: grey
 Company Contacts - Add new profile picture
 :::
-**✅ **Figure: Good Example - Straightaway, the Product Owner can see from the emoji that it is a bug****  
+**✅ Figure: Good Example - Straightaway, the Product Owner can see from the emoji that it is a bug**  
 
 ### Number of words
 
@@ -109,9 +109,9 @@ Sometimes less is more. Try to limit the number of words included and make those
 ::: grey
 Company Details - Add a new feature with the functionality to set a description in order to improve user comprehension
 :::
-**❌ **Figure: Bad Example - The description is needlessly wordy****  
+**❌ Figure: Bad Example - The description is needlessly wordy**  
 
 ::: grey
 Company Details - Add a description to improve user comprehension
 :::
-**✅ **Figure: Good Example - The description is half as long but communicates the same info****
+**✅ Figure: Good Example - The description is half as long but communicates the same info**

--- a/public/uploads/rules/pbi-titles/rule.mdx
+++ b/public/uploads/rules/pbi-titles/rule.mdx
@@ -49,12 +49,12 @@ Usually, sticking to the business value is a good rule of thumb.
 ::: grey
 Fix broken dependency
 :::
-**❌ Figure: Bad Example - Many Product Owners would have no idea what this means**  
+❌ **Figure: Bad Example - Many Product Owners would have no idea what this means**  
 
 ::: grey
 IDateTimeProvider - New 3rd party code breaks app
 :::
-**✅ Figure: Good Example - The Product Owner can see that there is new code that has broken the app**  
+✅ **Figure: Good Example - The Product Owner can see that there is new code that has broken the app**  
 
 ### Importance
 
@@ -65,12 +65,12 @@ Adding a fire emoji to critical PBIs helps communicate that it should be actione
 ::: grey
 CI/CD - Deployment pipeline broken
 :::
-**❌ Figure: Bad Example - The Product Owner might not realise this is a crucial PBI**  
+❌ **Figure: Bad Example - The Product Owner might not realise this is a crucial PBI**  
 
 ::: grey
 CI/CD - Deployment pipeline broken 🔥
 :::
-**✅ Figure: Good Example - The Product Owner won't miss this PBI with the help of an emoji**  
+✅ **Figure: Good Example - The Product Owner won't miss this PBI with the help of an emoji**  
 
 ### Prefixes
 
@@ -79,12 +79,12 @@ Prefixes help the team understand the area a PBI is touching. For example, prefi
 ::: grey
 Add new profile picture
 :::
-**❌ Figure: Bad Example - It isn't clear where the profile picture is going**  
+❌ **Figure: Bad Example - It isn't clear where the profile picture is going**  
 
 ::: grey
 Company Contacts - Add new profile picture
 :::
-**✅ Figure: Good Example - It's immediately clear that company contacts will get a profile picture**  
+✅ **Figure: Good Example - It's immediately clear that company contacts will get a profile picture**  
 
 ### Type of PBI
 
@@ -95,12 +95,12 @@ Adding an emoji at the start of the PBI communicates the type at a glance.
 ::: grey
 Company Details - Cannot save changes
 :::
-**❌ Figure: Bad Example - The Product Owner needs to read and process the whole title to realise it is a bug**  
+❌ **Figure: Bad Example - The Product Owner needs to read and process the whole title to realise it is a bug**  
 
 ::: grey
 Company Contacts - Add new profile picture
 :::
-**✅ Figure: Good Example - Straightaway, the Product Owner can see from the emoji that it is a bug**  
+✅ **Figure: Good Example - Straightaway, the Product Owner can see from the emoji that it is a bug**  
 
 ### Number of words
 
@@ -109,9 +109,9 @@ Sometimes less is more. Try to limit the number of words included and make those
 ::: grey
 Company Details - Add a new feature with the functionality to set a description in order to improve user comprehension
 :::
-**❌ Figure: Bad Example - The description is needlessly wordy**  
+❌ **Figure: Bad Example - The description is needlessly wordy**  
 
 ::: grey
 Company Details - Add a description to improve user comprehension
 :::
-**✅ Figure: Good Example - The description is half as long but communicates the same info**
+✅ **Figure: Good Example - The description is half as long but communicates the same info**

--- a/public/uploads/rules/practice-makes-perfect/rule.mdx
+++ b/public/uploads/rules/practice-makes-perfect/rule.mdx
@@ -34,7 +34,7 @@ You need to practice it so that you know your stuff backwards as well as forward
 
 
 <youtubeEmbed url="https://youtu.be/jPwNwNdE7pE" description={""} />
-**✅ Video: Good example - Practice your content forwards and backwards to be as good as Victor Borge**  
+✅ **Video: Good example - Practice your content forwards and backwards to be as good as Victor Borge**  
 
 These 5 steps can improve the delivery of a speech immensely (inspired by [Vinh Giang](https://www.vinhgiang.com/)):
 

--- a/public/uploads/rules/practice-makes-perfect/rule.mdx
+++ b/public/uploads/rules/practice-makes-perfect/rule.mdx
@@ -34,7 +34,7 @@ You need to practice it so that you know your stuff backwards as well as forward
 
 
 <youtubeEmbed url="https://youtu.be/jPwNwNdE7pE" description={""} />
-**✅ **Video: Good example - Practice your content forwards and backwards to be as good as Victor Borge****  
+**✅ Video: Good example - Practice your content forwards and backwards to be as good as Victor Borge**  
 
 These 5 steps can improve the delivery of a speech immensely (inspired by [Vinh Giang](https://www.vinhgiang.com/)):
 

--- a/public/uploads/rules/production-do-you-manage-audience-interactivity/rule.mdx
+++ b/public/uploads/rules/production-do-you-manage-audience-interactivity/rule.mdx
@@ -29,7 +29,7 @@ Try and give firm guidelines when you start as to the correct way to ask a ques
 <boxEmbed
   style="greybox"
   body={<>
-    **Speaker: ***"No questions please. Ask your questions at the end"*
+    **Speaker:** *"No questions please. Ask your questions at the end"*
   </>}
   figurePrefix="bad"
   figure="This kills the sense of interactivity that is so appealing about live presentations"

--- a/public/uploads/rules/production-do-you-set-up-the-speaker-prior-to-recording/rule.mdx
+++ b/public/uploads/rules/production-do-you-set-up-the-speaker-prior-to-recording/rule.mdx
@@ -46,7 +46,7 @@ The people who watch your video need to know what the questions were in order to
 <boxEmbed
   style="greybox"
   body={<>
-    **Audience member: ***"Why should we do things your way?*
+    **Audience member:** *"Why should we do things your way?*
     
     
     **Speaker:** *"Because..."*
@@ -58,7 +58,7 @@ The people who watch your video need to know what the questions were in order to
 <boxEmbed
   style="greybox"
   body={<>
-    **Audience member: ***"Why should we do things your way?"*
+    **Audience member:** *"Why should we do things your way?"*
     
     
     **Speaker:** *"The reason you should do things this is way is because..."*

--- a/public/uploads/rules/scrum/rule.mdx
+++ b/public/uploads/rules/scrum/rule.mdx
@@ -84,7 +84,7 @@ uri: scrum
 注意 #1: Product Owner（通常是客户）是没必要参加 Scrum 会议的，如果他想要参加，让他保证不要说话。
 注意 #2: 如果你正在一个未经批准的迭代中，或者是正在做临时特别任务，那么 Product Owner 参加是最好的了。([临时特别任务](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBeingSoftwareConsultantsDealingWithClients.aspx#AdHocManagedWork))
 
-**建议** ** 4：** **在 Scrum 会议开始前你是否更新了任务状态** **?**
+建议 4：在 Scrum 会议开始前你是否更新了任务状态?
 
 提前保证团队成员的任务状态被更新，这样会议会更有效率。
 SSW 规则 [Do you update your tasks before the daily stand-up meeting?](/meeting-do-you-update-your-tasks-before-the-daily-scrum)
@@ -93,15 +93,15 @@ SSW 规则 [Do you update your tasks before the daily stand-up meeting?](/meetin
 
 建议 6：不要打电话+不要检查邮件+不要分心科技可以使开会的人们失去了焦点，会议的焦点是使人们通过分享他们正在做什么来同步团队进度。在 Scrum 会议中通过禁止邮件，短信和电话以保证人们不会被分心。
 
-**
-建议** ** 7：** **使用一个任务板（使用电子版的更好** **)**
+
+建议 7：使用一个任务板（使用电子版的更好)
 
 人们可以通过 任务板 看到 当前正在讨论的问题。
 
 ![](/uploads/rules/scrum/tfspreviewtaskboard.png)
 **图：TFS Preview 中的任务板 (TFS 2012)**
 
-建议\*\* ** 8：** **带上纸和笔**
+建议 8：带上纸和笔
 
 带上纸和笔将事情的摘要记录下来，使用一个白板记录讨论中出现的问题也很有用。
 
@@ -117,7 +117,7 @@ SSW 规则 [Do you update your tasks before the daily stand-up meeting?](/meetin
 
 \*\*
 
-**建议 11： 如何将 Scrum 会议填入你的工时表中？ **
+建议 11：如何将 Scrum 会议填入你的工时表中？
 
 一旦你完成了 Scrum 会议，在你的工时表中添加'S'（[SSW 建议:更好的填写工时表](http://www.ssw.com.au/ssw/Standards/Rules/RulesToBetterTimesheets.aspx)）
 

--- a/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
+++ b/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
@@ -51,7 +51,7 @@ Dave
   figurePrefix="none"
   figure=""
 />
-**❌ **Figure: Bad example - run SQL scripts manually****  
+**❌ Figure: Bad example - run SQL scripts manually**  
 
 
 <boxEmbed

--- a/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
+++ b/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
@@ -51,7 +51,7 @@ Dave
   figurePrefix="none"
   figure=""
 />
-**❌ Figure: Bad example - run SQL scripts manually**  
+❌ **Figure: Bad example - run SQL scripts manually**  
 
 
 <boxEmbed

--- a/public/uploads/rules/untapped-keywords/rule.mdx
+++ b/public/uploads/rules/untapped-keywords/rule.mdx
@@ -31,13 +31,13 @@ Choosing the right keywords helps people discover your videos on YouTube. While 
 
 To find the right keywords:
 
-1\. **Create a list of seed keywords **– Broad topics related to your content (for example: *social media*, *LinkedIn marketing*, *content marketing*, or for a fitness channel: *fat loss*, *kettlebell workout*, or *cardio workout*)
+1\. **Create a list of seed keywords** – Broad topics related to your content (for example: *social media*, *LinkedIn marketing*, *content marketing*, or for a fitness channel: *fat loss*, *kettlebell workout*, or *cardio workout*)
 
 2\. **Enter each seed keyword into YouTube Search and note the suggested searches** - These suggestions reflect what people are actively searching for
 
 3\. **Evaluate the competition for each keyword** - Look for keywords that have good search demand but relatively low competition
 
-4\. **Use a keyword research tool such as **[**TubeBuddy**](https://www.tubebuddy.com) - Compare keyword search volume and competition
+4\. **Use a keyword research tool such as** [**TubeBuddy**](https://www.tubebuddy.com) - Compare keyword search volume and competition
 
 5\. **Choose and use the keywords that are relevant to your content** 
 

--- a/public/uploads/rules/uri-url-slug/rule.mdx
+++ b/public/uploads/rules/uri-url-slug/rule.mdx
@@ -98,7 +98,7 @@ Example - the slug is at the end of a full URL (see bold):
 
 ## When should you use each term?
 
-Use **URI **when speaking technically about identifiers. E.g. APIs, specifications.
+Use **URI** when speaking technically about identifiers. E.g. APIs, specifications.
 
 Use **URL** when referring to a full web address. E.g. links in pages, emails, or documentation.
 

--- a/public/uploads/rules/warn-then-call/rule.mdx
+++ b/public/uploads/rules/warn-then-call/rule.mdx
@@ -51,7 +51,7 @@ A good way to initiate a call is to warm them up by giving a warning (e.g. *“C
 <boxEmbed
   style="info"
   body={<>
-    **Hot Calling **- The only good reason not to give a warning before calling is when the person is already expecting your pre-arranged call.
+    **Hot Calling** - The only good reason not to give a warning before calling is when the person is already expecting your pre-arranged call.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/wechat-for-business/rule.mdx
+++ b/public/uploads/rules/wechat-for-business/rule.mdx
@@ -49,19 +49,19 @@ For these businesses, the goal is not to enter China; it is to reach customers t
   body={<>
     #### Common Examples
     
-    ###### **🏫 Private Schools & Childcare Centres**
+    ###### 🏫 **Private Schools & Childcare Centres**
     
     Chinese-speaking parents often prefer to receive updates via WeChat rather than email.
     
     Schools can use a **Service Account** for announcements and event reminders, WeChat Groups for community engagement, and a **Mini-Program** for enrolments, event registrations, payments, permission slips, and photo sharing.
     
-    ###### **🏨 Tourism & Attractions**
+    ###### 🏨 **Tourism & Attractions**
     
     A hotel, museum, theme park, or tourist attraction can use a **Mini-Program** to sell tickets, manage bookings, and promote special events.
     
     **Moments Ads** can target Chinese tourists before or during their trip.
     
-    ###### **🏥 Healthcare Providers**
+    ###### 🏥 **Healthcare Providers**
     
     Medical clinics and hospitals can use a **Service Account** to send appointment confirmations, test result notifications, and follow-up reminders.
     

--- a/public/uploads/rules/wechat-for-business/rule.mdx
+++ b/public/uploads/rules/wechat-for-business/rule.mdx
@@ -154,7 +154,7 @@ Think of a WeChat Mini-Program as a web app that runs directly inside WeChat. Wh
 * **Cheaper to build** - Development typically costs around 60% less than building a standalone app
 * **Plugs into the WeChat ecosystem** - Works hand-in-hand with your other WeChat tools (Service Account, WeCom, etc.), so you can turn followers into paying customers without sending them elsewhere
 * **Build almost anything** - Use it to run your own online store, SaaS portal, booking system, or membership hub
-* **App-like performance **-** **Built on Tencent's proprietary dual-thread JavaScript framework, Mini Programs provide a smooth, responsive user experience without requiring a separate app download
+* **App-like performance** - Built on Tencent's proprietary dual-thread JavaScript framework, Mini Programs provide a smooth, responsive user experience without requiring a separate app download
 
 ## 6. 📈Do you need WeCom for your community?
 
@@ -204,8 +204,8 @@ Moments Ads are used by big companies like Volvo.
 
 ### Limitations
 
-* **Higher Budget Requirements **- Moments Ads are generally better suited to medium and large campaigns
-* **Limited Self-Service Options **- Most campaigns are managed through Tencent or an authorized agency
+* **Higher Budget Requirements** - Moments Ads are generally better suited to medium and large campaigns
+* **Limited Self-Service Options** - Most campaigns are managed through Tencent or an authorized agency
 
 ### Industry Restrictions
 

--- a/public/uploads/rules/wechat-for-business/rule.mdx
+++ b/public/uploads/rules/wechat-for-business/rule.mdx
@@ -156,7 +156,7 @@ Think of a WeChat Mini-Program as a web app that runs directly inside WeChat. Wh
 * **Build almost anything** - Use it to run your own online store, SaaS portal, booking system, or membership hub
 * **App-like performance** - Built on Tencent's proprietary dual-thread JavaScript framework, Mini Programs provide a smooth, responsive user experience without requiring a separate app download
 
-## 6. 📈Do you need WeCom for your community?
+## 6. 📈 Do you need WeCom for your community?
 
 <youtubeEmbed url="https://www.youtube.com/watch?v=ufrtJshWj7s" description="Video: Key Benefits of WeCom" />
 
@@ -188,7 +188,7 @@ Think of WeCom as a more powerful version of Microsoft Teams or Slack: it handle
 | **Analytics**             | None                                            | Full dashboard - track growth, engagement, and customer churn  |
 | **Integrations**          | Strictly banned                                 | Open APIs (\~200) for global CRMs, automation, and AI          |
 
-## 8. What are Moments Ads (💰Expensive)?
+## 8. What are Moments Ads (💰 Expensive)?
 
 WeChat’s native feed ads display seamlessly within users’ personal timelines, functioning exactly like Instagram or Facebook Feed Ads.
 

--- a/public/uploads/rules/what-is-the-best-tool-for-your-email-marketing/rule.mdx
+++ b/public/uploads/rules/what-is-the-best-tool-for-your-email-marketing/rule.mdx
@@ -58,7 +58,7 @@ Email marketing is very important for your company and you need to use the best 
 - Nice - Dynamics CRM Integration (Built-in)
 - No end to end tracking of a purchase
 - Very cheap - $10 per month
-**❌ Bad example - Does not match requirements**  
+❌ **Bad example - Does not match requirements**  
 
 ### 3rd Party Options:
 
@@ -69,7 +69,7 @@ Email marketing is very important for your company and you need to use the best 
 - No Dynamics CRM integration
 - No end to end tracking of a purchase
 - Cheap - $240 per month
-**❌ Bad example - Does not match requirements**  
+❌ **Bad example - Does not match requirements**  
 
 **2. Campaign Monitor (basic)**
 
@@ -78,7 +78,7 @@ Email marketing is very important for your company and you need to use the best 
 - No Dynamics CRM integration
 - No end to end tracking of a purchase
 - Average price - $1,250 per month
-**❌ Bad example - Does not match requirements, expensive**  
+❌ **Bad example - Does not match requirements, expensive**  
 
 **3. Active Campaign (used at SSW)**
 
@@ -87,7 +87,7 @@ Email marketing is very important for your company and you need to use the best 
 - No Dynamics CRM integration
 - Nice - end to end tracking of a purchase
 - Cheap - $65 month
-**❌ Bad example - Does not match requirements, quite expensive**  
+❌ **Bad example - Does not match requirements, quite expensive**  
 
 **4. [CRM Click Dimensions (on premise)](https://clickdimensions.com/pricing/)**
 
@@ -98,7 +98,7 @@ Email marketing is very important for your company and you need to use the best 
 - Craig Bailey SEO expert says _"I have found the UI clunky and the support issues painful"_
 - Nice - end to end tracking of a purchase
 - Average price - $1,000 per month
-**✅ Good example - Match requirements**  
+✅ **Good example - Match requirements**  
 
 **5. Infusionsoft**
 
@@ -107,7 +107,7 @@ Email marketing is very important for your company and you need to use the best 
 - No Dynamics CRM integration
 - Nice - end to end tracking of a purchase
 - Average price - Unknown (requires quote)
-**❌ Bad example - Does not match requirements**  
+❌ **Bad example - Does not match requirements**  
 
 **6. Hubspot**
 
@@ -118,4 +118,4 @@ Email marketing is very important for your company and you need to use the best 
 - Craig Bailey SEO expert says "I have found the UI clunky and the support issues painful"
 - Nice - end to end tracking of a purchase
 - Very Expensive - $3,200 per month + Integration cost $500 per month
-**✅ Good example - Match requirements, but expensive**
+✅ **Good example - Match requirements, but expensive**

--- a/public/uploads/rules/what-is-the-best-tool-for-your-email-marketing/rule.mdx
+++ b/public/uploads/rules/what-is-the-best-tool-for-your-email-marketing/rule.mdx
@@ -42,7 +42,7 @@ Email marketing is very important for your company and you need to use the best 
 
 - E.g. at SSW we have 500,000 sent emails per year
 
-**Step #3: ** Get your requirements in order.
+**Step #3:** Get your requirements in order.
 
 - E.g. for SSW it is:
 

--- a/public/uploads/rules/when-do-you-use-silverlight/rule.mdx
+++ b/public/uploads/rules/when-do-you-use-silverlight/rule.mdx
@@ -51,7 +51,7 @@ YES. You can access the camera & microphone from Silverlight. System.Windows. Me
 
 YES. System.Net.Sockets.Socket Class provides a set of methods and properties for network communications. The Socket class allows you to perform asynchronous data transfer using any of the communication protocols listed in the ProtocolType enumeration. Currently, the only supported ProtocolType is the TCP protocol. Supported Version Silverlight 4 & 3.
 
-## For interactive charts in a BI (** **_Business Intelligence_** **) solution
+## For interactive charts in a BI (_Business Intelligence_) solution
 
 NO. There are some aftermarket solutions available. Notable are Telerik Silverlight Control, Infragistics Silverlight Data Visualization.
 Telerik provides BI solution using Advanced GridView, Charts with zooming, scrolling, multi-level resource grouping. Both solutions use shared API across Silverlight and WPF, as a result product users can visualize data in more flexible way.

--- a/scripts/check-malformed-bold/check-malformed-bold.js
+++ b/scripts/check-malformed-bold/check-malformed-bold.js
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+/**
+ * Checks Markdown/MDX content for malformed bold formatting where whitespace
+ * has been included immediately inside the `**` markers, e.g.
+ *
+ *   ** Note:**      -> should be **Note:**
+ *   **Note: **      -> should be **Note:**
+ *   ** important ** -> should be **important**
+ *
+ * These are produced when an editor bolds a selection that includes a leading
+ * or trailing space. Tina's preview looks fine but the saved Markdown renders
+ * incorrectly (the `**` show up as literal characters).
+ *
+ * If no argument is supplied, all tracked `.md`/`.mdx` files are scanned.
+ * A comma-separated list of files can be passed as the first argument (used by CI).
+ *
+ * Environment variables:
+ *   BOLD_REPORT_PATH - If set, writes a Markdown report to this path (used by CI to post PR comments).
+ *
+ * Detection is deliberately conservative to avoid false positives:
+ *   - YAML frontmatter is skipped.
+ *   - Fenced code blocks (``` / ~~~) are skipped.
+ *   - Inline code (`...`) and escaped characters (`\*`) are masked with a
+ *     same-length filler so `**` inside them is never treated as a marker.
+ *     This keeps valid bold-wrapping-inline-code such as **`Foo`** from being
+ *     flagged.
+ */
+
+/* --------------------------------- helpers -------------------------------- */
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
+    dir = path.dirname(dir);
+  }
+  return startDir;
+}
+
+function walk(dir, acc) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (/\.mdx?$/.test(entry.name)) acc.push(full);
+  }
+  return acc;
+}
+
+/**
+ * Return a same-length copy of the line where escaped chars and inline-code
+ * spans are replaced by 'X', so `**` inside them is neutralised. Positions are
+ * preserved so findings map back to the original line.
+ */
+function mask(line) {
+  const s = [...line];
+  const n = s.length;
+  // escaped: backslash + next char -> XX
+  for (let i = 0; i < n - 1; i++) {
+    if (s[i] === "\\") {
+      s[i] = "X";
+      s[i + 1] = "X";
+      i++;
+    }
+  }
+  // inline code: matching backtick runs
+  let i = 0;
+  while (i < n) {
+    if (s[i] === "`") {
+      let j = i;
+      while (j < n && s[j] === "`") j++;
+      const run = j - i;
+      let k = j;
+      let close = -1;
+      while (k < n) {
+        if (s[k] === "`") {
+          let m = k;
+          while (m < n && s[m] === "`") m++;
+          if (m - k === run) {
+            close = k;
+            break;
+          }
+          k = m;
+        } else k++;
+      }
+      if (close === -1) {
+        for (let t = i; t < n; t++) s[t] = "X";
+        break;
+      }
+      for (let t = i; t < close + run; t++) s[t] = "X";
+      i = close + run;
+    } else i++;
+  }
+  return s.join("");
+}
+
+// A bold span: ** ... ** where the inner text contains no `**`.
+const BOLD = /\*\*((?:[^*]|\*(?!\*))+?)\*\*/g;
+
+function findMalformed(line) {
+  const masked = mask(line);
+  const findings = [];
+  let m;
+  BOLD.lastIndex = 0;
+  while ((m = BOLD.exec(masked)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    const inner = line.slice(start + 2, end - 2);
+    if (inner !== inner.trim()) {
+      findings.push({ col: start + 1, text: line.slice(start, end) });
+    }
+  }
+  return findings;
+}
+
+function scanFile(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const lines = text.split("\n");
+  const findings = [];
+  let inFence = false;
+  let fence = null;
+  let inFrontmatter = false;
+
+  for (let idx = 0; idx < lines.length; idx++) {
+    const line = lines[idx];
+    const trimmedStart = line.replace(/^\s+/, "");
+
+    if (idx === 0 && trimmedStart === "---") {
+      inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter) {
+      if (trimmedStart === "---") inFrontmatter = false;
+      continue;
+    }
+
+    const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0].repeat(3);
+      if (!inFence) {
+        inFence = true;
+        fence = marker;
+      } else if (line.trim().startsWith(fence)) {
+        inFence = false;
+        fence = null;
+      }
+      continue;
+    }
+    if (inFence) continue;
+
+    for (const f of findMalformed(line)) {
+      findings.push({ line: idx + 1, col: f.col, text: f.text });
+    }
+  }
+  return findings;
+}
+
+/* ---------------------------------- main ---------------------------------- */
+
+const repoRoot = findRepoRoot(process.cwd());
+const rawArg = process.argv[2] || "";
+
+let files;
+if (rawArg.trim()) {
+  files = rawArg
+    .split(",")
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .filter((f) => /\.mdx?$/.test(f))
+    .map((f) => (path.isAbsolute(f) ? f : path.join(repoRoot, f)))
+    .filter((f) => fs.existsSync(f));
+} else {
+  files = walk(repoRoot, []).filter((f) => {
+    const rel = path.relative(repoRoot, f);
+    return (
+      rel.startsWith("public/uploads/rules") ||
+      rel.startsWith("categories") ||
+      rel.startsWith("homepage") ||
+      !rel.includes(path.sep) // top-level .md files (README, etc.)
+    );
+  });
+}
+
+let total = 0;
+const report = [];
+for (const file of files) {
+  const findings = scanFile(file);
+  if (findings.length === 0) continue;
+  total += findings.length;
+  const rel = path.relative(repoRoot, file);
+  for (const f of findings) {
+    console.log(`${rel}:${f.line}:${f.col}  ${JSON.stringify(f.text)}`);
+    report.push(`- \`${rel}:${f.line}\` — \`${f.text}\``);
+  }
+}
+
+if (process.env.BOLD_REPORT_PATH && report.length) {
+  const md = [
+    "## :warning: Malformed bold formatting",
+    "",
+    "Bold markdown must not contain whitespace immediately inside the `**` markers.",
+    "",
+    "| ❌ Incorrect | ✅ Correct |",
+    "| --- | --- |",
+    "| `** Note:**` | `**Note:**` |",
+    "| `**Note: **` | `**Note:**` |",
+    "| `This is ** important **` | `This is **important**` |",
+    "",
+    "Please fix the following:",
+    "",
+    ...report,
+    "",
+  ].join("\n");
+  fs.writeFileSync(process.env.BOLD_REPORT_PATH, md);
+}
+
+if (total > 0) {
+  console.error(
+    `\n❌ Found ${total} malformed bold occurrence(s) (whitespace inside ** markers).`
+  );
+  process.exit(1);
+}
+
+console.log("✅ No malformed bold formatting found.");

--- a/scripts/check-malformed-bold/package.json
+++ b/scripts/check-malformed-bold/package.json
@@ -1,0 +1,10 @@
+{
+  "description": "Check Markdown/MDX for malformed bold formatting (whitespace inside ** markers)",
+  "name": "check-malformed-bold",
+  "private": true,
+  "scripts": {
+    "start": "node check-malformed-bold.js"
+  },
+  "type": "module",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Fixes #13159.

Bold markdown that has whitespace immediately inside the `**` markers (e.g. `** Note:**`, `**Tip: **`) renders the `**` as literal characters. Tina lets editors bold a selection that includes a leading/trailing space, which produces this. This PR fixes every existing occurrence and adds a validator + GitHub Action so it can't easily be reintroduced.

## Content fixes

- **36 `.mdx` files, ~70 malformed occurrences** corrected.
- Patterns found and fixed:
  - `** text**`, `**text **`, `** text **` (leading/trailing space inside markers)
  - non-breaking space (`\u00a0`) inside markers — e.g. `**Warning:\u00a0**`
  - emoji "Figure:"/"Video:" captions where the emoji was split from the caption and left a dangling `****` — e.g. `**✅ **Figure: …****` → `**✅ Figure: …**`
  - invalid **nested** bold inside a caption — e.g. `**… in a **single** transaction …**` → one bold span
  - **escaped closing markers** — `**D:\*\*` was meant to be `**D:**`
  - a few corrupted Chinese headings in `scrum` that were plain text everywhere else
- Only bold markers and their internal whitespace changed. Wording, URLs, images, and code blocks are untouched. All 36 files still compile via `check-mdx`.

## Validation (so it can't come back)

- **`scripts/check-malformed-bold/check-malformed-bold.js`** — Node validator that scans `.md`/`.mdx`, reports `file:line`, and **exits non-zero** when whitespace is found inside `**` markers. It masks inline code and escaped asterisks with same-length filler, so valid bold — including bold that wraps inline code like **`` `code` ``** — is never flagged. Frontmatter and fenced code blocks are skipped.
- **`.github/workflows/check-malformed-bold.yml`** — runs the validator against changed `.md`/`.mdx` files on every PR, posts the findings as a PR comment, and fails the check.

## Docs

- `AGENTS.md` — a contributor note (`❌ ** Note: **` → `✅ **Note:**`) and the validation command.

## Verification

- Validator run against the cleaned repo: **0 findings** (passes).
- Validator tested against representative malformed samples: caught `** Note:**`, `**Tip: **`, `** important **`.
- Confirmed valid bold is **not** flagged: `**Note:**`, **`` `code` ``**-wrapping, inline code, escaped `\*\*`, and multi-bold lines like `**Videos**, **Shorts**, and **Live**`.
- `check-mdx` passes on all 36 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
