### PR TITLE
content: add rule - Conflict - Do you end disagreements with an agreement or a follow-up?

### DIFF
--- a/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
+++ b/categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
@@ -13,6 +13,7 @@ index:
   - rule: public/uploads/rules/investigate-before-asking-someone-on-im/rule.mdx
   - rule: public/uploads/rules/best-effort-before-asking-for-help/rule.mdx
   - rule: public/uploads/rules/elephant-in-the-room/rule.mdx
+  - rule: public/uploads/rules/resolve-disagreements/rule.mdx
   - rule: public/uploads/rules/follow-up-effectively/rule.mdx
   - rule: public/uploads/rules/do-you-know-the-5-dysfunctions-of-a-team/rule.mdx
   - rule: public/uploads/rules/teamwork-pillars/rule.mdx

--- a/categories/communication/rules-to-better-communication.mdx
+++ b/categories/communication/rules-to-better-communication.mdx
@@ -25,6 +25,7 @@ index:
   - rule: public/uploads/rules/do-you-know-you-should-write-notes-when-an-activity-is-going/rule.mdx
   - rule: public/uploads/rules/loop-someone-in/rule.mdx
   - rule: public/uploads/rules/speak-up/rule.mdx
+  - rule: public/uploads/rules/resolve-disagreements/rule.mdx
   - rule: public/uploads/rules/match-tone-with-intent/rule.mdx
   - rule: public/uploads/rules/avoid-but/rule.mdx
   - rule: public/uploads/rules/the-happiness-equation/rule.mdx

--- a/public/uploads/rules/resolve-disagreements/rule.mdx
+++ b/public/uploads/rules/resolve-disagreements/rule.mdx
@@ -1,0 +1,136 @@
+---
+type: rule
+archivedreason: null
+title: Conflict - Do you end disagreements with an agreement or a follow-up?
+uri: resolve-disagreements
+guid: 3a5e4857-3d73-458c-8c7e-2eb7a58707f8
+seoDescription: 'A thumbs up is not a resolution. Every disagreement should end with either an explicit agreement or a follow-up conversation booked in the calendar.'
+created: 2026-08-27T00:00:00.000Z
+authors:
+  - title: Ulysses Maclaren
+    url: 'https://www.ssw.com.au/people/ulysses-maclaren'
+  - title: Adam Cogan
+    url: 'https://www.ssw.com.au/people/adam-cogan'
+related:
+  - rule: public/uploads/rules/fix-problems-quickly/rule.mdx
+  - rule: public/uploads/rules/meaningful-chat-reactions/rule.mdx
+  - rule: public/uploads/rules/elephant-in-the-room/rule.mdx
+  - rule: public/uploads/rules/for-the-record/rule.mdx
+  - rule: public/uploads/rules/if-communication-is-not-simple-call-the-person-instead-of-im/rule.mdx
+  - rule: public/uploads/rules/handle-passive-aggressive-comments/rule.mdx
+categories:
+  - category: categories/communication/rules-to-better-communication.mdx
+  - category: categories/client-engagement/rules-to-better-software-consultants-working-in-a-team.mdx
+---
+
+Disagreements at work often go back and forth. One person makes a point, the other responds defensively, and the discussion stops being productive. Eventually someone sends a 👍 and the thread goes quiet.
+
+The conversation ended, but the disagreement didn't. Nothing was actually agreed, so the same issue comes back next week.
+
+<endIntro />
+
+## A 👍 is not a resolution
+
+On a tense thread, a thumbs up is not agreement - it is an escape hatch. It looks like closure, but it usually means *"fine, whatever"*, and both people walk away with a different idea of what happens next.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **Alex:** Please don't deploy on a Friday afternoon again.
+
+    **Sam:** 👍
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - The conversation stopped, but nothing was agreed - so it will happen again"
+/>
+
+This is a different problem to using 👍 as a status update. For reactions on everyday messages, see [Do you keep your chat reactions meaningful?](/meaningful-chat-reactions)
+
+## End every disagreement 1 of 2 ways
+
+A disagreement is only finished when there is:
+
+1. **An explicit agreement** - a clear yes or no, in words
+2. **A booked follow-up** - a specific time to finish the conversation
+
+Anything else is kicking the can down the road.
+
+## Option 1 - Ask for an explicit agreement
+
+Often the other person is not going to die on this hill. They have reasons for preferring their way, but they can see the other point of view - they are just in a defensive mindset.
+
+The way through is to name the disagreement, say why it matters, and ask for a straight answer.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I can see we're not quite seeing eye to eye on this, and I know you've got your reasons for preferring the other way. But this one is important to me, and I'd like it done this way every time. Can you agree to that?"
+  </>}
+  figurePrefix="good"
+  figure="Good example - Names the disagreement, gives the reason, and asks for a yes or no"
+/>
+
+The value is that it forces a real answer. When someone says *"OK, I'm not going to die on this hill - I'll do it your way from now on"*, that is an agreement worth having.
+
+It also makes next time easy. Instead of restarting the whole argument, the conversation becomes *"Hey, we agreed on this one"* - which is a much shorter and friendlier discussion.
+
+## Option 2 - Book the follow-up
+
+Sometimes the mindset isn't right. Emotions are running high, someone is being defensive, or it is the end of a long day. That is a bad time to force a resolution - but a great time to book one.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **Bad:** "Let's talk about it later."
+
+    **Good:** "I can see we're not going to land this now, and it's important to me. Can we grab 15 minutes on Monday at 10am to sort it out?"
+  </>}
+  figurePrefix="good"
+  figure="Good example - A follow-up with a real time beats a vague promise that never happens"
+/>
+
+"Later" never arrives. Give it a time, send the invite, and let the other person cool off knowing the issue is not being swept away.
+
+<boxEmbed
+  style="info"
+  body={<>
+    **Tip:** If a disagreement is going back and forth over IM, that is a strong signal it should be a call. See [Calling - Do you call instead of IM when communication is not simple?](/if-communication-is-not-simple-call-the-person-instead-of-im)
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+## Get their agreement - don't force it
+
+The goal is agreement, not surrender. Shutting the conversation down wins the exchange and loses the person - they will comply while it is fresh, then quietly go back to their own way later.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I don't want to hear it. Just do it my way."
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - Bullying someone into silence is not agreement"
+/>
+
+Leaning on seniority has the same problem. It ends the discussion without ever getting a genuine yes.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I'm going to have to pull rank on this one."
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - Rank closes the conversation, but leaves the disagreement intact"
+/>
+
+> I certainly wouldn't like to say "I'm going to pull rank here and tell you to do it". I wouldn't like that.\
+> **Adam Cogan, SSW**
+
+Explaining *why* it matters and then asking for agreement gets to the same outcome, and the agreement actually sticks.
+
+## When agreement is impossible
+
+Occasionally a follow-up conversation still ends without agreement. That is fine - but make the position clear in writing so nobody is surprised later. See [Do you send a 'For the record' email when you disagree?](/for-the-record)
+
+And once the dust settles, offer an olive branch. See [Conflict - Do you fix problems quickly?](/fix-problems-quickly)


### PR DESCRIPTION
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Closes #13240 - raised by @uly1 via YakShaver, from a conversation with @adamcogan about disagreements that fizzle out on a 👍 without ever being resolved.

Checked first for an existing rule - there isn't one. The closest are [Conflict - Do you fix problems quickly?](https://www.ssw.com.au/rules/fix-problems-quickly) (covers *starting* the conversation, not closing it out) and [Do you keep your chat reactions meaningful?](https://www.ssw.com.au/rules/meaningful-chat-reactions) (👍 as a status update, not as an exit from a disagreement). This rule fills the gap and links to both.

> 2. What was changed?

New rule: **Conflict - Do you end disagreements with an agreement or a follow-up?** (`/resolve-disagreements`)

The core idea - a disagreement is only finished when there is either an **explicit agreement** (a clear yes or no, in words) or a **booked follow-up** (a specific time, not "let's talk later").

* Explains the pain of defensive back-and-forth that ends on a 👍
* Option 1 - phrasing to ask for a straight yes/no when the other person isn't going to die on this hill
* Option 2 - phrasing to book a real follow-up when the mindset isn't right
* Bad examples for bullying ("just do it my way") and pulling rank, with @adamcogan's quote on why rank doesn't get you genuine agreement
* Falls back to [For the record](https://www.ssw.com.au/rules/for-the-record) when agreement is genuinely impossible

Added to 2 categories: Rules to Better Communication, and Rules to Better Software Consultants - Working in a Team.

Frontmatter validator and markdownlint both pass.

**Note for reviewers:** the rule is text-only - no figures yet. A Teams screenshot of a 👍 dead-end thread would be a good addition if someone wants to grab one.

> 3. I paired or mob programmed with:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
