### PR TITLE
Update rule.mdx

### DIFF
--- a/public/uploads/rules/retain-deleted-records-with-a-soft-delete/rule.mdx
+++ b/public/uploads/rules/retain-deleted-records-with-a-soft-delete/rule.mdx
@@ -8,7 +8,7 @@ authors:
   - title: Adam Cogan
     url: 'https://www.ssw.com.au/people/adam-cogan'
 redirects:
-  - data-do-you-avoid-deleting-records-by-flagging-them-as-isdeleted-aka-soft-delete
+  - data-avoid-deleting-records-by-flagging-them-as-isdeleted
   - data-do-you-avoid-deleting-records-by-flagging-them-as-isdeleted-(aka-soft-delete)
   - do-you-know-you-can-retain-deleted-records-with-a-soft-delete
 guid: 56fff82d-9ed7-4aee-ab22-68e4c61fe162


### PR DESCRIPTION

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Fixing a stale/incorrect redirect slug on the "Avoid Deleting Records by Flagging as IsDeleted (Soft Delete)" rule page — the old redirect entry didn't match the current URL pattern.

> 2. What was changed?

✏️ Updated the `redirects` list in the front matter: replaced `data-do-you-avoid-deleting-records-by-flagging-them-as-isdeleted-aka-soft-delete` with `data-avoid-deleting-records-by-flagging-them-as-isdeleted` so old links to this rule resolve correctly.
