### PR TITLE
Fix dictation rule URI with redirect, and trim custom words section

### DIFF
--- a/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -41,7 +41,7 @@ index:
   - rule: public/uploads/rules/ai-agent-memory-systems/rule.mdx
   - rule: public/uploads/rules/design-system/rule.mdx
   - rule: public/uploads/rules/centralize-ai-workflows/rule.mdx
-  - rule: public/uploads/rules/handy-dictation-tool/rule.mdx
+  - rule: public/uploads/rules/dictation-for-ai-agents/rule.mdx
 created: 2024-08-26T22:47:01.000Z
 createdBy: 'Eddie Kranz [SSW]'
 createdByEmail: EddieKranz@ssw.com.au

--- a/categories/artificial-intelligence/rules-to-better-ai.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai.mdx
@@ -35,7 +35,7 @@ index:
   - rule: public/uploads/rules/ai-investigation-prompts/rule.mdx
   - rule: public/uploads/rules/chatgpt-security-risks/rule.mdx
   - rule: public/uploads/rules/avoid-leading-prompt-questions/rule.mdx
-  - rule: public/uploads/rules/handy-dictation-tool/rule.mdx
+  - rule: public/uploads/rules/dictation-for-ai-agents/rule.mdx
   - rule: public/uploads/rules/ai-agent-memory-systems/rule.mdx
   - rule: public/uploads/rules/verify-ai-skill-safety/rule.mdx
   - rule: public/uploads/rules/feed-data-to-ai/rule.mdx

--- a/categories/communication/rules-to-better-email.mdx
+++ b/categories/communication/rules-to-better-email.mdx
@@ -81,7 +81,7 @@ index:
 - rule: public/uploads/rules/avoid-sarcasm-misunderstanding/rule.mdx
 - rule: public/uploads/rules/autocorrect-in-outlook/rule.mdx
 - rule: public/uploads/rules/dictate-emails/rule.mdx
-- rule: public/uploads/rules/handy-dictation-tool/rule.mdx
+- rule: public/uploads/rules/dictation-for-ai-agents/rule.mdx
 - rule: public/uploads/rules/readable-screenshots/rule.mdx
 - rule: public/uploads/rules/screenshots-avoid-walls-of-text/rule.mdx
 - rule: public/uploads/rules/screenshots-add-branding/rule.mdx

--- a/public/uploads/rules/dictation-for-ai-agents/rule.mdx
+++ b/public/uploads/rules/dictation-for-ai-agents/rule.mdx
@@ -1,7 +1,7 @@
 ---
 type: rule
 title: Do you use the right dictation tool for AI agents?
-uri: handy-dictation-tool
+uri: dictation-for-ai-agents
 seoDescription: Dictation only sticks when it is one hotkey in every app, so use Handy everywhere including your AI CLI. On Windows pick Parakeet over Whisper, and add custom words so your product names transcribe correctly.
 guid: 37041b24-e07b-4422-a259-7f4eb865a38b
 created: 2026-04-23T00:00:00.000Z
@@ -14,6 +14,8 @@ related:
   - rule: public/uploads/rules/dictate-emails/rule.mdx
   - rule: public/uploads/rules/ai-cli-tools/rule.mdx
   - rule: public/uploads/rules/best-ai-tools/rule.mdx
+redirects:
+  - handy-dictation-tool
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
   - category: categories/artificial-intelligence/rules-to-better-ai.mdx
@@ -165,22 +167,14 @@ Custom words are for the places where nothing is going to fix it for you afterwa
 
 ### How custom words actually work
 
-Knowing the mechanism explains why some entries work and others quietly do nothing:
+Whisper models take your custom words as the `initial_prompt`, so they bias recognition itself. Every other model, which on Windows means Parakeet, is not biased - Handy runs a fuzzy match over the finished transcript instead. That leaves a few limits worth knowing:
 
-* **With Whisper models**, your custom words are passed as the `initial_prompt`, so they bias recognition itself
-* **With any other model, which on Windows means Parakeet**, recognition is not biased. Handy instead runs a fuzzy correction pass over the finished transcript
+* **Up to 3 words per entry** - A longer phrase will never match
+* **Punctuation breaks a match** - "Yak, shaver" will not be corrected
+* **Avoid short acronyms** - They fire on the wrong word too easily. Use distinctive coined terms instead
+* **Judge it on what lands, not what flickers** - The streaming preview can show raw text while the pasted result is corrected
 
-For that fuzzy pass, every run of 1 to 3 words in the transcript is stripped of punctuation, lowercased and concatenated, then compared against your custom word treated the same way. So "yak shaver" becomes `yakshaver`, the entry YakShaver becomes `yakshaver`, they match exactly, and the correction is applied. Scoring is Levenshtein distance normalised by length, with a heavy Soundex phonetic boost, accepted below a threshold that defaults to 0.18.
-
-That leads to some practical gotchas:
-
-* **Multi-word terms work, up to 3 words** - A 4-word phrase will never match
-* **Punctuation breaks a candidate** - "Yak, shaver" will not be corrected
-* **Casing comes from the first word** of the matched run
-* **Avoid short acronyms** - There is a length guard of 25% or at least 2 characters, so for a 3-letter entry almost any short word is length-eligible and Soundex can fire on something unintended. Add distinctive coined terms instead
-* **Judge it on what lands, not what flickers** - The live streaming preview can show the raw text while the pasted result is corrected
-
-For bulk entry there is no import button. Edit `%APPDATA%\com.pais.handy\settings_store.json`, add to the `custom_words` array, and restart Handy.
+There is no import button. For bulk entry, edit `%APPDATA%\com.pais.handy\settings_store.json`, add to the `custom_words` array, and restart Handy.
 
 ## Other great uses
 


### PR DESCRIPTION
### 1. What triggered this change?

Follow-up to #13253, which renamed the rule to *"Do you use the right dictation tool for AI agents?"* but kept the old `handy-dictation-tool` slug. The rule is no longer about Handy specifically, so the URL no longer matched the title.

### 2. What was changed?

**Fixed the URI and added a redirect**

```yaml
uri: dictation-for-ai-agents
redirects:
  - handy-dictation-tool
```

The folder is renamed to match, per the convention that the folder name equals the `uri`. The old slug is in `redirects`, so the existing URL keeps working. The 3 category indexes that referenced the old path are updated.

**Shortened "How custom words actually work"**

The Levenshtein and Soundex scoring detail, and the 25% length guard, read more like a wiki page than a rule. This keeps the 4 practical limits (3-word cap, punctuation, short acronyms, streaming preview) and drops the algorithm internals. The section goes from 18 lines to 11.

Nothing else in the rule is touched.

**Validation:** frontmatter validator, check-mdx, markdownlint, category-sync and endIntro all pass.

### 3. I paired or mob programmed with:

Claude Code