### PR TITLE
New rule: Do you scope your DbContext to the unit of work in long-running jobs?

### DIFF
--- a/categories/software-engineering/rules-to-better-entity-framework.mdx
+++ b/categories/software-engineering/rules-to-better-entity-framework.mdx
@@ -19,6 +19,7 @@ index:
 - rule: public/uploads/rules/entity-framework-benchmark/rule.mdx
 - rule: public/uploads/rules/the-best-entity-framework-benchmarking-tools/rule.mdx
 - rule: public/uploads/rules/bulk-process-in-chunks/rule.mdx
+- rule: public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
 - rule: public/uploads/rules/when-to-use-raw-sql/rule.mdx
 - rule: public/uploads/rules/use-code-migrations/rule.mdx
 - rule: public/uploads/rules/efcore-in-memory-provider/rule.mdx

--- a/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
+++ b/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
@@ -4,8 +4,8 @@ title: Do you scope your DbContext to the unit of work in long-running jobs?
 seoDescription: >-
   Long-running background jobs that keep one EF Core DbContext for the whole
   run get slower with every row as the change tracker grows. Create a fresh
-  DbContext per chunk with IDbContextFactory - or a DI scope per chunk when
-  services own the context - to keep throughput flat.
+  DbContext per chunk with IDbContextFactory, or a DI scope per chunk when
+  services own the context, to keep throughput flat.
 guid: 9adbe77d-cdc4-4687-8902-acbb05a33577
 uri: scope-dbcontext-in-long-running-jobs
 created: 2026-08-19T00:00:00.000Z
@@ -25,13 +25,13 @@ archivedreason: null
 isArchived: false
 ---
 
-A background job that syncs or imports thousands of rows often starts fast and gets slower with every row. A run that did 60 chunks in its first hour is down to 10 a day later, and it never logs "complete". The database is usually innocent - the cause is the EF Core change tracker, quietly holding every entity the job has ever touched.
+A background job that syncs or imports thousands of rows often starts fast and gets slower with every row. A run that did 60 chunks in its first hour is down to 10 a day later, and it never logs "complete". The database is usually innocent. The cause is the EF Core change tracker, quietly holding every entity the job has ever touched.
 
 <endIntro />
 
 ## Why long jobs slow down
 
-Job frameworks like Hangfire create one dependency injection scope per job execution. For a web request, a scope lives for milliseconds. For a bulk job, that same scope - and every scoped `DbContext` in it - lives for the entire run, which can be hours or days.
+Job frameworks like Hangfire create one dependency injection scope per job execution. For a web request, a scope lives for milliseconds. For a bulk job, that same scope (and every scoped `DbContext` in it) lives for the entire run, which can be hours or days.
 
 Every entity the job loads or adds stays in the change tracker. Each `SaveChangesAsync` then walks all tracked entities to detect changes, and any `SaveChanges` interceptors (audit stamping, outbox) walk them all again. Chunk 100 pays for the 99 chunks before it, so each save costs more than the last. Eventually a save crosses the SQL command timeout and the run dies without finishing.
 
@@ -59,9 +59,9 @@ public class SyncAllProductsJob(AppDbContext dbContext)
 
 ❌ **Figure: Bad example - One injected DbContext for the whole run. Every chunk's entities stay tracked, so every save walks all of them again**
 
-## OK - Clear the change tracker after each chunk
+## OK example: Clear the change tracker after each chunk
 
-If you keep the single context, empty its tracker at the end of every chunk - in a `finally`, so a failed chunk clears too:
+If you keep the single context, empty its tracker at the end of every chunk. Put the clear in a `finally` so a failed chunk clears too:
 
 ```csharp
 foreach (var chunk in ids.Chunk(500))
@@ -87,15 +87,15 @@ foreach (var chunk in ids.Chunk(500))
 <boxEmbed
   style="warning"
   body={<>
-    Only clear at the chunk boundary. If one chunk involves two saves - save the parents, then save their children - a `Clear()` between them detaches the parents, and the children are silently never written. No exception, just missing data. Keep the clear in one place, the `finally` on the loop, and never inside the methods that do the saves.
+    Only clear at the chunk boundary. If one chunk involves two saves (save the parents, then save their children), a `Clear()` between them detaches the parents, and the children are silently never written. No exception, just missing data. Keep the clear in one place: the `finally` on the loop. Never put it inside the methods that do the saves.
   </>}
   figurePrefix="none"
   figure="Warning - A misplaced Clear() causes silent data loss, which is worse than the slowdown it fixes"
 />
 
-## Good - A fresh DbContext per chunk with IDbContextFactory
+## Good example: A fresh DbContext per chunk with IDbContextFactory
 
-`DbContext` is designed to be short-lived. Instead of reusing one context and cleaning up after it, create one per chunk and throw it away - there is nothing to remember and nothing to leak.
+`DbContext` is designed to be short-lived. Instead of reusing one context and cleaning up after it, create one per chunk and throw it away. There is nothing to remember and nothing to leak.
 
 Register the factory:
 
@@ -132,7 +132,7 @@ public class SyncAllProductsJob(IDbContextFactory<AppDbContext> dbContextFactory
 
 ## When the DbContext hides behind services
 
-Many jobs never touch the `DbContext` directly - they call sync services or MediatR handlers that get their context from dependency injection. A factory can't reach those contexts. Create a DI scope per chunk instead, and resolve the services from it. Disposing the scope disposes every scoped `DbContext` inside it - including one hiding behind an `ISender`, or one a teammate adds next year:
+Many jobs never touch the `DbContext` directly. They call sync services or MediatR handlers that get their context from dependency injection, and a factory can't reach those contexts. Create a DI scope per chunk instead, and resolve the services from it. Disposing the scope disposes every scoped `DbContext` inside it, including one hiding behind an `ISender` or one a teammate adds next year:
 
 ```csharp
 public class SyncAllProductsJob(IServiceScopeFactory scopeFactory)
@@ -152,14 +152,14 @@ public class SyncAllProductsJob(IServiceScopeFactory scopeFactory)
 }
 ```
 
-✅ **Figure: Good example - For service graphs, a scope per chunk plays the factory's role - the scope owns every DbContext the chunk used**
+✅ **Figure: Good example - For service graphs, a scope per chunk plays the factory's role: the scope owns every DbContext the chunk used**
 
 ## How to spot it in production
 
-* Throughput decays smoothly over the run - the first hour is the fastest the job will ever be
+* Throughput decays smoothly over the run: the first hour is the fastest the job will ever be
 * Memory climbs for the life of the job
 * Saves start failing with command timeouts, even though the same save is instant when run on its own
 
-Log a short heartbeat per chunk - rows processed, elapsed time, rows per second - so the decay shows up in one log line instead of being reconstructed from timestamps after the incident.
+Log a short heartbeat per chunk (rows processed, elapsed time, rows per second) so the decay shows up in one log line instead of being reconstructed from timestamps after the incident.
 
-For reads the job never modifies, keep entities out of the tracker entirely - see [Do you use AsNoTracking for readonly queries?](/use-asnotracking-for-readonly-queries).
+For reads the job never modifies, keep entities out of the tracker entirely. See [Do you use AsNoTracking for readonly queries?](/use-asnotracking-for-readonly-queries).

--- a/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
+++ b/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
@@ -13,6 +13,8 @@ authors:
     url: https://www.ssw.com.au/people/gordon-beeming
   - title: Anton Polkanov
     url: https://www.ssw.com.au/people/anton-polkanov
+  - title: Daniel Mackay
+    url: https://www.ssw.com.au/people/daniel-mackay
 related:
   - rule: public/uploads/rules/bulk-process-in-chunks/rule.mdx
   - rule: public/uploads/rules/use-asnotracking-for-readonly-queries/rule.mdx

--- a/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
+++ b/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
@@ -1,0 +1,128 @@
+---
+type: rule
+title: Do you scope your DbContext to the unit of work in long-running jobs?
+seoDescription: >-
+  Long-running background jobs that keep one EF Core DbContext for the whole
+  run get slower with every row as the change tracker grows. Scope DbContexts
+  per chunk and clear the tracker per row to keep throughput flat.
+guid: 9adbe77d-cdc4-4687-8902-acbb05a33577
+uri: scope-dbcontext-in-long-running-jobs
+created: 2026-08-19T00:00:00.000Z
+authors:
+  - title: Gordon Beeming
+    url: https://www.ssw.com.au/people/gordon-beeming
+  - title: Anton Polkanov
+    url: https://www.ssw.com.au/people/anton-polkanov
+related:
+  - rule: public/uploads/rules/bulk-process-in-chunks/rule.mdx
+  - rule: public/uploads/rules/use-asnotracking-for-readonly-queries/rule.mdx
+categories:
+  - category: categories/software-engineering/rules-to-better-entity-framework.mdx
+archivedreason: null
+isArchived: false
+---
+
+A background job that syncs or imports thousands of rows often starts fast and gets slower with every row. A run that did 60 chunks in its first hour is down to 10 a day later, and it never logs "complete". The database is usually innocent - the cause is the EF Core change tracker, quietly holding every entity the job has ever touched.
+
+<endIntro />
+
+## Why long jobs slow down
+
+Job frameworks like Hangfire create one dependency injection scope per job execution. For a web request, a scope lives for milliseconds. For a bulk job, that same scope - and every scoped `DbContext` in it - lives for the entire run, which can be hours or days.
+
+Every entity the job loads or adds stays in the change tracker. Each `SaveChangesAsync` then walks all tracked entities to detect changes, and any `SaveChanges` interceptors (audit stamping, outbox) walk them all again. Row 10,000 pays for the 9,999 rows before it, so each save costs more than the last. Eventually a save crosses the SQL command timeout and the run dies without finishing.
+
+Constructor injection is what makes this easy to miss - the code looks completely normal:
+
+```csharp
+public class SyncAllProductsJob(ProductSyncService syncService)
+{
+    public async Task Execute(CancellationToken ct)
+    {
+        var ids = await GetAllProductIds(ct);
+
+        foreach (var chunk in ids.Chunk(500))
+        {
+            // Same service, same DbContext, same change tracker - for the whole run
+            await syncService.SyncProducts(chunk, ct);
+        }
+    }
+}
+```
+
+❌ **Figure: Bad example - The injected service holds one DbContext whose change tracker grows for the whole run**
+
+## Fix 1 - Create a DI scope per chunk
+
+Process the data in chunks (see [Do you bulk process in chunks?](/bulk-process-in-chunks)) and create a fresh DI scope for each one. Resolve everything that touches a `DbContext` from that scope - your own services, and indirect users like a MediatR `ISender`, whose handlers get their `DbContext` from whatever scope the sender came from.
+
+```csharp
+public class SyncAllProductsJob(IServiceScopeFactory scopeFactory)
+{
+    public async Task Execute(CancellationToken ct)
+    {
+        var ids = await GetAllProductIds(ct);
+
+        foreach (var chunk in ids.Chunk(500))
+        {
+            using var scope = scopeFactory.CreateScope();
+            var syncService = scope.ServiceProvider.GetRequiredService<ProductSyncService>();
+
+            await syncService.SyncProducts(chunk, ct);
+        } // Disposing the scope disposes every DbContext resolved from it
+    }
+}
+```
+
+✅ **Figure: Good example - Each chunk gets its own scope, so no DbContext outlives one chunk**
+
+Lead with this fix because it doesn't rely on anyone remembering anything. Clearing trackers by hand only fixes the contexts you thought of - a `DbContext` hiding behind a MediatR handler, or one a teammate adds next year, keeps leaking. Disposing the scope catches them all.
+
+## Fix 2 - Clear the change tracker after each row
+
+Scoping per chunk stops the leak between chunks, but the rows within one chunk still share a `DbContext`. If you save row by row, entities from finished rows pile up. Clear the tracker in a `finally` at the end of each row:
+
+```csharp
+foreach (var row in chunk)
+{
+    try
+    {
+        await ProcessRow(row, ct);
+    }
+    finally
+    {
+        dbContext.ChangeTracker.Clear();
+    }
+}
+```
+
+✅ **Figure: Good example - Each row leaves the tracker empty, whether it succeeded or failed**
+
+<boxEmbed
+  style="warning"
+  body={<>
+    Only clear at the row boundary. If one row involves two saves - save the parent, then save its children - a `Clear()` between them detaches the parent, and the children are silently never written. No exception, just missing data. Keep the clear in one place, the `finally` on the row loop, and never inside the methods that do the saves.
+  </>}
+  figurePrefix="none"
+  figure="Warning - A misplaced Clear() causes silent data loss, which is worse than the slowdown it fixes"
+/>
+
+## A simpler alternative - IDbContextFactory
+
+When the job talks to a `DbContext` directly instead of through a graph of services, you can skip the scope and create a short-lived context per chunk:
+
+```csharp
+using var db = await dbContextFactory.CreateDbContextAsync(ct);
+```
+
+✅ **Figure: Good example - IDbContextFactory gives a fresh context per chunk when there is no service graph to resolve**
+
+## How to spot it in production
+
+* Throughput decays smoothly over the run - the first hour is the fastest the job will ever be
+* Memory climbs for the life of the job
+* Saves start failing with command timeouts, even though the same save is instant when run on its own
+
+Log a short heartbeat per chunk - rows processed, elapsed time, rows per second - so the decay shows up in one log line instead of being reconstructed from timestamps after the incident.
+
+For reads the job never modifies, keep entities out of the tracker entirely - see [Do you use AsNoTracking for readonly queries?](/use-asnotracking-for-readonly-queries).

--- a/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
+++ b/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
@@ -3,8 +3,9 @@ type: rule
 title: Do you scope your DbContext to the unit of work in long-running jobs?
 seoDescription: >-
   Long-running background jobs that keep one EF Core DbContext for the whole
-  run get slower with every row as the change tracker grows. Scope DbContexts
-  per chunk and clear the tracker per row to keep throughput flat.
+  run get slower with every row as the change tracker grows. Create a fresh
+  DbContext per chunk with IDbContextFactory - or a DI scope per chunk when
+  services own the context - to keep throughput flat.
 guid: 9adbe77d-cdc4-4687-8902-acbb05a33577
 uri: scope-dbcontext-in-long-running-jobs
 created: 2026-08-19T00:00:00.000Z
@@ -32,64 +33,47 @@ A background job that syncs or imports thousands of rows often starts fast and g
 
 Job frameworks like Hangfire create one dependency injection scope per job execution. For a web request, a scope lives for milliseconds. For a bulk job, that same scope - and every scoped `DbContext` in it - lives for the entire run, which can be hours or days.
 
-Every entity the job loads or adds stays in the change tracker. Each `SaveChangesAsync` then walks all tracked entities to detect changes, and any `SaveChanges` interceptors (audit stamping, outbox) walk them all again. Row 10,000 pays for the 9,999 rows before it, so each save costs more than the last. Eventually a save crosses the SQL command timeout and the run dies without finishing.
+Every entity the job loads or adds stays in the change tracker. Each `SaveChangesAsync` then walks all tracked entities to detect changes, and any `SaveChanges` interceptors (audit stamping, outbox) walk them all again. Chunk 100 pays for the 99 chunks before it, so each save costs more than the last. Eventually a save crosses the SQL command timeout and the run dies without finishing.
 
-Constructor injection is what makes this easy to miss - the code looks completely normal:
+Process the data in chunks (see [Do you bulk process in chunks?](/bulk-process-in-chunks)), then look at what owns the `DbContext`:
 
 ```csharp
-public class SyncAllProductsJob(ProductSyncService syncService)
+public class SyncAllProductsJob(AppDbContext dbContext)
 {
     public async Task Execute(CancellationToken ct)
     {
-        var ids = await GetAllProductIds(ct);
+        var ids = await GetProductIdsToSync(ct);
 
         foreach (var chunk in ids.Chunk(500))
         {
-            // Same service, same DbContext, same change tracker - for the whole run
-            await syncService.SyncProducts(chunk, ct);
+            var products = await dbContext.Products
+                .Where(p => chunk.Contains(p.Id))
+                .ToListAsync(ct);
+
+            ApplyChanges(products);
+            await dbContext.SaveChangesAsync(ct);
         }
     }
 }
 ```
 
-❌ **Figure: Bad example - The injected service holds one DbContext whose change tracker grows for the whole run**
+❌ **Figure: Bad example - One injected DbContext for the whole run. Every chunk's entities stay tracked, so every save walks all of them again**
 
-## Fix 1 - Create a DI scope per chunk
+## OK - Clear the change tracker after each chunk
 
-Process the data in chunks (see [Do you bulk process in chunks?](/bulk-process-in-chunks)) and create a fresh DI scope for each one. Resolve everything that touches a `DbContext` from that scope - your own services, and indirect users like a MediatR `ISender`, whose handlers get their `DbContext` from whatever scope the sender came from.
-
-```csharp
-public class SyncAllProductsJob(IServiceScopeFactory scopeFactory)
-{
-    public async Task Execute(CancellationToken ct)
-    {
-        var ids = await GetAllProductIds(ct);
-
-        foreach (var chunk in ids.Chunk(500))
-        {
-            using var scope = scopeFactory.CreateScope();
-            var syncService = scope.ServiceProvider.GetRequiredService<ProductSyncService>();
-
-            await syncService.SyncProducts(chunk, ct);
-        } // Disposing the scope disposes every DbContext resolved from it
-    }
-}
-```
-
-✅ **Figure: Good example - Each chunk gets its own scope, so no DbContext outlives one chunk**
-
-Lead with this fix because it doesn't rely on anyone remembering anything. Clearing trackers by hand only fixes the contexts you thought of - a `DbContext` hiding behind a MediatR handler, or one a teammate adds next year, keeps leaking. Disposing the scope catches them all.
-
-## Fix 2 - Clear the change tracker after each row
-
-Scoping per chunk stops the leak between chunks, but the rows within one chunk still share a `DbContext`. If you save row by row, entities from finished rows pile up. Clear the tracker in a `finally` at the end of each row:
+If you keep the single context, empty its tracker at the end of every chunk - in a `finally`, so a failed chunk clears too:
 
 ```csharp
-foreach (var row in chunk)
+foreach (var chunk in ids.Chunk(500))
 {
     try
     {
-        await ProcessRow(row, ct);
+        var products = await dbContext.Products
+            .Where(p => chunk.Contains(p.Id))
+            .ToListAsync(ct);
+
+        ApplyChanges(products);
+        await dbContext.SaveChangesAsync(ct);
     }
     finally
     {
@@ -98,26 +82,77 @@ foreach (var row in chunk)
 }
 ```
 
-✅ **Figure: Good example - Each row leaves the tracker empty, whether it succeeded or failed**
+😐 **Figure: OK example - Clearing the tracker caps the cost, but it relies on every code path remembering to clear**
 
 <boxEmbed
   style="warning"
   body={<>
-    Only clear at the row boundary. If one row involves two saves - save the parent, then save its children - a `Clear()` between them detaches the parent, and the children are silently never written. No exception, just missing data. Keep the clear in one place, the `finally` on the row loop, and never inside the methods that do the saves.
+    Only clear at the chunk boundary. If one chunk involves two saves - save the parents, then save their children - a `Clear()` between them detaches the parents, and the children are silently never written. No exception, just missing data. Keep the clear in one place, the `finally` on the loop, and never inside the methods that do the saves.
   </>}
   figurePrefix="none"
   figure="Warning - A misplaced Clear() causes silent data loss, which is worse than the slowdown it fixes"
 />
 
-## A simpler alternative - IDbContextFactory
+## Good - A fresh DbContext per chunk with IDbContextFactory
 
-When the job talks to a `DbContext` directly instead of through a graph of services, you can skip the scope and create a short-lived context per chunk:
+`DbContext` is designed to be short-lived. Instead of reusing one context and cleaning up after it, create one per chunk and throw it away - there is nothing to remember and nothing to leak.
+
+Register the factory:
 
 ```csharp
-using var db = await dbContextFactory.CreateDbContextAsync(ct);
+services.AddDbContextFactory<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
 ```
 
-✅ **Figure: Good example - IDbContextFactory gives a fresh context per chunk when there is no service graph to resolve**
+Then create a context per chunk:
+
+```csharp
+public class SyncAllProductsJob(IDbContextFactory<AppDbContext> dbContextFactory)
+{
+    public async Task Execute(CancellationToken ct)
+    {
+        var ids = await GetProductIdsToSync(ct);
+
+        foreach (var chunk in ids.Chunk(500))
+        {
+            await using var dbContext = await dbContextFactory.CreateDbContextAsync(ct);
+
+            var products = await dbContext.Products
+                .Where(p => chunk.Contains(p.Id))
+                .ToListAsync(ct);
+
+            ApplyChanges(products);
+            await dbContext.SaveChangesAsync(ct);
+        }
+    }
+}
+```
+
+✅ **Figure: Good example - Each chunk gets a brand-new DbContext and disposes it, so nothing accumulates between chunks**
+
+## When the DbContext hides behind services
+
+Many jobs never touch the `DbContext` directly - they call sync services or MediatR handlers that get their context from dependency injection. A factory can't reach those contexts. Create a DI scope per chunk instead, and resolve the services from it. Disposing the scope disposes every scoped `DbContext` inside it - including one hiding behind an `ISender`, or one a teammate adds next year:
+
+```csharp
+public class SyncAllProductsJob(IServiceScopeFactory scopeFactory)
+{
+    public async Task Execute(CancellationToken ct)
+    {
+        var ids = await GetProductIdsToSync(ct);
+
+        foreach (var chunk in ids.Chunk(500))
+        {
+            using var scope = scopeFactory.CreateScope();
+            var syncService = scope.ServiceProvider.GetRequiredService<ProductSyncService>();
+
+            await syncService.SyncProducts(chunk, ct);
+        }
+    }
+}
+```
+
+✅ **Figure: Good example - For service graphs, a scope per chunk plays the factory's role - the scope owns every DbContext the chunk used**
 
 ## How to spot it in production
 

--- a/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
+++ b/public/uploads/rules/scope-dbcontext-in-long-running-jobs/rule.mdx
@@ -12,10 +12,10 @@ created: 2026-08-19T00:00:00.000Z
 authors:
   - title: Gordon Beeming
     url: https://www.ssw.com.au/people/gordon-beeming
-  - title: Anton Polkanov
-    url: https://www.ssw.com.au/people/anton-polkanov
   - title: Daniel Mackay
     url: https://www.ssw.com.au/people/daniel-mackay
+  - title: Anton Polkanov
+    url: https://www.ssw.com.au/people/anton-polkanov
 related:
   - rule: public/uploads/rules/bulk-process-in-chunks/rule.mdx
   - rule: public/uploads/rules/use-asnotracking-for-readonly-queries/rule.mdx


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

A production incident on a client project. A bulk sync job had been running for three days without finishing - it started at ~63 chunks an hour and decayed to 11. 

> 2. What was changed?

Added a new rule which describes how long running jobs should work with EF Core

> 3. I paired or mob programmed with:

No

🤖
