### PR TITLE
Humanise the Handy dictation rule

### DIFF
--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -2,7 +2,7 @@
 type: rule
 title: Do you use the right dictation tool for AI agents?
 uri: handy-dictation-tool
-seoDescription: Dictation only sticks when it is one hotkey in every app, so use Handy everywhere including your AI CLI. On Windows pick Parakeet over Whisper, and add custom words so your product names transcribe correctly.
+seoDescription: Dictation only sticks when it is one hotkey in every app, so use Handy everywhere including your AI CLI, and add custom words so your product names transcribe correctly.
 guid: 37041b24-e07b-4422-a259-7f4eb865a38b
 created: 2026-04-23T00:00:00.000Z
 authors:
@@ -113,27 +113,6 @@ It's also missing in places you might well be working. It needs a Claude.ai acco
 
 **Learn more:** [Claude Code voice dictation docs](https://code.claude.com/docs/en/voice-dictation)
 
-## On Windows, choose **Parakeet**, not Whisper
-
-Handy ships both Whisper and Parakeet models, and on Windows the Whisper path is the flaky one.
-
-Handy's own README warns that Whisper models crash on certain Windows and Linux configurations. Whispering hit the same wall and pulled whisper.cpp and Moonshine out of its Windows builds in [v7.11.0](https://github.com/EpicenterHQ/epicenter/releases/tag/v7.11.0), after CPU-only Windows machines crashed at launch with `vulkan-1.dll was not found`. Its Windows builds are Parakeet only now.
-
-Parakeet runs on ONNX Runtime. No Vulkan, no CUDA, works on any machine.
-
-<boxEmbed
-  style="greybox"
-  body={<>
-    **Parakeet Unified EN 0.6B** (731 MB, English only)
-  </>}
-  figurePrefix="good"
-  figure="Good example - The model to pick in Handy on Windows"
-/>
-
-One bug to know about: on Windows, Parakeet Unified sometimes drops the last word of a sentence in 0.9.6 ([cjpais/Handy issue #1983](https://github.com/cjpais/Handy/issues/1983), still open).
-
-Skip Canary 180M Flash, which is too small, and skip Nemotron, which is multilingual and does nothing for an Australian English audience.
-
 ## Configure it properly
 
 3 tweaks take Handy from "works" to "used every day":
@@ -168,7 +147,7 @@ Save custom words for the places where nothing will fix it for you afterwards: a
 Worth knowing, because it explains why some entries work and others quietly do nothing:
 
 * **With Whisper models**, your custom words go in as the `initial_prompt`, so they bias recognition itself
-* **With anything else, which on Windows means Parakeet**, recognition isn't biased at all. Handy runs a fuzzy correction pass over the finished transcript instead
+* **With any other model**, recognition isn't biased at all. Handy runs a fuzzy correction pass over the finished transcript instead
 
 In that pass, every run of 1 to 3 words is stripped of punctuation, lowercased and concatenated, then compared against your custom word treated the same way. So "yak shaver" becomes `yakshaver`, the entry YakShaver becomes `yakshaver`, they match exactly, and the correction lands. Scoring is Levenshtein distance normalised by length, with a heavy Soundex phonetic boost, accepted below a threshold that defaults to 0.18.
 

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -28,7 +28,7 @@ Dictation fixes it. Most people quit before they find a tool that works, because
 <endIntro />
 
 <boxEmbed
-  style="warning"
+  style="tips"
   body={<>
     **Dictate intent and constraints, not code.**
 

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -21,9 +21,9 @@ categories:
 isArchived: false
 ---
 
-Typing is now the bottleneck. An AI agent will happily take 3 times the context you would ever bother typing, including your constraints, your edge cases and the things you explicitly do not want. Most people never give it that, because typing a paragraph is tedious, so they send a one-liner and get a one-liner's worth of quality back.
+Typing is the bottleneck now. An agent will happily take 3 times the context you'd ever bother typing: your constraints, your edge cases, the things you explicitly don't want. Almost nobody gives it that. Typing a paragraph is a chore, so you send a one-liner and get a one-liner's quality back.
 
-Dictation fixes that, but most people give up on it before they find a tool that works. The tools you try first are bad in specific ways: they are slow, they clip the start of your sentence, and they cannot spell your own product names.
+Dictation fixes it. Most people quit before they find a tool that works, because the first ones you try are slow, clip the start of your sentence, and can't spell your own product names.
 
 <endIntro />
 
@@ -32,7 +32,7 @@ Dictation fixes that, but most people give up on it before they find a tool that
   body={<>
     **Dictate intent and constraints, not code.**
 
-    Describing what you want and what you do not want works well, because the model imposes the structure. Speaking out variable names, brackets and indentation does not.
+    Describe what you want and what you don't want. The model handles the structure. Speaking out variable names, brackets and indentation is a waste of breath.
   </>}
   figurePrefix="none"
   figure=""
@@ -40,31 +40,31 @@ Dictation fixes that, but most people give up on it before they find a tool that
 
 ## Use one tool everywhere: **Handy**
 
-What decides whether dictation sticks is not accuracy or speed. It is whether it is the same action in every context.
+Accuracy and speed matter less than you'd think. What makes dictation stick is pressing the same key everywhere: an email, VS Code, a commit message, Claude chat, a Teams reply, your agent's prompt. Once you stop checking whether this app has a mic button, it's automatic.
 
-The same key in an email, in VS Code, in a commit message, in Claude chat, in a Teams reply, and in your agent's prompt. You stop thinking about which app you are in and whether this one has a mic button, and it becomes automatic. That rules out per-app mic buttons, and it rules out running a different dictation tool inside your AI CLI than the one you use everywhere else. Pick one hotkey and use it for everything.
+So no per-app mic buttons, and don't run one dictation tool inside your AI CLI and a different one everywhere else. Pick one hotkey and use it for everything.
 
-[Handy](https://handy.computer/) is the tool to pick. It is a free, open-source (MIT) push-to-talk app for Windows, macOS and Linux. Press a shortcut, speak, and your words are pasted into whatever text field has focus.
+[Handy](https://handy.computer/) is the one to pick. Free, open source (MIT), push-to-talk, and it runs on Windows, macOS and Linux. Press the shortcut, talk, and your words paste into whatever field has focus.
 
 * `winget install cjpais.Handy` on Windows
 * `brew install --cask handy` on macOS
 
 ### ✅ Why Handy
 
-* **One shortcut everywhere** - It types into whatever has focus, so there is nowhere it does not work: your terminal, your IDE, your browser, Teams, a commit message
-* **Runs entirely on device** - Nothing leaves your machine. When you dictate a paragraph of context to an agent, that paragraph usually contains client details, so this is the point that matters most for a consultancy
+* **One shortcut everywhere** - It types into whatever has focus, so there's nowhere it doesn't work: your terminal, your IDE, your browser, Teams, a commit message
+* **Runs on device** - Nothing leaves your machine. The paragraph of context you dictate to an agent usually has client details in it, so for a consultancy this is the one that matters
 * **You can teach it your vocabulary** - Custom words fix the product names and people's names that every model mangles (see [below](#configure-it-properly))
 * **No warm-up** - Recording starts on the keypress
 * **Free and open source** - See the code on [GitHub](https://github.com/cjpais/Handy)
 
-That 4th point is worth dwelling on, because it is the single most annoying failure mode of in-app dictation and almost nobody diagnoses it.
+The no warm-up point sounds minor. It's the reason most people give up on in-app dictation, and almost nobody works out what actually went wrong.
 
 <boxEmbed
   style="greybox"
   body={<>
-    You click the microphone button in the Claude or ChatGPT app, start talking straight away (and you will), and the first few words never make it. The button needs a moment to spin up.
+    You click the mic button in the Claude or ChatGPT app and start talking straight away, because of course you do. The first few words never make it. The button needs a moment to spin up.
 
-    Your transcript starts mid-sentence, you retype it by hand, and after the 3rd time you abandon the habit.
+    Your transcript starts mid-sentence, you retype it by hand, and the 3rd time it happens you stop bothering.
   </>}
   figurePrefix="bad"
   figure="Bad example - An in-app mic button that clips the start of every sentence"
@@ -73,18 +73,18 @@ That 4th point is worth dwelling on, because it is the single most annoying fail
 <boxEmbed
   style="greybox"
   body={<>
-    You press the Handy hotkey and start talking immediately. Recording begins on the keypress, so the first words land.
+    You press the Handy hotkey and talk. Recording starts on the keypress, so the first words land.
   </>}
   figurePrefix="good"
   figure="Good example - Push-to-talk that is recording from the moment the key goes down"
 />
 
-Handy is also the reason you do not need to pay a subscription for this. [Wispr Flow](https://wisprflow.ai/pricing) is USD $12/user/month billed annually (USD $15 monthly) and [Aqua Voice](https://aquavoice.com/pricing) is USD $8/month billed annually (USD $10 monthly). Both are cloud-based, which reintroduces the confidentiality question that Handy avoids.
+Handy is also why you don't need a subscription for this. [Wispr Flow](https://wisprflow.ai/pricing) is USD $12/user/month billed annually (USD $15 monthly) and [Aqua Voice](https://aquavoice.com/pricing) is USD $8/month billed annually (USD $10 monthly). Both are cloud-based, so you get the confidentiality question back.
 
 <boxEmbed
   style="greybox"
   body={<>
-    Windows' built-in `Win+H` dictation. It is slow and unreliable, and it is the reason most people conclude that dictation is not for them before they ever try something good.
+    Windows' built-in `Win+H` dictation. Slow, unreliable, and the reason most people decide dictation isn't for them before they ever try anything good.
   </>}
   figurePrefix="bad"
   figure="Bad example - The OS dictation that puts people off dictation entirely"
@@ -92,20 +92,20 @@ Handy is also the reason you do not need to pay a subscription for this. [Wispr 
 
 ## What about Claude Code's built-in **/voice**?
 
-Claude Code has dictation built in. Run `/voice`, hold `Space` while you speak, then release. Transcription is free (it does not consume tokens and does not count toward the limits shown in `/usage`), and it is tuned for coding vocabulary.
+Claude Code has dictation built in. Run `/voice`, hold `Space` while you talk, then release. It's free (no tokens, and it doesn't count toward the limits in `/usage`) and it's tuned for coding vocabulary.
 
-It costs nothing to try, and it is not bad. It is still not worth switching tools for:
+It's fine. It's still not worth switching tools for:
 
-* **It breaks the one-shortcut habit** - `/voice` does not exist in Claude chat, in Codex, in your browser, in your IDE or in Teams, so you need Handy for all of those anyway. Two dictation keys is worse than one, and the one you use in the other 20 apps is the one that will win
-* **You cannot teach it your vocabulary** - There is no custom words equivalent. Its recognition hints are your project name and git branch, added automatically, and there is no way to add your own terms. YakShaver, SugarLearning and your colleagues' names will keep coming out wrong, every time
-* **Audio is sent to Anthropic for transcription** - It is not processed on your machine, unlike Handy. Under a client confidentiality agreement that is a question you have to answer, and with Handy you never have to
+* **It breaks the one-shortcut habit** - `/voice` doesn't exist in Claude chat, in Codex, in your browser, in your IDE or in Teams, so you need Handy for all of those anyway. Two dictation keys is worse than one, and the key you use in the other 20 apps is the one that wins
+* **You can't teach it your vocabulary** - There's no custom words equivalent. Its only recognition hints are your project name and git branch, added automatically. YakShaver, SugarLearning and your colleagues' names will keep coming out wrong, every time
+* **Your audio goes to Anthropic** - It's not transcribed on your machine, unlike Handy. Under a client confidentiality agreement that's a question you have to answer. With Handy it never comes up
 
-It is also unavailable in places you may well be working. It needs a Claude.ai account, so it does not work with an Anthropic API key, Amazon Bedrock, Google Cloud or Microsoft Foundry, and it does not work over SSH or in Claude Code on the web because the microphone is local. Handy has none of those limits, because it just types into whatever is in front of you.
+It's also missing in places you might well be working. It needs a Claude.ai account, so it's out with an Anthropic API key, Amazon Bedrock, Google Cloud or Microsoft Foundry, and it's out over SSH or in Claude Code on the web, because the microphone is local. Handy has none of those limits. It just types into whatever's in front of you.
 
 <boxEmbed
   style="greybox"
   body={<>
-    Use `/voice` when you are on a machine that does not have Handy installed and you want dictation right now. Then install Handy.
+    Use `/voice` when you're on a machine that doesn't have Handy and you want dictation right now. Then install Handy.
   </>}
   figurePrefix="ok"
   figure="OK example - /voice as a stopgap, not as your dictation setup"
@@ -115,11 +115,11 @@ It is also unavailable in places you may well be working. It needs a Claude.ai a
 
 ## On Windows, choose **Parakeet**, not Whisper
 
-This is the non-obvious bit. Handy ships both Whisper and Parakeet models, and on Windows the Whisper path is the flaky one.
+Handy ships both Whisper and Parakeet models, and on Windows the Whisper path is the flaky one.
 
-Handy's own README warns that Whisper models crash on certain Windows and Linux configurations. It is not only Handy: Whispering removed whisper.cpp and Moonshine from its Windows builds entirely in [v7.11.0](https://github.com/EpicenterHQ/epicenter/releases/tag/v7.11.0), after CPU-only Windows machines hit a `vulkan-1.dll was not found` crash at launch. Its Windows builds now ship Parakeet only.
+Handy's own README warns that Whisper models crash on certain Windows and Linux configurations. Whispering hit the same wall and pulled whisper.cpp and Moonshine out of its Windows builds in [v7.11.0](https://github.com/EpicenterHQ/epicenter/releases/tag/v7.11.0), after CPU-only Windows machines crashed at launch with `vulkan-1.dll was not found`. Its Windows builds are Parakeet only now.
 
-Parakeet runs on ONNX Runtime and needs no Vulkan and no CUDA, so it works on any machine.
+Parakeet runs on ONNX Runtime. No Vulkan, no CUDA, works on any machine.
 
 <boxEmbed
   style="greybox"
@@ -130,19 +130,19 @@ Parakeet runs on ONNX Runtime and needs no Vulkan and no CUDA, so it works on an
   figure="Good example - The model to pick in Handy on Windows"
 />
 
-One known bug to be aware of: on Windows, Parakeet Unified sometimes drops the last word of a sentence in 0.9.6 ([cjpais/Handy issue #1983](https://github.com/cjpais/Handy/issues/1983), still open).
+One bug to know about: on Windows, Parakeet Unified sometimes drops the last word of a sentence in 0.9.6 ([cjpais/Handy issue #1983](https://github.com/cjpais/Handy/issues/1983), still open).
 
-Do not bother with Canary 180M Flash, which is too small, or Nemotron, which is multilingual and unnecessary for an Australian English audience.
+Skip Canary 180M Flash, which is too small, and skip Nemotron, which is multilingual and does nothing for an Australian English audience.
 
 ## Configure it properly
 
-These are the tweaks that move Handy from "works" to "used daily":
+3 tweaks take Handy from "works" to "used every day":
 
-1. **Launch at computer startup, and start hidden** - It should always be there and never in the way
+1. **Launch at computer startup, and start hidden** - Always there, never in the way
 2. **Add custom words** for your product names and people's names - Settings, Advanced, Custom Words, type the word, press Enter
-3. **Turn on Auto Submit** - Settings, Advanced. Off by default. It presses the send key for you when the paste lands, so you speak your prompt and let go without touching the keyboard. Pick Ctrl+Enter or Cmd+Enter rather than Enter for anything where Enter means a newline
+3. **Turn on Auto Submit** - Settings, Advanced. Off by default. It presses the send key for you when the paste lands, so you speak your prompt and let go without touching the keyboard. Pick Ctrl+Enter or Cmd+Enter, not Enter, for anything where Enter means a newline
 
-Custom words are the highest-value setting, because the words you dictate most often are exactly the ones every model gets wrong.
+Custom words earn their keep fastest, because the words you say most often are the ones every model gets wrong.
 
 <boxEmbed
   style="greybox"
@@ -157,37 +157,37 @@ Custom words are the highest-value setting, because the words you dictate most o
   figure="Good example - Custom words worth adding at SSW"
 />
 
-Do not add your codebase's symbols. Loading in every class and function name is tempting, and it is unnecessary.
+Don't add your codebase's symbols. Loading in every class and function name is tempting and pointless.
 
-Your agent already has the repo in context, so say "the yak shaver controller" and it will resolve that to `YakShaverController` on its own, because it can see the file. When you are dictating to an agent, the transcript does not need to be exact. It only needs to be close enough to be understood, which is a much lower bar than it sounds.
+Your agent already has the repo in context, so say "the yak shaver controller" and it'll resolve that to `YakShaverController` on its own, because it can see the file. Dictating to an agent doesn't need an exact transcript, only one that's close enough to understand.
 
-Custom words are for the places where nothing is going to fix it for you afterwards: a product name in a client email, a colleague's name in Teams, a commit message. Keep the list short. Every extra entry is another candidate for the fuzzy matcher to test, and another chance for it to fire on something you did not mean.
+Save custom words for the places where nothing will fix it for you afterwards: a product name in a client email, a colleague's name in Teams, a commit message. Keep the list short. Every extra entry is another candidate for the fuzzy matcher to test, and another chance it fires on something you didn't mean.
 
 ### How custom words actually work
 
-Knowing the mechanism explains why some entries work and others quietly do nothing:
+Worth knowing, because it explains why some entries work and others quietly do nothing:
 
-* **With Whisper models**, your custom words are passed as the `initial_prompt`, so they bias recognition itself
-* **With any other model, which on Windows means Parakeet**, recognition is not biased. Handy instead runs a fuzzy correction pass over the finished transcript
+* **With Whisper models**, your custom words go in as the `initial_prompt`, so they bias recognition itself
+* **With anything else, which on Windows means Parakeet**, recognition isn't biased at all. Handy runs a fuzzy correction pass over the finished transcript instead
 
-For that fuzzy pass, every run of 1 to 3 words in the transcript is stripped of punctuation, lowercased and concatenated, then compared against your custom word treated the same way. So "yak shaver" becomes `yakshaver`, the entry YakShaver becomes `yakshaver`, they match exactly, and the correction is applied. Scoring is Levenshtein distance normalised by length, with a heavy Soundex phonetic boost, accepted below a threshold that defaults to 0.18.
+In that pass, every run of 1 to 3 words is stripped of punctuation, lowercased and concatenated, then compared against your custom word treated the same way. So "yak shaver" becomes `yakshaver`, the entry YakShaver becomes `yakshaver`, they match exactly, and the correction lands. Scoring is Levenshtein distance normalised by length, with a heavy Soundex phonetic boost, accepted below a threshold that defaults to 0.18.
 
-That leads to some practical gotchas:
+Hence the gotchas:
 
-* **Multi-word terms work, up to 3 words** - A 4-word phrase will never match
-* **Punctuation breaks a candidate** - "Yak, shaver" will not be corrected
+* **Multi-word terms work, up to 3 words** - A 4-word phrase never matches
+* **Punctuation breaks a candidate** - "Yak, shaver" won't be corrected
 * **Casing comes from the first word** of the matched run
-* **Avoid short acronyms** - There is a length guard of 25% or at least 2 characters, so for a 3-letter entry almost any short word is length-eligible and Soundex can fire on something unintended. Add distinctive coined terms instead
-* **Judge it on what lands, not what flickers** - The live streaming preview can show the raw text while the pasted result is corrected
+* **Avoid short acronyms** - The length guard is 25% or at least 2 characters, so for a 3-letter entry almost any short word is length-eligible and Soundex can fire on something you didn't intend. Use distinctive coined terms instead
+* **Judge what lands, not what flickers** - The live streaming preview can show raw text while the pasted result is corrected
 
-For bulk entry there is no import button. Edit `%APPDATA%\com.pais.handy\settings_store.json`, add to the `custom_words` array, and restart Handy.
+There's no import button for bulk entry. Edit `%APPDATA%\com.pais.handy\settings_store.json`, add to the `custom_words` array, and restart Handy.
 
 ## Other great uses
 
-Once the habit exists, it is not only for prompts:
+Once the habit's there, it's not only for prompts:
 
-* Drafting long emails or docs without RSI
-* Dictating commit messages and PR descriptions
+* Long emails and docs without the RSI
+* Commit messages and PR descriptions
 * Chat replies in Slack or Teams
 * Accessibility - hands-free text input
 

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -28,7 +28,7 @@ Dictation fixes it. Most people quit before they find a tool that works, because
 <endIntro />
 
 <boxEmbed
-  style="highlight"
+  style="warning"
   body={<>
     **Dictate intent and constraints, not code.**
 

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -142,25 +142,6 @@ Your agent already has the repo in context, so say "the yak shaver controller" a
 
 Save custom words for the places where nothing will fix it for you afterwards: a product name in a client email, a colleague's name in Teams, a commit message. Keep the list short. Every extra entry is another candidate for the fuzzy matcher to test, and another chance it fires on something you didn't mean.
 
-### How custom words actually work
-
-Worth knowing, because it explains why some entries work and others quietly do nothing:
-
-* **With Whisper models**, your custom words go in as the `initial_prompt`, so they bias recognition itself
-* **With any other model**, recognition isn't biased at all. Handy runs a fuzzy correction pass over the finished transcript instead
-
-In that pass, every run of 1 to 3 words is stripped of punctuation, lowercased and concatenated, then compared against your custom word treated the same way. So "yak shaver" becomes `yakshaver`, the entry YakShaver becomes `yakshaver`, they match exactly, and the correction lands. Scoring is Levenshtein distance normalised by length, with a heavy Soundex phonetic boost, accepted below a threshold that defaults to 0.18.
-
-Hence the gotchas:
-
-* **Multi-word terms work, up to 3 words** - A 4-word phrase never matches
-* **Punctuation breaks a candidate** - "Yak, shaver" won't be corrected
-* **Casing comes from the first word** of the matched run
-* **Avoid short acronyms** - The length guard is 25% or at least 2 characters, so for a 3-letter entry almost any short word is length-eligible and Soundex can fire on something you didn't intend. Use distinctive coined terms instead
-* **Judge what lands, not what flickers** - The live streaming preview can show raw text while the pasted result is corrected
-
-There's no import button for bulk entry. Edit `%APPDATA%\com.pais.handy\settings_store.json`, add to the `custom_words` array, and restart Handy.
-
 ## Other great uses
 
 Once the habit's there, it's not only for prompts:

--- a/public/uploads/rules/handy-dictation-tool/rule.mdx
+++ b/public/uploads/rules/handy-dictation-tool/rule.mdx
@@ -126,7 +126,7 @@ Custom words earn their keep fastest, because the words you say most often are t
 <boxEmbed
   style="greybox"
   body={<>
-    Product names: **YakShaver**, **SugarLearning**, **TimePRO**
+    Product names: **YakShaver**, **SugarLearning**, **TimePro**
 
     AI tool names you say constantly: **Codex**, **Cowork**, **Claude** (frequently transcribed as "clawed"), **Anthropic**
 


### PR DESCRIPTION
Copy edit of `handy-dictation-tool` to strip the AI writing tells. No changes to facts, links, frontmatter, categories or boxEmbed prefixes.

What changed:

- **Contractions** - the original had none in ~1,700 words, which is the loudest tell and made it read like a policy document
- **Removed the "it is not X, it is Y" flip** - e.g. "What decides whether dictation sticks is not accuracy or speed. It is whether..." became "Accuracy and speed matter less than you'd think. What makes dictation stick is..."
- **Cut the meta-signposting** - "This is the non-obvious bit", "That 4th point is worth dwelling on", "That leads to some practical gotchas", "Knowing the mechanism explains why"
- **Varied sentence length** and broke up the rhythmic three-beat sentences
- **Trimmed flourishes** - "which is a much lower bar than it sounds", "It costs nothing to try, and it is not bad"

One thing worth checking before merge: the Wispr Flow and Aqua Voice prices date from April and may have moved.
