### PR TITLE
Skills: say when a skill should trigger and keep SKILL.md short

### DIFF
--- a/public/uploads/rules/ai-agents-with-skills/rule.mdx
+++ b/public/uploads/rules/ai-agents-with-skills/rule.mdx
@@ -244,6 +244,57 @@ A good skill is specific about what the agent should do, how it should structure
   style="greybox"
 />
 
+### Say when the skill should trigger
+
+The `description` is not documentation. It is the text the agent reads to decide whether to load the skill at all. A skill that is installed but never fires is wasted, and a skill that fires on the wrong request is worse.
+
+Matching is semantic, not a string comparison, so the agent will recognise paraphrases. It still needs to know the intent. Write the description in three parts: what the skill does, examples of what a user says when they want it, and any scope guard. Then test it with a few different phrasings and adjust.
+
+<boxEmbed
+  body={<>
+    ```yaml
+    description: Helps with sprint reviews
+    ```
+  </>}
+  figurePrefix="bad"
+  figure="Too broad to separate this skill from a retro summary, a sprint report, or a planning session"
+  style="greybox"
+/>
+
+<boxEmbed
+  body={<>
+    ```yaml
+    description: Prepare draft emails for a Sprint Review, Retro, and Planning meeting.
+      Trigger when the user says "prepare sprint review", "draft sprint emails",
+      "sprint review prep", or asks to get ready for the sprint ceremony.
+      Accepts an optional sprint number and auto-detects the board from the repo.
+      Drafts only - never sends email.
+    ```
+  </>}
+  figurePrefix="good"
+  figure="What it does, example phrases, what it accepts, and what it will never do"
+  style="greybox"
+/>
+
+Some skills should only run when a person asks for them by name, for example anything that pushes, sends, bills, or deletes. Say so in the description, and in Claude Code set `disable-model-invocation: true` so the agent cannot load the skill on its own. Other tools ignore that field. OpenCode, for example, reads only its own frontmatter fields, so there the guard has to come from the agent's tool permissions rather than the skill file.
+
+### Keep SKILL.md short and load the rest on demand
+
+A skill that runs to 600 lines is loaded into the context window in full every time it triggers. Keep the `SKILL.md` to the workflow, roughly 100 lines, and put the long material beside it:
+
+```text
+skills/
+└── timesheets/
+    ├── SKILL.md              → the workflow, read every time
+    ├── references/
+    │   ├── source-gathering.md   → read only when the step needs it
+    │   └── gotchas.md
+    └── scripts/
+        └── scan_activity.py      → run, not read
+```
+
+Tell the agent in `SKILL.md` which reference to open at which step. The agent pays for the detail only when it needs it.
+
 Tips for writing skills:
 
 * **One task per skill** - a focused skill is easier to maintain and produces more consistent results than one that tries to handle multiple scenarios

--- a/public/uploads/rules/ai-agents-with-skills/rule.mdx
+++ b/public/uploads/rules/ai-agents-with-skills/rule.mdx
@@ -1,5 +1,5 @@
 ---
-title: Do you use skills to standardize your AI workflows?
+title: Do you use skills to standardize AI workflows?
 uri: ai-agents-with-skills
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -79,12 +79,12 @@ If you're using Claude Code only, you can alternatively install via the plugin s
 /plugin install document-skills@anthropic-agent-skills
 ```
 
-Consider creating a skill when:
+Consider creating a skill when you are:
 
-* **You're repeating the same instructions** - if you keep typing the same prompt for code reviews, commit messages, or planning tasks, package it as a skill
-* **You need consistent output** - when a task must follow a specific format or checklist every time (e.g. PR descriptions, architecture decision records)
-* **You're working with internal frameworks** - domain specific language or internal tools that aren't well-represented in the AI's training data benefit from explicit guidance
-* **You're onboarding team members** - skills encode tribal knowledge so everyone gets consistent results from day one
+* **Repeating the same instructions** - If you keep typing the same prompt for code reviews, commit messages, or planning tasks, package it as a skill
+* **Needing consistent output** - When a task must follow a specific format or checklist every time (e.g. PR descriptions, architecture decision records)
+* **Working with internal frameworks** - Domain specific language or internal tools that aren't well-represented in the AI's training data benefit from explicit guidance
+* **Onboarding team members** - Skills encode tribal knowledge so everyone gets consistent results from day one
 
 <boxEmbed
   body={<>
@@ -122,10 +122,10 @@ Project-specific skills should be stored within their project repositories.
 
 Project-level skills (committed to the repo) are one of the most effective ways to standardize workflows across a team:
 
-* **Commit skills to version control** - store them in the project's commands directory so everyone on the team benefits
-* **Review changes like code** - skill updates should go through the same PR review process as any other change
-* **Reference skills in your README** - mention available skills in your project's README so contributors know what's available (e.g. "Run `/code-review` for a code review" or "Use `/deploy` to deploy to staging")
-* **Combine with MCP servers when needed** - use skills to define *how* the agent should work and [MCP servers](/rules/mcp-servers-for-context) to provide *what data* it can access
+* **Commit skills to version control** - Store them in the project's commands directory so everyone on the team benefits
+* **Review changes like code** - Skill updates should go through the same PR review process as any other change
+* **Reference skills in your README** - Mention available skills in your project's README so contributors know what's available (e.g. "Run `/code-review` for a code review" or "Use `/deploy` to deploy to staging")
+* **Combine with MCP servers when needed** - Use skills to define *how* the agent should work and [MCP servers](/rules/mcp-servers-for-context) to provide *what data* it can access
 
 ## Using skills safely
 
@@ -138,10 +138,10 @@ Project-level skills (committed to the repo) are one of the most effective ways 
   style="warning"
 />
 
-* **Always read the full contents of a skill before using it** - never blindly trust a skill file, even from a seemingly reputable source
-* **Avoid skills from third-party marketplaces or untrusted sources** - treat installing a skill with the same caution as running an unknown script, we consider skills from sources such as Anthropic and OpenAI to be trusted sources
-* **Review skill changes in PRs** - when a teammate updates a skill, review it like you would review code
-* **Be cautious of skills that run shell commands** - skills that instruct the agent to execute commands or access sensitive files deserve extra scrutiny
+* **Always read the full contents of a skill before using it** - Never blindly trust a skill file, even from a seemingly reputable source
+* **Avoid skills from third-party marketplaces or untrusted sources** - Treat installing a skill with the same caution as running an unknown script, we consider skills from sources such as Anthropic and OpenAI to be trusted sources
+* **Review skill changes in PRs** - When a teammate updates a skill, review it like you would review code
+* **Be cautious of skills that run shell commands** - Skills that instruct the agent to execute commands or access sensitive files deserve extra scrutiny
 
 ## Publishing skills
 
@@ -297,10 +297,10 @@ Tell the agent in `SKILL.md` which reference to open at which step. The agent pa
 
 Tips for writing skills:
 
-* **One task per skill** - a focused skill is easier to maintain and produces more consistent results than one that tries to handle multiple scenarios
-* **Specify the output format** - tell the agent exactly how to structure its response (bullet points, markdown headings, numbered steps, etc.)
-* **Include constraints** - explicitly state what the agent should *not* do to prevent unwanted behavior
-* **Use variables where supported** - some tools support `$ARGUMENTS` or similar placeholders so users can pass context when invoking the skill
+* **One task per skill** - A focused skill is easier to maintain and produces more consistent results than one that tries to handle multiple scenarios
+* **Specify the output format** - Tell the agent exactly how to structure its response (bullet points, markdown headings, numbered steps, etc.)
+* **Include constraints** - Explicitly state what the agent should *not* do to prevent unwanted behavior
+* **Use variables where supported** - Some tools support `$ARGUMENTS` or similar placeholders so users can pass context when invoking the skill
 
 ### Frontmatter properties
 
@@ -327,12 +327,14 @@ Where you store a skill determines who can use it:
 
 **Personal skills** are great for your own preferences and workflows (e.g. your preferred commit message format). **Project skills** are committed to version control so the whole team benefits. When a personal and project skill share the same name, project-level skills take precedence.
 
+---
+
 ## Further reading
 
-* [skills.sh - The Open Agent Skills Ecosystem](https://www.skills.sh/) - discover, install, and publish skills across 70+ agents
+* [skills.sh - The Open Agent Skills Ecosystem](https://www.skills.sh/) - Discover, install, and publish skills across 70+ agents
 * [Specification - Agent Skills](https://agentskills.io/specification)
 * [Extend Claude with skills - Claude Code](https://code.claude.com/docs/en/skills)
 * [Agent Skills - OpenCode](https://opencode.ai/docs/skills/)
 * [Custom agents - GitHub Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents)
-* [Anthropic Skills Repository](https://github.com/anthropics/skills) - pre-built skills for document creation, design, and development
-* [Do you give your AI agents context with MCP servers and skills?](/rules/mcp-servers-for-context) - for guidance on when to use skills vs MCP servers
+* [Anthropic Skills Repository](https://github.com/anthropics/skills) - Pre-built skills for document creation, design, and development
+* [Do you give your AI agents context with MCP servers and skills?](/rules/mcp-servers-for-context) - For guidance on when to use skills vs MCP servers


### PR DESCRIPTION
> 1. What triggered this change?

A sweep of active repos for lessons worth turning into rules. Across the SSW skills repos, the skills that reliably fire follow one shape: what it does, then the literal phrases that trigger it, then what it accepts and what it will never do. Skills with vague descriptions sit installed and unused. The existing rule has a frontmatter table but nothing on trigger phrasing, explicit-only skills, or keeping SKILL.md short.

> 2. What was changed?

* New section **Say when the skill should trigger** in `ai-agents-with-skills`, with a bad and good description example, and guidance to set `disable-model-invocation: true` on skills that push, send, bill, or delete
* New section **Keep SKILL.md short and load the rest on demand**, showing a references/ and scripts/ layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG4q4SABArdapUR4FYUbBT