### PR TITLE
Code commenting: add the one-year test

### DIFF
--- a/public/uploads/rules/code-commenting/rule.mdx
+++ b/public/uploads/rules/code-commenting/rule.mdx
@@ -60,6 +60,39 @@ There is almost always a better alternative to adding comments to your code. [Ch
 4. ...that are documentation comments for your next-biggest-thing-on-Nuget library
 5. ...that are real apologies (perhaps you had to add some gut-wrenching nasty code just to meeting time constraints, must be accompanied by a link to Bug/PBI)
 
+### The one-year test
+
+A good comment explains something that stays true and is not visible in the code: what a sentinel value means, an invariant, why a value must never change. A bad comment narrates the change that produced the current state, or restates what is on the line. Once the change settles, the second kind reads as stale clutter.
+
+AI coding agents are especially prone to the second kind. They tend to narrate the diff they just made, so review their comments with this test: would this comment still earn its place a year from now, with the change long forgotten?
+
+```csharp
+public enum OrderSource
+{
+    // Renamed from LegacyChannel in the March refactor. Kept the same numbers
+    // so the refactor did not need a data migration.
+    Workflow = 1,
+    Import = 2,
+    Api = 3,
+}
+```
+
+**❌ Bad example - This narrates the refactor that produced the code. Once it ships, nobody asks what the enum used to be called**
+
+```csharp
+public enum OrderSource
+{
+    // 0 is a sentinel meaning the source was never set. New code never writes it.
+    // These values are persisted in Orders.Source, so never renumber them.
+    Unknown = 0,
+    Workflow = 1,
+    Import = 2,
+    Api = 3,
+}
+```
+
+**✅ Good example - The meaning of 0 and the "never renumber" invariant are written down in the one place a maintainer will look, and both stay true next year**
+
 Last but not the least, [some parting words](http://butunclebob.com/ArticleS.TimOttinger.ApologizeIncode) from [@UncleBob](https://twitter.com/unclebobmartin) himself:
 
 > "A comment is an apology for not choosing a more clear name, or a more reasonable set of parameters, or for the failure to use explanatory variables and explanatory functions. Apologies for making the code unmaintainable, apologies for not using well-known algorithms, apologies for writing 'clever' code, apologies for not having a good version control system, apologies for not having finished the job of writing the code, or for leaving vulnerabilities or flaws in the code, apologies for hand-optimizing C code in ugly ways."

--- a/public/uploads/rules/code-commenting/rule.mdx
+++ b/public/uploads/rules/code-commenting/rule.mdx
@@ -28,13 +28,13 @@ What are the downsides of comments? What are the alternatives? What are bad and 
 
 There is almost always a better alternative to adding comments to your code. [Chapter 4: Comments, Clean Code](https://www.amazon.ca/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM) is a treatise par excellence on the topic.
 
-### What are the downsides of comments?
+## What are the downsides of comments?
 
 1. Comments don't participate in refactoring and therefore get out of date surprisingly quickly.
 2. Comments are dismissed by the compiler (except in weird languages like java) and therefore don't participate in the design.
 3. Unless strategically added, they place a burden on the reader of the code (they now have to understand 2 things: the code and your comments).
 
-### What are the alternatives to comments?
+## What are the alternatives to comments?
 
 1. Change name of the element (class, function, parameter, variable, test etc.) to a longer more apt name to further document it
 2. For ‘cryptic’ code (perhaps to optimize it), rewrite it in simpler terms (leave optimization to the runtimes)
@@ -44,7 +44,7 @@ There is almost always a better alternative to adding comments to your code. [Ch
     * For a method with large number of parameters, wrap them all up in a Parameter Object
     * Pair up with someone else, think... be creative
 
-### What are some **bad** comments?
+## What are some **bad** comments?
 
 1. Those that explain the "what"/"how" of the code. Basically the code rewritten in your mother tongue
 2. Those that documentation comments in non-public surface area
@@ -52,7 +52,7 @@ There is almost always a better alternative to adding comments to your code. [Ch
 4. TODO comments (Little ones are OK, don't leave them there for too long. The big effort TODOs - say that are over an hour or two - should have a work item URL to it)
    And many more...
 
-### What are some **good** comments?
+## What are some **good** comments?
 
 1. Comments that explain the why (e.g. strategic insights)
 2. ...that hyperlink to an external source where you got the idea/piece of code
@@ -60,7 +60,7 @@ There is almost always a better alternative to adding comments to your code. [Ch
 4. ...that are documentation comments for your next-biggest-thing-on-Nuget library
 5. ...that are real apologies (perhaps you had to add some gut-wrenching nasty code just to meeting time constraints, must be accompanied by a link to Bug/PBI)
 
-### The one-year test
+## The one-year test
 
 A good comment explains something that stays true and is not visible in the code: what a sentinel value means, an invariant, why a value must never change. A bad comment narrates the change that produced the current state, or restates what is on the line. Once the change settles, the second kind reads as stale clutter.
 


### PR DESCRIPTION
> 1. What triggered this change?

A sweep of active repos for lessons worth turning into rules. AI coding agents tend to narrate the diff they just made in comments ("keeps its original value because it is already persisted"), which reads as stale clutter once the change ships. The existing rule lists good and bad comment types but has no test a reviewer can apply, and does not mention agent-written comments.

> 2. What was changed?

* New section **The one-year test** in `code-commenting`: would this comment still earn its place a year from now, with the change long forgotten?
* Enum example with a bad transient comment and a good permanent one (a sentinel value's meaning)
* Notes that agents are prone to the transient kind, so review their comments with this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG4q4SABArdapUR4FYUbBT