### PR TITLE
Rename category to Rules to Better Wizards

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -15,7 +15,7 @@ index:
 - category: categories/design/rules-to-better-forms.mdx
 - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
 - category: categories/design/rules-to-better-data-visualization.mdx
-- category: categories/design/rules-to-better-interfaces-wizards.mdx
+- category: categories/design/rules-to-better-wizards.mdx
 - category: categories/design/rules-to-better-figma.mdx
 - category: categories/design/rules-to-better-logos.mdx
 

--- a/categories/design/rules-to-better-wizards.mdx
+++ b/categories/design/rules-to-better-wizards.mdx
@@ -1,11 +1,12 @@
 ---
 _template: category
 type: category
-title: Rules to Better Interfaces (Wizards)
+title: Rules to Better Wizards
 guid: fae34265-2b20-4081-b9a2-0ab7a6175737
-uri: rules-to-better-interfaces-wizards
+uri: rules-to-better-wizards
 redirects:
  - rules-to-better-interfaces-(wizards)
+ - rules-to-better-interfaces-wizards
 seoDescription: How to design effective wizard interfaces. Best practices for multi-step workflows, navigation, and user guidance in software applications.
 index:
 - rule: public/uploads/rules/add-introduction-screen-before-settings/rule.mdx

--- a/public/uploads/rules/add-introduction-screen-before-settings/rule.mdx
+++ b/public/uploads/rules/add-introduction-screen-before-settings/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Enhance user experience by adding an introductory screen with a 
 title: Do you add an useful introduction screen (with an image of where it is going)
   prior to settings?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: add-introduction-screen-before-settings
 ---

--- a/public/uploads/rules/back-buttons/rule.mdx
+++ b/public/uploads/rules/back-buttons/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Always include a "Back" button in multi-step wizards to improve 
   reduce frustration, and let users safely navigate between steps.
 title: Do you include a “Back” button in multi-step wizards?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
   - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
 type: rule
 uri: back-buttons

--- a/public/uploads/rules/do-you-know-the-difference-between-close-and-cancel/rule.mdx
+++ b/public/uploads/rules/do-you-know-the-difference-between-close-and-cancel/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Mastering UI best practices, learn the difference between "Close
   and "Cancel" buttons to ensure seamless user experience.
 title: Do you know the difference between Close and Cancel?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: do-you-know-the-difference-between-close-and-cancel
 ---

--- a/public/uploads/rules/do-you-use-a-wizard-to-help-a-user-through-a-complicated-set-of-steps/rule.mdx
+++ b/public/uploads/rules/do-you-use-a-wizard-to-help-a-user-through-a-complicated-set-of-steps/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Help users navigate complex processes with intuitive wizards tha
   guide them through setup and configuration.
 title: Do you use a Wizard to help a user through a complicated set of steps?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: do-you-use-a-wizard-to-help-a-user-through-a-complicated-set-of-steps
 ---

--- a/public/uploads/rules/do-you-use-bold-text-and-indentation-instead-of-dividing-lines/rule.mdx
+++ b/public/uploads/rules/do-you-use-bold-text-and-indentation-instead-of-dividing-lines/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Use bold text and indentation instead of dividing lines to separ
   sections, enhancing visual clarity and reducing clutter for a better user experience.
 title: Do you use bold text and indentation, instead of dividing lines?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: do-you-use-bold-text-and-indentation-instead-of-dividing-lines
 ---

--- a/public/uploads/rules/do-you-visually-indicate-the-step-where-users-are-up-to-in-the-wizard/rule.mdx
+++ b/public/uploads/rules/do-you-visually-indicate-the-step-where-users-are-up-to-in-the-wizard/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Visually indicate user progress in a wizard to help users stay o
   track.
 title: Do you visually indicate the step where users are up to in the wizard?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: do-you-visually-indicate-the-step-where-users-are-up-to-in-the-wizard
 ---

--- a/public/uploads/rules/do-you-visually-let-the-user-know-when-they-are-finished/rule.mdx
+++ b/public/uploads/rules/do-you-visually-let-the-user-know-when-they-are-finished/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Visual indications on the last page of a wizard help users confi
   completion, enhancing their experience.
 title: Do you visually let the user know when they are finished?
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 type: rule
 uri: do-you-visually-let-the-user-know-when-they-are-finished
 ---

--- a/public/uploads/rules/does-the-first-form-provide-the-user-product-information/rule.mdx
+++ b/public/uploads/rules/does-the-first-form-provide-the-user-product-information/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you give users key product details upfront?
 uri: does-the-first-form-provide-the-user-product-information
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
   - category: categories/software-engineering/rules-to-better-windows-forms-applications.mdx
 authors: []
 redirects: []

--- a/public/uploads/rules/show-users-wizard-progress/rule.mdx
+++ b/public/uploads/rules/show-users-wizard-progress/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you show users their progress in a wizard?
 uri: show-users-wizard-progress
 categories:
-  - category: categories/design/rules-to-better-interfaces-wizards.mdx
+  - category: categories/design/rules-to-better-wizards.mdx
 authors:
   - title: Ken Shi
     url: 'https://www.ssw.com.au/people/ken-shi'


### PR DESCRIPTION
## Rename category

`Rules to Better Interfaces (Wizards)` → **`Rules to Better Wizards`**

- **Title** updated.
- **URI + filename** renamed `rules-to-better-interfaces-wizards` → `rules-to-better-wizards` (file moved with `git mv`, history preserved).
- **Redirect added** from the old URI so existing links and SEO traffic keep working (kept the pre-existing `rules-to-better-interfaces-(wizards)` redirect):
  - `/rules/rules-to-better-interfaces-wizards` → `/rules/rules-to-better-wizards`
- Updated the category path in **all 9 member rules** and in `categories/design/index.mdx`.
- Position under **Design and Usability** is unchanged.
- Individual rules were not otherwise modified.

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues (reciprocal category ↔ rule references agree)
- No remaining references to the old title `Rules to Better Interfaces (Wizards)`.
- No references to the old URI/path remain except the intentional redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
