### PR TITLE
Enhance rule linking guidance to prevent repetition

### DIFF
--- a/public/uploads/rules/avoid-repetition/rule.mdx
+++ b/public/uploads/rules/avoid-repetition/rule.mdx
@@ -127,3 +127,37 @@ If the same emoji appears **3 or more times**, move it to the intro sentence ins
   figurePrefix="good"
   figure="Following the DRY principle"
 />
+## Links
+
+DRY also applies to how you link between rules. Repeating a link to the same rule more than once **within the same piece of written content** creates clutter and reads like keyword stuffing. Link it once, then refer back to it by name if you mention it again.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Check your audio devices for the best quality and make sure your audio is clear and not distracting. E.g. Position the microphone close to your mouth (see rule - [Do you use a mic for better audio for mobile phone recordings?](/better-audio-on-phones/))
+
+    If you're recording on your phone, [using an external USB-C microphone](/better-audio-on-phones/) is an easy and cheap way to improve audio quality.
+  </>}
+  figurePrefix="bad"
+  figure="The same rule is linked twice, creating clutter and confusion."
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Check your audio devices for the best quality and make sure your audio is clear and not distracting. E.g. Position the microphone close to your mouth.
+
+    If you're recording on your phone, using an external USB-C microphone is an easy and cheap way to improve audio quality. (see rule - [Do you use a mic for better audio for mobile phone recordings?](/better-audio-on-phones/))
+  </>}
+  figurePrefix="good"
+  figure="Link is only used once and added near relevant content."
+/>
+
+<boxEmbed
+  style="info"
+  body={<>
+    **Note:** This does not apply across separate components on a page. For example, the written content of a rule and the "Related Rules" list are two different components serving two different purposes, so repetition is not a concern.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Email Subject "Suggestions – Adding supplementary rule link to Done Video SugarLearning"

Decision: in-body links & `related` links to the same rule are **not** a violation of DRY principles. Linking in both places is good for organization and discoverability by users.

> 2. What was changed?

✏️ Added `Links` section to the content, with good and bad figures.

> 3. I paired or mob programmed with: 
✏️ @18-th @bradystroud @calumjs @vladislav-kir 