### PR TITLE
New rule - Do you follow good Microsoft Teams meeting etiquette?

### DIFF
--- a/categories/communication/rules-to-better-meetings.mdx
+++ b/categories/communication/rules-to-better-meetings.mdx
@@ -15,6 +15,7 @@ index:
   - rule: public/uploads/rules/start-and-finish-on-time/rule.mdx
   - rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
   - rule: public/uploads/rules/teams-meeting-etiquette/rule.mdx
+  - rule: public/uploads/rules/microsoft-teams-etiquette/rule.mdx
   - rule: public/uploads/rules/meetings-in-english/rule.mdx
   - rule: public/uploads/rules/stick-to-the-agenda-and-complete-the-meetings-goal/rule.mdx
   - rule: public/uploads/rules/keep-track-of-a-parking-lot-for-topics/rule.mdx

--- a/categories/communication/rules-to-better-microsoft-teams.mdx
+++ b/categories/communication/rules-to-better-microsoft-teams.mdx
@@ -12,6 +12,7 @@ index:
   - rule: public/uploads/rules/teams-group-chat/rule.mdx
   - rule: public/uploads/rules/warn-when-leaving-a-call/rule.mdx
   - rule: public/uploads/rules/teams-meeting-etiquette/rule.mdx
+  - rule: public/uploads/rules/microsoft-teams-etiquette/rule.mdx
   - rule: public/uploads/rules/when-to-use-meet-now/rule.mdx
   - rule: public/uploads/rules/send-appointment-or-teams-meeting/rule.mdx
   - rule: public/uploads/rules/do-you-make-your-team-meetings-easy-to-find/rule.mdx

--- a/public/uploads/rules/microsoft-teams-etiquette/rule.mdx
+++ b/public/uploads/rules/microsoft-teams-etiquette/rule.mdx
@@ -1,0 +1,54 @@
+---
+type: rule
+title: Do you follow good Microsoft Teams meeting etiquette?
+seoDescription: Hybrid meetings work better when everyone shares the same context. Learn four simple habits — introducing room attendees, announcing yourself, sharing screens respectfully, and finishing with a recorded summary.
+guid: 1fbc415f-dbef-4260-9779-ef9a665122eb
+uri: microsoft-teams-etiquette
+created: 2026-08-25T00:00:00.000Z
+authors:
+  - title: Adam Cogan
+    url: https://www.ssw.com.au/people/adam-cogan
+related:
+  - rule: public/uploads/rules/teams-meeting-etiquette/rule.mdx
+  - rule: public/uploads/rules/warn-when-leaving-a-call/rule.mdx
+  - rule: public/uploads/rules/start-meetings-with-energy/rule.mdx
+  - rule: public/uploads/rules/do-you-share-screens-when-working-remotely/rule.mdx
+  - rule: public/uploads/rules/use-ai-for-meeting-notes/rule.mdx
+  - rule: public/uploads/rules/consent-to-record/rule.mdx
+categories:
+  - category: categories/communication/rules-to-better-microsoft-teams.mdx
+  - category: categories/communication/rules-to-better-meetings.mdx
+archivedreason: null
+isArchived: false
+---
+
+Hybrid meetings can become confusing when some attendees are together in a room while others join remotely — remote participants often miss context that is obvious to those on-site. A few simple habits make sure everyone shares the same experience:
+
+<endIntro />
+
+<youtubeEmbed url="https://youtu.be/aVwT934Xi-U" description={"Microsoft Teams Etiquette: Simple Habits That Make Meetings Better (3 min)"} />
+
+## Tip 1: Introduce people in the room
+
+When someone joins remotely, tell them who is physically present. Remote attendees may not be able to see everyone in the room and need that context to follow the conversation.
+
+## Tip 2: Announce yourself when joining
+
+If you join a meeting already in progress, say hello and identify yourself. This avoids the awkward moment later when the group has to work out who joined mid-call.
+
+## Tip 3: Share your screen respectfully
+
+Don't unexpectedly take over somebody else's screen share. Let them know you want to share, wait until they are ready, then hand control back when you are finished.
+
+## Tip 4: Finish with a recorded summary
+
+Before ending the meeting, summarize the key decisions and action items out loud. Recording the summary creates a useful record and allows AI tools to turn the discussion into documentation or a PBI automatically.
+
+<boxEmbed
+  style="info"
+  body={<>
+    **Tip:** In a good hybrid meeting, remote attendees should have the same context as the people sitting in the room.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>


### PR DESCRIPTION
New rule covering hybrid meeting etiquette for Microsoft Teams.

URI: microsoft-teams-etiquette
Author: Adam Cogan
Categories: Rules to Better Microsoft Teams + Rules to Better Meetings

Covers 4 practices: introducing room attendees, announcing yourself when joining, sharing screens respectfully, and finishing with a recorded summary. Includes the YouTube video and a Tip info box.

Note: a related rule exists at teams-meeting-etiquette — this one follows a different format with the video prominently placed and structured tip headings.

Generated with Claude Code