### PR TITLE
Add rule for natural teleprompter delivery

### DIFF
--- a/categories/marketing-and-video/rules-to-better-video-pre-production.mdx
+++ b/categories/marketing-and-video/rules-to-better-video-pre-production.mdx
@@ -9,6 +9,7 @@ index:
   - rule: public/uploads/rules/video-topic-ideas/rule.mdx
   - rule: public/uploads/rules/consultancy-videos/rule.mdx
   - rule: public/uploads/rules/content-check-before-public-facing-video/rule.mdx
+  - rule: public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
   - rule: public/uploads/rules/define-the-level-of-quality-up-front/rule.mdx
   - rule: public/uploads/rules/what-type-of-microphone-to-use/rule.mdx
   - rule: public/uploads/rules/pre-production-do-you-test-technical-scripts-properly/rule.mdx

--- a/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
+++ b/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
@@ -1,20 +1,25 @@
 ---
 type: rule
 title: Do you use a teleprompter without sounding scripted?
-seoDescription: Learn how to use a teleprompter while keeping natural eye contact, energy, pacing, and an authentic delivery on camera.
-guid: 22423e88-2b17-48c7-8152-677f5f2f356e
 uri: use-a-teleprompter-naturally
-created: 2026-08-31T00:00:00.000Z
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-pre-production.mdx
 authors:
   - title: Marcus Irmscher
-    url: https://www.ssw.com.au/people/marcus-irmscher
+    url: 'https://www.ssw.com.au/people/marcus-irmscher'
 related:
   - rule: public/uploads/rules/content-check-before-public-facing-video/rule.mdx
   - rule: public/uploads/rules/test-please-for-video/rule.mdx
-categories:
-  - category: categories/marketing-and-video/rules-to-better-video-pre-production.mdx
-archivedreason: null
+guid: 22423e88-2b17-48c7-8152-677f5f2f356e
+seoDescription: 'Learn how to use a teleprompter while keeping natural eye contact, energy, pacing, and an authentic delivery on camera.'
+created: 2026-08-31T00:00:00.000Z
+createdBy: Marcus Irmscher
+createdByEmail: MarcusIrmscher@ssw.com.au
+lastUpdated: 2026-09-01T05:05:37.476Z
+lastUpdatedBy: Marcus Irmscher
+lastUpdatedByEmail: MarcusIrmscher@ssw.com.au
 isArchived: false
+archivedreason: null
 ---
 
 A teleprompter can turn a nervous presenter into a confident one. It keeps key messages accurate, reduces retakes, and helps the presenter look at the audience instead of down at notes.
@@ -49,7 +54,7 @@ A script that reads well on paper can sound stiff out loud. Write the way people
   style="greybox"
   body={<>
     **Today, I’ll show you our new AI feature.**
-
+    
     **It removes the repetitive work — so you can focus on what matters.**
   </>}
   figurePrefix="good"
@@ -90,7 +95,7 @@ Before the final take:
 5. Adjust the script, text size, line width, or scroll speed
 
 <boxEmbed
-  style="highlight"
+  style="tips"
   body={<>
     A teleprompter is a safety net, not a cage. Know the message well enough to smile, gesture, pause, and occasionally say a line in your own words.
   </>}

--- a/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
+++ b/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
@@ -1,0 +1,105 @@
+---
+type: rule
+title: Do you use a teleprompter without sounding scripted?
+seoDescription: Learn how to use a teleprompter while keeping natural eye contact, energy, pacing, and an authentic delivery on camera.
+guid: 22423e88-2b17-48c7-8152-677f5f2f356e
+uri: use-a-teleprompter-naturally
+created: 2026-08-31T00:00:00.000Z
+authors:
+  - title: Marcus Irmscher
+    url: https://www.ssw.com.au/people/marcus-irmscher
+related:
+  - rule: public/uploads/rules/content-check-before-public-facing-video/rule.mdx
+  - rule: public/uploads/rules/test-please-for-video/rule.mdx
+categories:
+  - category: categories/marketing-and-video/rules-to-better-video-pre-production.mdx
+archivedreason: null
+isArchived: false
+---
+
+A teleprompter can turn a nervous presenter into a confident one. It keeps key messages accurate, reduces retakes, and helps the presenter look at the audience instead of down at notes.
+
+However, when it is used poorly, the presenter's eyes scan from side to side, their voice becomes flat, and the audience can tell they are reading. The words may be perfect, but the connection is lost.
+
+<endIntro />
+
+The goal is not to hide the teleprompter. The goal is to make the presenter sound like they mean every word.
+
+## Write for the ear, not the page 👂
+
+A script that reads well on paper can sound stiff out loud. Write the way people speak:
+
+* Use short sentences and familiar words
+* Keep one idea per paragraph
+* Add contractions, such as “you’re” instead of “you are”
+* Use line breaks to mark pauses and changes in thought
+* Bold or capitalize only the words that need emphasis
+* Spell difficult names and technical terms phonetically
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **Today I will demonstrate the implementation of our newly developed artificial intelligence capability, which enables users to increase their productivity.**
+  </>}
+  figurePrefix="bad"
+  figure="Bad example - A formal, crowded sentence is difficult to deliver naturally"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **Today, I’ll show you our new AI feature.**
+
+    **It removes the repetitive work — so you can focus on what matters.**
+  </>}
+  figurePrefix="good"
+  figure="Good example - Short, conversational lines make the intended pace clear"
+/>
+
+## Put the words next to the lens 👀
+
+Place the teleprompter directly in front of the camera lens and keep the text close to the centre of the screen. The further the words are from the lens, the more obvious the presenter's eye movement becomes.
+
+Use large text and a narrow line width so each line is easy to absorb at a glance. The presenter should be far enough from the camera that small eye movements are not noticeable.
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** If the audience can see your eyes moving left and right, make the text column narrower, increase the font size, or move the presenter further from the camera.
+  </>}
+  figurePrefix="none"
+  figure="Tune the setup until reading does not create visible eye movement"
+/>
+
+## Let the presenter control the pace 🎙️
+
+The script should follow the presenter — the presenter should not chase the script.
+
+Use a remote, foot pedal, or a teleprompter operator who can match the natural speaking pace. Leave enough space between paragraphs for breathing, smiling, and emphasis. If the presenter stumbles, pause and restart the sentence instead of speeding up to catch the scrolling text.
+
+## Rehearse for meaning, not memorization
+
+Read the script aloud before recording. This exposes tongue-twisters, long sentences, awkward transitions, and words that do not sound like the presenter.
+
+Before the final take:
+
+1. Get the script [content checked](/content-check-before-public-facing-video)
+2. Read it aloud and rewrite anything that feels unnatural
+3. Record a short test and watch it without sound — check for scanning eyes and a frozen expression
+4. Listen without looking — check for flat pacing and unnatural emphasis
+5. Adjust the script, text size, line width, or scroll speed
+
+<boxEmbed
+  style="highlight"
+  body={<>
+    A teleprompter is a safety net, not a cage. Know the message well enough to smile, gesture, pause, and occasionally say a line in your own words.
+  </>}
+  figurePrefix="good"
+  figure="Good example - The presenter uses the script as a guide while staying connected to the audience"
+/>
+
+## Know when not to use one
+
+A teleprompter is useful for polished intros, outros, announcements, compliance-sensitive wording, and short-form videos. For interviews, demonstrations, and personal stories, talking points often feel more authentic and allow the presenter to react naturally.
+
+Choose the lightest tool that gives the presenter confidence without taking away their personality.

--- a/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
+++ b/public/uploads/rules/use-a-teleprompter-naturally/rule.mdx
@@ -15,7 +15,7 @@ seoDescription: 'Learn how to use a teleprompter while keeping natural eye conta
 created: 2026-08-31T00:00:00.000Z
 createdBy: Marcus Irmscher
 createdByEmail: MarcusIrmscher@ssw.com.au
-lastUpdated: 2026-09-01T05:05:37.476Z
+lastUpdated: 2026-09-01T05:08:44.529Z
 lastUpdatedBy: Marcus Irmscher
 lastUpdatedByEmail: MarcusIrmscher@ssw.com.au
 isArchived: false
@@ -78,7 +78,7 @@ Use large text and a narrow line width so each line is easy to absorb at a glanc
 
 ## Let the presenter control the pace 🎙️
 
-The script should follow the presenter — the presenter should not chase the script.
+The script should follow the presenter - the presenter should not chase the script.
 
 Use a remote, foot pedal, or a teleprompter operator who can match the natural speaking pace. Leave enough space between paragraphs for breathing, smiling, and emphasis. If the presenter stumbles, pause and restart the sentence instead of speeding up to catch the scrolling text.
 
@@ -90,8 +90,8 @@ Before the final take:
 
 1. Get the script [content checked](/content-check-before-public-facing-video)
 2. Read it aloud and rewrite anything that feels unnatural
-3. Record a short test and watch it without sound — check for scanning eyes and a frozen expression
-4. Listen without looking — check for flat pacing and unnatural emphasis
+3. Record a short test and watch it without sound - check for scanning eyes and a frozen expression
+4. Listen without looking - check for flat pacing and unnatural emphasis
 5. Adjust the script, text size, line width, or scroll speed
 
 <boxEmbed


### PR DESCRIPTION
Adds a new SSW-style video pre-production rule covering conversational teleprompter scripts, lens placement, pacing, rehearsal, and when talking points are more suitable. Includes good and bad examples, registers the rule in the pre-production category, and lists Marcus Irmscher as the author. All relevant content validators pass.