### PR TITLE
🐛 Fix malformed redirects breaking all TinaCMS saves

### DIFF
--- a/public/uploads/rules/production-do-you-know-how-to-record-live-video-interviews-on-location/rule.mdx
+++ b/public/uploads/rules/production-do-you-know-how-to-record-live-video-interviews-on-location/rule.mdx
@@ -12,7 +12,7 @@ lastUpdated: 2021-07-07 00:42:57.670000+00:00
 lastUpdatedBy: bradystroud
 lastUpdatedByEmail: bradystroud@users.noreply.github.com
 redirects:
-- document: rules/production-do-you-know-how-to-record-live-video-interviews-on-location.mdx
+- production-do-you-know-how-to-record-live-video-interviews-on-location
 seoDescription: Recording live video interviews on location requires attention to
   audio, lighting, and framing. Simplify the process by having the interviewer hold
   the camera and use a tight frame, rule of thirds, and smooth zooms.


### PR DESCRIPTION
No linked issue - hotfix for a live content outage.

**TL;DR** - One malformed `redirects` entry on `main` has been failing every TinaCMS "Save (ready for review)" in SSW.Rules since 26 Aug.

**Pain:** https://github.com/SSWConsulting/SSW.Rules.Content/pull/13232 changed `redirects: []` into a list of objects (`- document: rules/...mdx`). The field is declared `type: "string", list: true`, so indexing calls `.replace()` on each entry, gets an object, and throws `val.replace is not a function` / `Unable to seed .../rule.mdx`. The editorial workflow indexes every newly created branch from `main`, so every editor saving any rule fails, seeing only "Failed to complete workflow. Please try again." Since the bad file landed on 26 Aug 13:57 AEST there have been 11 failed saves across 2 editors, 5 orphan branches and zero PRs.

**Solution:** Restore the bare-string form (the pre-shortening URI), matching every other rule in the repo. This is the only file with the object shape, so it is the only landmine.
