### PR TITLE
Rename category to Rules to Better Dialogs and Notifications

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -13,7 +13,7 @@ index:
 - category: categories/design/rules-to-better-user-authentication.mdx
 - category: categories/design/rules-to-better-accessibility.mdx
 - category: categories/design/rules-to-better-forms.mdx
-- category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+- category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 - category: categories/design/rules-to-better-data-visualization.mdx
 - category: categories/design/rules-to-better-interfaces-wizards.mdx
 - category: categories/design/rules-to-better-figma.mdx

--- a/categories/design/rules-to-better-dialogs-and-notifications.mdx
+++ b/categories/design/rules-to-better-dialogs-and-notifications.mdx
@@ -1,11 +1,14 @@
 ---
 type: category
-title: Rules to Better Interfaces (Popups and Messages)
-uri: rules-to-better-interfaces-popups-and-messages
+title: Rules to Better Dialogs and Notifications
+uri: rules-to-better-dialogs-and-notifications
 guid: ffd39156-3df1-41c3-9a3d-8441c03d8caa
 redirects:
   - rules-to-better-interfaces-(popups-and-messages)
+  - rules-to-better-interfaces-popups-and-messages
 index:
+  - rule: public/uploads/rules/toast-notifications/rule.mdx
+  - rule: public/uploads/rules/modal-dialog-branding/rule.mdx
   - rule: public/uploads/rules/popup-do-you-know-pop-ups-are-evil/rule.mdx
   - rule: public/uploads/rules/do-you-use-javascript-alert/rule.mdx
   - rule: public/uploads/rules/popup-do-you-know-when-popup-forms-are-good/rule.mdx
@@ -19,9 +22,7 @@ index:
   - rule: public/uploads/rules/messages-do-you-use-messages-that-are-concise/rule.mdx
   - rule: public/uploads/rules/clean-no-match-found-screen/rule.mdx
   - rule: public/uploads/rules/help-do-you-help-users-when-they-get-errors-by-directing-them-to-a-wiki-or-kb/rule.mdx
-  - rule: public/uploads/rules/toast-notifications/rule.mdx
   - rule: public/uploads/rules/messages-do-you-use-green-tick-red-cross-and-spinning-icon-to-show-the-status/rule.mdx
-  - rule: public/uploads/rules/modal-dialog-branding/rule.mdx
 _template: category
 ---
 

--- a/public/uploads/rules/clean-no-match-found-screen/rule.mdx
+++ b/public/uploads/rules/clean-no-match-found-screen/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Clean "no match found" screen is essential to provide a positive
 title: Do you have a clean “no match found” screen?
 categories:
   - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
   - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
 type: rule
 uri: clean-no-match-found-screen

--- a/public/uploads/rules/do-you-use-javascript-alert/rule.mdx
+++ b/public/uploads/rules/do-you-use-javascript-alert/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: JavaScript alerts are evil, and using Toastr instead can improve
   experience with customizable notifications.
 title: Popup - Do you know JavaScript alerts are evil?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: do-you-use-javascript-alert
 ---

--- a/public/uploads/rules/help-do-you-help-users-when-they-get-errors-by-directing-them-to-a-wiki-or-kb/rule.mdx
+++ b/public/uploads/rules/help-do-you-help-users-when-they-get-errors-by-directing-them-to-a-wiki-or-kb/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Error messages solved with expert guidance from our wiki and kno
 title: Help - Do you help users when they get errors by directing them to a wiki or
   KB?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: help-do-you-help-users-when-they-get-errors-by-directing-them-to-a-wiki-or-kb
 ---

--- a/public/uploads/rules/messages-do-you-avoid-giving-an-error-message-for-validation-purposes/rule.mdx
+++ b/public/uploads/rules/messages-do-you-avoid-giving-an-error-message-for-validation-purposes/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Avoid giving an "Error" message for validation purposes and inst
   provide informative messages to users.
 title: Messages - Do you avoid giving an "Error" message for validation purposes?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-avoid-giving-an-error-message-for-validation-purposes
 ---

--- a/public/uploads/rules/messages-do-you-avoid-message-boxes-at-all-costs/rule.mdx
+++ b/public/uploads/rules/messages-do-you-avoid-message-boxes-at-all-costs/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Avoid message boxes at all costs and only use them to confirm re
   deletion or kick off long running processes that cannot be cancelled.
 title: Messages - Do you avoid message boxes at all costs?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-avoid-message-boxes-at-all-costs
 ---

--- a/public/uploads/rules/messages-do-you-avoid-ok-button-when-the-action-is-clear/rule.mdx
+++ b/public/uploads/rules/messages-do-you-avoid-ok-button-when-the-action-is-clear/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Avoid using "OK" buttons when actions are clear, instead opt for
   names like Save, Move, or Print.
 title: Messages - Do you avoid 'OK' button when the action is clear?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-avoid-ok-button-when-the-action-is-clear
 ---

--- a/public/uploads/rules/messages-do-you-clearly-show-a-pass-fail-or-warning/rule.mdx
+++ b/public/uploads/rules/messages-do-you-clearly-show-a-pass-fail-or-warning/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: 'Messages - Do you clearly show a pass, fail or warning?'
 uri: messages-do-you-clearly-show-a-pass-fail-or-warning
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/messages-do-you-know-how-to-make-message-boxes-user-friendly-1-3-titles/rule.mdx
+++ b/public/uploads/rules/messages-do-you-know-how-to-make-message-boxes-user-friendly-1-3-titles/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Learn how to create user-friendly message box titles with consis
   application names and versions
 title: Messages - Do you know how to make message boxes user friendly? (1/3 Titles)
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-know-how-to-make-message-boxes-user-friendly-1-3-titles
 ---

--- a/public/uploads/rules/messages-do-you-know-how-to-put-the-technical-info-2-3-description/rule.mdx
+++ b/public/uploads/rules/messages-do-you-know-how-to-put-the-technical-info-2-3-description/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Error messages should be clear and concise, providing a brief ex
   of what went wrong along with helpful details for debugging.
 title: Messages - Do you know how to put the technical info? (2/3 Description)
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-know-how-to-put-the-technical-info-2-3-description
 ---

--- a/public/uploads/rules/messages-do-you-know-what-icons-to-use-3-3-icons/rule.mdx
+++ b/public/uploads/rules/messages-do-you-know-what-icons-to-use-3-3-icons/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Microsoft recommends using specific icons to convey message seve
   and importance, including Information, Warning, and Error symbols.
 title: Messages - Do you know what icons to use? (3/3 Icons)
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-know-what-icons-to-use-3-3-icons
 ---

--- a/public/uploads/rules/messages-do-you-use-green-tick-red-cross-and-spinning-icon-to-show-the-status/rule.mdx
+++ b/public/uploads/rules/messages-do-you-use-green-tick-red-cross-and-spinning-icon-to-show-the-status/rule.mdx
@@ -17,7 +17,7 @@ related:
 seoDescription: Use consistent icons to show message status, such as green tick, red cross and spinning icon.
 title: Do you use green tick, red cross and spinning icon to show the status?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-use-green-tick-red-cross-and-spinning-icon-to-show-the-status
 ---

--- a/public/uploads/rules/messages-do-you-use-messages-that-are-concise/rule.mdx
+++ b/public/uploads/rules/messages-do-you-use-messages-that-are-concise/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Use concise messages that your users will understand, avoiding t
   terms that may confuse them.
 title: Messages - Do you use messages that are concise?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: messages-do-you-use-messages-that-are-concise
 ---

--- a/public/uploads/rules/modal-dialog-branding/rule.mdx
+++ b/public/uploads/rules/modal-dialog-branding/rule.mdx
@@ -2,7 +2,7 @@
 title: Do your modal dialogs include the application icon?
 uri: modal-dialog-branding
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
   - category: categories/marketing-and-video/rules-to-better-websites-branding-and-marketing.mdx
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/popup-do-you-know-pop-ups-are-evil/rule.mdx
+++ b/public/uploads/rules/popup-do-you-know-pop-ups-are-evil/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Pop-up ads are intrusive and annoying, disrupting user experienc
   online.
 title: Popup - Do you know Pop-ups are evil?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: popup-do-you-know-pop-ups-are-evil
 ---

--- a/public/uploads/rules/popup-do-you-know-when-popup-forms-are-good/rule.mdx
+++ b/public/uploads/rules/popup-do-you-know-when-popup-forms-are-good/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: When to use popup forms - Simplify complex forms, provide clear 
   steps and avoid distractions.
 title: Popup - Do you know when Popup forms are good?
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 type: rule
 uri: popup-do-you-know-when-popup-forms-are-good
 ---

--- a/public/uploads/rules/toast-notifications/rule.mdx
+++ b/public/uploads/rules/toast-notifications/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you know when and where to use toast notifications?
 uri: toast-notifications
 categories:
-  - category: categories/design/rules-to-better-interfaces-popups-and-messages.mdx
+  - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
 authors:
   - title: Tiago Araujo
     url: 'https://www.ssw.com.au/people/tiago-araujo'


### PR DESCRIPTION
## Rename category

`Rules to Better Interfaces (Popups and Messages)` → **`Rules to Better Dialogs and Notifications`**

- **Title** updated.
- **URI + filename** renamed `rules-to-better-interfaces-popups-and-messages` → `rules-to-better-dialogs-and-notifications` (`git mv`, history preserved).
- **Redirect added** from the old URI (kept the pre-existing `rules-to-better-interfaces-(popups-and-messages)` redirect):
  - `/rules/rules-to-better-interfaces-popups-and-messages` → `/rules/rules-to-better-dialogs-and-notifications`
- Updated the category path in **all 16 member rules** and in `categories/design/index.mdx`.
- Position under **Design and Usability** is unchanged.

## Reorder

Moved these two rules to the very top of the category index (the other 14 keep their relative order):

1. [Do you know when and where to use toast notifications?](https://www.ssw.com.au/rules/toast-notifications)
2. [Do your modal dialogs include the application icon?](https://www.ssw.com.au/rules/modal-dialog-branding)

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues
- No remaining references to the old title `Rules to Better Interfaces (Popups and Messages)`.
- No references to the old URI/path remain except the intentional redirect; no duplicate index entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
