### PR TITLE
Feature flags: give every flag a lifecycle and a retirement PBI

### DIFF
--- a/public/uploads/rules/use-feature-flags/rule.mdx
+++ b/public/uploads/rules/use-feature-flags/rule.mdx
@@ -177,6 +177,43 @@ app.MapGet("/api/recommendations", async (
 
 **✅ Figure: Good example - Disable expensive features during incidents without redeployment**
 
+## Give every flag a lifecycle
+
+Flags outlive their features. Six months after `NewCheckout` reaches 100%, the flag is still in the code, both branches are still being tested, and nobody remembers whether it is safe to delete. A flag with no exit plan is technical debt that was created on purpose.
+
+Fix this at the moment the flag is created, not at cleanup time. Keep a registry of flags in the repo and require a lifecycle for each one:
+
+* **Temporary** flags carry an expected lifetime and a retirement PBI that is opened when the flag is created. The PBI sits in the backlog with a date, so retirement gets planned like any other work
+* **Permanent** flags (kill switches, operational toggles) carry a named owner. Somebody is accountable for whether it still earns its place
+
+```json
+{
+  "flags": [
+    {
+      "id": "NewCheckout",
+      "description": "New checkout flow for the Northwind store",
+      "lifecycle": "temporary",
+      "expectedLifetime": "2026-11-30",
+      "retirementPbi": "https://github.com/northwind/store/issues/1284"
+    },
+    {
+      "id": "MLRecommendations",
+      "description": "Kill switch for the recommendation service during high load",
+      "lifecycle": "permanent",
+      "owner": "Jane Smith"
+    }
+  ]
+}
+```
+
+**✅ Figure: Good example - Every flag states whether it is temporary or permanent, and who or what retires it**
+
+Then make the registry enforce itself:
+
+* **Fail the build** when a flag has no lifecycle, when a temporary flag has no expected lifetime or retirement PBI, or when a permanent flag has no owner. The rule is only real if a missing field stops the pipeline
+* **Report overdue flags** - a scheduled job or a dashboard that lists temporary flags past their expected lifetime, so the debt is visible in the sprint review rather than discovered by accident
+* **Delete both the flag and the old branch** when you retire it. A retired flag that leaves the fallback code in place has only done half the job
+
 ## When to use feature flags vs configuration
 
 | Use Feature Flags | Use Configuration |
@@ -188,7 +225,7 @@ app.MapGet("/api/recommendations", async (
 
 ## Best practices
 
-1. **Clean up old flags** - Remove flags once features are fully rolled out
+1. **Clean up old flags** - Give each flag a lifecycle when you create it (see above). Temporary flags get a retirement PBI, permanent flags get an owner. Remove a temporary flag and its old branch once the feature is fully rolled out
 2. **Name flags clearly** - Use descriptive names like `NewCheckoutFlow` not `Flag1`
 3. **Default to off** - New features should be disabled by default
 4. **Log flag evaluations** - Track which users see which features

--- a/public/uploads/rules/use-feature-flags/rule.mdx
+++ b/public/uploads/rules/use-feature-flags/rule.mdx
@@ -1,6 +1,6 @@
 ---
 type: rule
-title: Do you use Feature Flags for safer deployments?
+title: Do you use feature flags for safer deployments?
 uri: use-feature-flags
 authors:
   - title: Hajir Lesani
@@ -14,7 +14,7 @@ seoDescription: Learn how to use feature flags for safer deployments, trunk-base
 created: 2026-02-05T00:00:00.000Z
 ---
 
-Deploying new features is risky - bugs can affect all users instantly. Feature flags let you deploy code to production but control who sees new features. You can gradually roll out to 1%, then 10%, then 100% of users, and instantly disable a feature if something goes wrong - no redeployment needed.
+Deploying new features is risky. A bug can affect every user the moment it goes live. Feature flags let you deploy code to production while controlling who sees new features. Gradually roll out to 1%, then 10%, then 100% of users, and instantly disable a feature if something goes wrong, with no redeployment needed.
 
 Feature flags enable trunk-based development, where all developers commit to main and features are hidden behind flags until ready.
 
@@ -28,7 +28,7 @@ Feature flags enable trunk-based development, where all developers commit to mai
 * **A/B testing** - Show different experiences to different user groups
 * **Kill switches** - Disable expensive features during incidents
 
-## Setting up Feature Flags with Microsoft.FeatureManagement
+## Setting up feature flags with Microsoft.FeatureManagement
 
 ```csharp
 // Program.cs
@@ -216,7 +216,7 @@ Then make the registry enforce itself:
 
 ## When to use feature flags vs configuration
 
-| Use Feature Flags | Use Configuration |
+| Use feature flags | Use configuration |
 |-------------------|-------------------|
 | New features being developed | Stable settings (connection strings, URLs) |
 | Gradual rollouts needed | Per-environment differences |

--- a/public/uploads/rules/use-feature-flags/rule.mdx
+++ b/public/uploads/rules/use-feature-flags/rule.mdx
@@ -211,7 +211,7 @@ Fix this at the moment the flag is created, not at cleanup time. Keep a registry
 Then make the registry enforce itself:
 
 * **Fail the build** when a flag has no lifecycle, when a temporary flag has no expected lifetime or retirement PBI, or when a permanent flag has no owner. The rule is only real if a missing field stops the pipeline
-* **Report overdue flags** - a scheduled job or a dashboard that lists temporary flags past their expected lifetime, so the debt is visible in the sprint review rather than discovered by accident
+* **Report overdue flags** - A scheduled job or a dashboard that lists temporary flags past their expected lifetime, so the debt is visible in the sprint review rather than discovered by accident
 * **Delete both the flag and the old branch** when you retire it. A retired flag that leaves the fallback code in place has only done half the job
 
 ## When to use feature flags vs configuration


### PR DESCRIPTION
> 1. What triggered this change?

A sweep of active repos for lessons worth turning into rules. Two unrelated projects, one a client project and one open source, independently built the same thing: a flag registry where each flag must declare whether it is temporary or permanent, temporary flags carry an expected lifetime and a retirement PBI opened at creation, and the build fails when the field is missing. The existing rule has one line on cleanup and no guidance on how to make cleanup happen.

> 2. What was changed?

* New section **Give every flag a lifecycle** in `use-feature-flags`
* Temporary flags: expected lifetime plus a retirement PBI created with the flag. Permanent flags: a named owner
* A Northwind registry example, plus enforcement: fail the build on a missing lifecycle, report overdue flags, delete the old branch when the flag goes
* Best practice 1 now points at the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG4q4SABArdapUR4FYUbBT