### PR TITLE
Rename category to Rules to Better UI and UX

### DIFF
--- a/categories/design/index.mdx
+++ b/categories/design/index.mdx
@@ -6,7 +6,7 @@ uri: design
 index:
 - category: categories/design/rules-to-better-designers.mdx
 - category: categories/design/rules-to-better-content-design.mdx
-- category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+- category: categories/design/rules-to-better-ui-and-ux.mdx
 - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
 - category: categories/design/rules-to-better-mobile-ui-ux.mdx
 - category: categories/design/rules-to-better-navigation-and-links.mdx

--- a/categories/design/rules-to-better-ui-and-ux.mdx
+++ b/categories/design/rules-to-better-ui-and-ux.mdx
@@ -1,10 +1,11 @@
 ---
 type: category
-title: Rules to Better Interfaces (General Usability Practices)
-uri: rules-to-better-interfaces-general-usability-practices
+title: Rules to Better UI and UX
+uri: rules-to-better-ui-and-ux
 guid: 42bb8843-7a37-4727-b51e-4d168242b1bb
 redirects:
   - rules-to-better-interfaces-(general-usability-practices)
+  - rules-to-better-interfaces-general-usability-practices
 seoDescription: SSW's general usability best practices for software interfaces. Learn how to design intuitive, consistent, and user-friendly applications.
 index:
   - rule: public/uploads/rules/interface-testing/rule.mdx

--- a/categories/design/rules-to-better-ui-and-ux.mdx
+++ b/categories/design/rules-to-better-ui-and-ux.mdx
@@ -46,4 +46,6 @@ index:
 _template: category
 ---
 
+Good UI and UX come from applying general usability practices consistently across every interface. Clear, intuitive interfaces help users understand what to do, complete tasks efficiently, and avoid unnecessary confusion.
+
 If you still need help, visit our [User Interface & User Experience showcase](https://www.ssw.com.au/ssw/Consulting/UI-UX-Design.aspx) and book in a consultant.

--- a/public/uploads/rules/add-a-spot-of-color-for-emphasis/rule.mdx
+++ b/public/uploads/rules/add-a-spot-of-color-for-emphasis/rule.mdx
@@ -3,7 +3,7 @@ seoDescription: Add a spot of color for emphasis, making important text stand ou
 type: rule
 title: Do you add a spot of color for text emphasis?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 uri: add-a-spot-of-color-for-emphasis
 authors:
   - title: Ken Shi

--- a/public/uploads/rules/always-reduce-complexity/rule.mdx
+++ b/public/uploads/rules/always-reduce-complexity/rule.mdx
@@ -13,7 +13,7 @@ seoDescription: Reducing complexity helps users make faster and more accurate de
   by presenting them with smaller sets of options
 title: Do you always try to reduce complexity?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: always-reduce-complexity
 ---

--- a/public/uploads/rules/avoid-labels/rule.mdx
+++ b/public/uploads/rules/avoid-labels/rule.mdx
@@ -22,7 +22,7 @@ seoDescription: Minimize clutter and create clean interfaces by removing unneces
   labels and emphasizing user understanding.
 title: Do you avoid unnecessary labels?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: avoid-labels
 ---

--- a/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
+++ b/public/uploads/rules/avoid-using-mailto-on-your-website/rule.mdx
@@ -6,7 +6,7 @@ categories:
   - category: categories/software-engineering/rules-to-better-asp-net.mdx
   - category: categories/design/rules-to-better-forms.mdx
   - category: categories/design/rules-to-better-accessibility.mdx
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Alex Blum
     url: 'https://www.ssw.com.au/people/alex-blum'

--- a/public/uploads/rules/clean-no-match-found-screen/rule.mdx
+++ b/public/uploads/rules/clean-no-match-found-screen/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Clean "no match found" screen is essential to provide a positive
   experience.
 title: Do you have a clean “no match found” screen?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
   - category: categories/design/rules-to-better-dialogs-and-notifications.mdx
   - category: categories/design/rules-to-better-websites-layout-and-formatting.mdx
 type: rule

--- a/public/uploads/rules/column-data-do-you-do-alphanumeric-down-instead-of-across/rule.mdx
+++ b/public/uploads/rules/column-data-do-you-do-alphanumeric-down-instead-of-across/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: When designing multicolumn lists, it's best to display data vert
   instead of horizontally for better readability and faster scanning.
 title: Column Data - Do you do alphanumeric down instead of across?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: column-data-do-you-do-alphanumeric-down-instead-of-across
 ---

--- a/public/uploads/rules/column-data-do-you-know-when-to-use-columns-or-text/rule.mdx
+++ b/public/uploads/rules/column-data-do-you-know-when-to-use-columns-or-text/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Easily compare and reorder data with columns, perfect for side-b
   comparisons and calculating totals.
 title: Column Data - Do you know when to use columns or text?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: column-data-do-you-know-when-to-use-columns-or-text
 ---

--- a/public/uploads/rules/column-data-do-you-make-matrix-columns-as-simple-as-possible/rule.mdx
+++ b/public/uploads/rules/column-data-do-you-make-matrix-columns-as-simple-as-possible/rule.mdx
@@ -13,7 +13,7 @@ redirects: []
 seoDescription: Simplify matrix columns to improve readability and enhance user understanding.
 title: Column Data - Do you make matrix columns as simple as possible?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: column-data-do-you-make-matrix-columns-as-simple-as-possible
 ---

--- a/public/uploads/rules/continually-improve-ui/rule.mdx
+++ b/public/uploads/rules/continually-improve-ui/rule.mdx
@@ -1,5 +1,5 @@
 ---
-archivedreason: This generic rule has been replaced by [https://www.ssw.com.au/rules/rules-to-better-interfaces-general-usability-practices](/rules/rules-to-better-interfaces-general-usability-practices)
+archivedreason: This generic rule has been replaced by [https://www.ssw.com.au/rules/rules-to-better-ui-and-ux](/rules/rules-to-better-ui-and-ux)
 authors:
 - title: Adam Cogan
   url: https://www.ssw.com.au/people/adam-cogan

--- a/public/uploads/rules/date-and-time-of-change-as-tooltip/rule.mdx
+++ b/public/uploads/rules/date-and-time-of-change-as-tooltip/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Dates and times of change displayed as tooltips on hover, provid
   additional context without cluttering the main interface.
 title: Dates – Do you provide the date and time of change as a tooltip?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: date-and-time-of-change-as-tooltip
 ---

--- a/public/uploads/rules/destructive-button-ui-ux/rule.mdx
+++ b/public/uploads/rules/destructive-button-ui-ux/rule.mdx
@@ -4,7 +4,7 @@ type: rule
 title: Do you follow best UI practices for delete buttons?
 uri: destructive-button-ui-ux
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Micaela Blank
     url: 'https://www.ssw.com.au/people/micaela-blank'

--- a/public/uploads/rules/do-you-consider-optical-alignment/rule.mdx
+++ b/public/uploads/rules/do-you-consider-optical-alignment/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Optical alignment ensures a harmonious visual flow by balancing 
   and whitespace to create a pleasing layout.
 title: Do you consider optical alignment?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-consider-optical-alignment
 ---

--- a/public/uploads/rules/do-you-encourage-experimentation/rule.mdx
+++ b/public/uploads/rules/do-you-encourage-experimentation/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you let users preview changes to encourage experimentation?
 uri: do-you-encourage-experimentation
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/do-you-have-a-last-taken-option/rule.mdx
+++ b/public/uploads/rules/do-you-have-a-last-taken-option/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: Discover how apps predict your needs with a "last taken" feature
   enhance user experience.
 title: Do you have a "last taken" option?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-have-a-last-taken-option
 ---

--- a/public/uploads/rules/do-you-have-a-search-box-to-make-your-data-easy-to-find/rule.mdx
+++ b/public/uploads/rules/do-you-have-a-search-box-to-make-your-data-easy-to-find/rule.mdx
@@ -17,7 +17,7 @@ seoDescription: Make your data easily accessible by incorporating a "search box"
   helps users find relevant information quickly.
 title: Do you have a "search box" to make your data easy to find?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-have-a-search-box-to-make-your-data-easy-to-find
 ---

--- a/public/uploads/rules/do-you-highlight-the-search-term/rule.mdx
+++ b/public/uploads/rules/do-you-highlight-the-search-term/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Highlighting search terms in page body results enhances user exp
   and helps users quickly identify relevant information.
 title: Do you highlight the search term?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-highlight-the-search-term
 ---

--- a/public/uploads/rules/do-you-know-how-to-use-storyboards/rule.mdx
+++ b/public/uploads/rules/do-you-know-how-to-use-storyboards/rule.mdx
@@ -14,7 +14,7 @@ seoDescription: Storyboarding simplifies complex user requirements through visua
   mockups, saving time and improving understanding.
 title: Do you know how to use storyboards?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-know-how-to-use-storyboards
 ---

--- a/public/uploads/rules/do-you-make-it-easy-to-your-users-to-add-an-event-to-their-calendar/rule.mdx
+++ b/public/uploads/rules/do-you-make-it-easy-to-your-users-to-add-an-event-to-their-calendar/rule.mdx
@@ -4,7 +4,7 @@ title: Do you make it easy for users to add events to their calendars?
 uri: do-you-make-it-easy-to-your-users-to-add-an-event-to-their-calendar
 categories:
   - category: categories/communication/rules-to-better-calendars.mdx
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/do-you-make-the-homepage-as-a-portal/rule.mdx
+++ b/public/uploads/rules/do-you-make-the-homepage-as-a-portal/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Turn your homepage into a portal by showcasing top billing custo
   and key metrics, making it easy to find core functions.
 title: Do you make the homepage as a portal?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-make-the-homepage-as-a-portal
 ---

--- a/public/uploads/rules/do-you-make-users-intuitively-know-how-to-use-something/rule.mdx
+++ b/public/uploads/rules/do-you-make-users-intuitively-know-how-to-use-something/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: Intuitive design makes users instinctively know how to use a pro
   or system by leveraging affordances and clear visual cues.
 title: Do you make users intuitively know how to use something?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-make-users-intuitively-know-how-to-use-something
 ---

--- a/public/uploads/rules/do-you-make-your-cancel-button-less-obvious/rule.mdx
+++ b/public/uploads/rules/do-you-make-your-cancel-button-less-obvious/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Avoid accidental cancellations by making your cancel button less
   and consider user platform preferences when placing it.
 title: Do you make your cancel button less obvious?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-make-your-cancel-button-less-obvious
 ---

--- a/public/uploads/rules/do-you-provide-options-for-sharing/rule.mdx
+++ b/public/uploads/rules/do-you-provide-options-for-sharing/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you make content easy to share?
 uri: do-you-provide-options-for-sharing
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Jayden Alchin
     url: 'https://www.ssw.com.au/people/jayden-alchin'

--- a/public/uploads/rules/do-you-realize-that-a-good-interface-should-not-require-instructions/rule.mdx
+++ b/public/uploads/rules/do-you-realize-that-a-good-interface-should-not-require-instructions/rule.mdx
@@ -16,7 +16,7 @@ seoDescription: A well-designed interface should be intuitive and self-explanent
   eliminating the need for instructions.
 title: Do you realize that a good interface should not require instructions?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-realize-that-a-good-interface-should-not-require-instructions
 ---

--- a/public/uploads/rules/do-you-remember-to-change-the-default-title-of-a-newly-created-page/rule.mdx
+++ b/public/uploads/rules/do-you-remember-to-change-the-default-title-of-a-newly-created-page/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you remember to change the default title of a newly created page?
 uri: do-you-remember-to-change-the-default-title-of-a-newly-created-page
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/do-you-strike-through-completed-items/rule.mdx
+++ b/public/uploads/rules/do-you-strike-through-completed-items/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you strike-through completed items?
 uri: do-you-strike-through-completed-items
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
   - category: categories/communication/rules-to-better-technical-documentation.mdx
 authors:
   - title: Adam Cogan

--- a/public/uploads/rules/do-you-understand-the-importance-of-language-in-your-ui/rule.mdx
+++ b/public/uploads/rules/do-you-understand-the-importance-of-language-in-your-ui/rule.mdx
@@ -20,7 +20,7 @@ seoDescription: Discover how language shapes your application's tone and user ex
   with essential tips for clear and effective communication in your UI.
 title: Do you understand the importance of language in your UI?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: do-you-understand-the-importance-of-language-in-your-ui
 ---

--- a/public/uploads/rules/give-feedback-report-bugs-link/rule.mdx
+++ b/public/uploads/rules/give-feedback-report-bugs-link/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you make it easy for users to report bugs or give feedback?
 uri: give-feedback-report-bugs-link
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors: []
 redirects:
   - do-you-have-the-ability-for-users-to-give-you-free-feedback-and-report-bugs-on-every-page

--- a/public/uploads/rules/have-a-request-access-button-when-you-require-permission/rule.mdx
+++ b/public/uploads/rules/have-a-request-access-button-when-you-require-permission/rule.mdx
@@ -16,7 +16,7 @@ redirects:
 seoDescription: Require permission to access pages and get a request access button
 title: Do you have a "request access" button in pages that require permission?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: have-a-request-access-button-when-you-require-permission
 ---

--- a/public/uploads/rules/how-to-use-gamification/rule.mdx
+++ b/public/uploads/rules/how-to-use-gamification/rule.mdx
@@ -18,7 +18,7 @@ seoDescription: Gamification encourages user participation through incentives an
   rewards, driving engagement and loyalty.
 title: Do you know how to use "gamification"?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: how-to-use-gamification
 ---

--- a/public/uploads/rules/interface-testing/rule.mdx
+++ b/public/uploads/rules/interface-testing/rule.mdx
@@ -4,7 +4,7 @@ title: Do you know the importance of testing your interface?
 uri: interface-testing
 categories:
   - category: >-
-      categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+      categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Alex Blum
     url: 'https://www.ssw.com.au/people/alex-blum'

--- a/public/uploads/rules/mockups-and-prototypes/rule.mdx
+++ b/public/uploads/rules/mockups-and-prototypes/rule.mdx
@@ -114,7 +114,7 @@ To make a mockup more realistic and accurate to the end product, add interactivi
     **Tips:** Here are some hot tips on using mockups for specification analysis:
     
     * It is best to have a designer, developer, and customer work together
-    * Mock-ups should follow [interface rules](/rules-to-better-interfaces-general-usability-practices)
+    * Mock-ups should follow [interface rules](/rules-to-better-ui-and-ux)
     * Get the mockups [physically initialed](/tasks-do-you-know-to-ensure-that-relevant-emails-are-attached-to-tasks), especially if you are performing a fixed-price contract. Yes, paperless is great, but not in this case
     * If you can't get mockups initialed, then page by page approval over email is the 2nd best option
     * Write the related business rules at the bottom of each screen - to be turned into unit tests

--- a/public/uploads/rules/show-inactive-record/rule.mdx
+++ b/public/uploads/rules/show-inactive-record/rule.mdx
@@ -19,7 +19,7 @@ seoDescription: Clear visual indicators of inactive or disabled records help pre
   confusion and ensure a seamless user experience.
 title: Do you clearly show what is inactive/disabled?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: show-inactive-record
 ---

--- a/public/uploads/rules/skeleton-loaders/rule.mdx
+++ b/public/uploads/rules/skeleton-loaders/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you use skeleton loaders in your UI?
 uri: skeleton-loaders
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Micaela Blank
     url: 'https://www.ssw.com.au/people/micaela-blank'

--- a/public/uploads/rules/test-high-risk-features/rule.mdx
+++ b/public/uploads/rules/test-high-risk-features/rule.mdx
@@ -10,7 +10,7 @@ seoDescription: Don’t release critical features without testing them first. Us
 tips: ''
 title: Do you test high-risk features with real users before launch?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
   - category: categories/software-engineering/rules-to-better-testing.mdx
 type: rule
 uri: test-high-risk-features

--- a/public/uploads/rules/use-icons-to-reinforce-meaning/rule.mdx
+++ b/public/uploads/rules/use-icons-to-reinforce-meaning/rule.mdx
@@ -3,7 +3,7 @@ type: rule
 title: Do you use icons to support text in your UI?
 uri: use-icons-to-reinforce-meaning
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/use-ui-animations/rule.mdx
+++ b/public/uploads/rules/use-ui-animations/rule.mdx
@@ -2,7 +2,7 @@
 title: Do you use animation to guide users’ attention after interactions?
 uri: use-ui-animations
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'

--- a/public/uploads/rules/visually-indicate-active-sort-column/rule.mdx
+++ b/public/uploads/rules/visually-indicate-active-sort-column/rule.mdx
@@ -10,7 +10,7 @@ redirects: []
 seoDescription: Make sorted table columns obvious to users by bolding the active column header and showing clear sort direction arrows.
 title: Do you visually indicate the active sort column?
 categories:
-  - category: categories/design/rules-to-better-interfaces-general-usability-practices.mdx
+  - category: categories/design/rules-to-better-ui-and-ux.mdx
 type: rule
 uri: visually-indicate-active-sort-column
 ---


### PR DESCRIPTION
## Rename category

`Rules to Better Interfaces (General Usability Practices)` → **`Rules to Better UI and UX`**

- **Title** updated.
- **URI + filename** renamed `rules-to-better-interfaces-general-usability-practices` → `rules-to-better-ui-and-ux` (`git mv`, history preserved).
- **Redirect added** from the old URI (kept the pre-existing `rules-to-better-interfaces-(general-usability-practices)` redirect):
  - `/rules/rules-to-better-interfaces-general-usability-practices` → `/rules/rules-to-better-ui-and-ux`
- Updated the category path in **all 35 member rules** and in `categories/design/index.mdx`.
- Also updated two `/uri`-form links to this category: the **archive reason** in `continually-improve-ui` and a **prose link** in `mockups-and-prototypes`.
- Position under **Design and Usability** is unchanged (same relative position).

## Intro text (commit 2)

Added an intro paragraph to the category body:

> Good UI and UX come from applying general usability practices consistently across every interface. Clear, intuitive interfaces help users understand what to do, complete tasks efficiently, and avoid unnecessary confusion.

## Validation

- `frontmatter-validator` — no errors
- `category-sync-validator` — no sync issues
- `check-mdx` — category compiles
- No remaining references to the old title `Rules to Better Interfaces (General Usability Practices)`.
- No references to the old URI/path remain except the intentional redirect (no broken internal links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
