### PR TITLE
New rule: Do you get your AI agent to capture its own UI changes?

### DIFF
--- a/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+++ b/categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
@@ -36,6 +36,7 @@ index:
   - rule: public/uploads/rules/start-vibe-coding-best-practices/rule.mdx
   - rule: public/uploads/rules/ai-with-design-system/rule.mdx
   - rule: public/uploads/rules/playwright-with-ai/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
   - rule: public/uploads/rules/reduce-design-debt-with-ai/rule.mdx
   - rule: public/uploads/rules/write-design-md/rule.mdx
   - rule: public/uploads/rules/ai-agent-memory-systems/rule.mdx

--- a/categories/project-delivery/rules-to-better-pull-requests.mdx
+++ b/categories/project-delivery/rules-to-better-pull-requests.mdx
@@ -8,6 +8,7 @@ seoDescription: Best practices for creating and reviewing pull requests. Learn h
 index:
 - rule: public/uploads/rules/enable-pull-requests-to-ensure-code-is-reviewed/rule.mdx
 - rule: public/uploads/rules/write-a-good-pull-request/rule.mdx
+- rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 - rule: public/uploads/rules/use-and-indicate-draft-pull-requests/rule.mdx
 - rule: public/uploads/rules/over-the-shoulder/rule.mdx
 - rule: public/uploads/rules/merge-debt/rule.mdx

--- a/public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
+++ b/public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
@@ -18,6 +18,7 @@ related:
 - rule: public/uploads/rules/ai-assisted-development-workflow/rule.mdx
 - rule: public/uploads/rules/use-images-to-replace-words/rule.mdx
 - rule: public/uploads/rules/set-language-on-code-blocks/rule.mdx
+- rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 seoDescription: Quickly test AI-built desktop features by switching to PR pre-releases
   in your desktop app. Avoid slow local branch builds and adopt a professional AI-assisted
   workflow for Electron apps.
@@ -85,7 +86,7 @@ By exposing a settings option to switch to specific PR builds, they can be easil
 * Prefer small, focused steps that map one-to-one to PRs
 * Write down assumptions and risks in the PR description
 * Add lightweight checks to catch regressions early
-* Use screenshots or short videos for reviewers
+* Use screenshots or short videos for reviewers. The agent can [capture these itself](/ai-capture-ui-changes) while it verifies the change
 * Keep a changelog entry for user-visible behavior
 
 ## References

--- a/public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
+++ b/public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
@@ -18,7 +18,6 @@ related:
 - rule: public/uploads/rules/ai-assisted-development-workflow/rule.mdx
 - rule: public/uploads/rules/use-images-to-replace-words/rule.mdx
 - rule: public/uploads/rules/set-language-on-code-blocks/rule.mdx
-- rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 seoDescription: Quickly test AI-built desktop features by switching to PR pre-releases
   in your desktop app. Avoid slow local branch builds and adopt a professional AI-assisted
   workflow for Electron apps.

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -1,0 +1,145 @@
+---
+type: rule
+title: Do you get your AI agent to capture its own UI changes?
+seoDescription: An AI agent that verifies its UI change in a real browser should keep the screenshot or video it took. Put that evidence on the PR and the Done comment, so bugs get fixed before a human reviews and reviewers see the change without checking out the branch.
+guid: 82547870-a225-4398-9034-75c41500ab8b
+uri: ai-capture-ui-changes
+created: 2026-09-03T01:04:28.000Z
+authors:
+  - title: Brady Stroud
+    url: https://www.ssw.com.au/people/brady-stroud
+related:
+  - rule: public/uploads/rules/playwright-with-ai/rule.mdx
+  - rule: public/uploads/rules/write-a-good-pull-request/rule.mdx
+  - rule: public/uploads/rules/definition-of-done/rule.mdx
+  - rule: public/uploads/rules/done-video/rule.mdx
+  - rule: public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
+  - rule: public/uploads/rules/devtools-design-changes/rule.mdx
+  - rule: public/uploads/rules/screenshots-avoid-walls-of-text/rule.mdx
+categories:
+  - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
+  - category: categories/project-delivery/rules-to-better-pull-requests.mdx
+archivedreason: null
+isArchived: false
+---
+
+An AI agent changes a header component, runs the build, and reports "done". The code compiles, so as far as the agent can tell, the job is finished. The reviewer opens the PR, checks out the branch, and finds the header overlapping the navigation on mobile. Now the PBI goes back, the agent fixes it, and the reviewer looks again. Every bug the agent could not see costs a full round trip.
+
+The fix has two halves. First, the agent looks at its own change in a real browser and fixes what it finds. Second, it keeps the screenshot or video from that check, and that evidence goes on the PR and the Done comment. Most teams do the first half by hand and the second half not at all.
+
+<endIntro />
+
+<boxEmbed
+  style="todo"
+  body={<>
+    **TODO:** Record an SSW video for this rule and embed it here. The closest existing video is [3 Ways to Supercharge Playwright with AI Agents | Hark Singh | SSW Rules (18 min)](https://www.youtube.com/watch?v=EUhQ1J-69KY), which covers the browser side but not the evidence side.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
+## Verify first, evidence second
+
+The screenshot is a by-product of a verification loop, not a separate step. Give the agent a browser and make the loop part of its definition of done for any UI change:
+
+1. **Open the page** - the agent drives a real browser with the [Playwright MCP or CLI](/playwright-with-ai) or the [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+2. **Check against the acceptance criteria** - it walks the flow the PBI describes and compares what it sees with what the [acceptance criteria](/acceptance-criteria) say
+3. **Fix what it finds** - a layout that breaks at a narrow width, a button that does nothing, a state that never loads. The agent fixes these before a human looks
+4. **Keep the capture** - the screenshot or short video from the last pass becomes the evidence
+
+Step 3 is where the time saving comes from. Step 4 is what most teams forget.
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    Once the header change looks right in the browser at desktop and mobile widths, take a screenshot of each and save them to `.pr-assets/header-after-desktop.png` and `.pr-assets/header-after-mobile.png`. Take the same two screenshots on `main` first so we have a before pair.
+  </>}
+  figurePrefix="good"
+  figure="A prompt that asks for the capture as part of the verification, not as an afterthought"
+/>
+
+## Keep the right artefact
+
+Match the capture to the change:
+
+* **Before and after screenshots** for visual changes - spacing, colours, layout, new components. Take both at the same viewport size so the reviewer can compare them
+* **A short video** for flows - a form submission, a wizard, a drag and drop. Playwright can record the run, and 10 to 30 seconds is enough
+* **One screenshot per state** for conditional UI - empty state, loading state, error state. These are the states a reviewer rarely clicks through by hand
+
+## Put the evidence where reviewers look
+
+The capture is only useful if it lands where the next person will see it:
+
+* **The PR description** - this fills the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request). Put it in the body, not in a comment that scrolls away
+* **The Done comment on the PBI** - [Definition of Done](/definition-of-done) already lists screenshots and Done videos as evidence. Reuse the same image instead of taking a second one by hand
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **PR title:** ✨ Header - Move the account menu into the top bar
+
+    **PR description:**
+    Relates to #4521
+
+    Updated the header so the account menu sits in the top bar.
+  </>}
+  figurePrefix="bad"
+  figure="The reviewer has to check out the branch and run the app to see what changed"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    **PR title:** ✨ Header - Move the account menu into the top bar
+
+    **PR description:**
+    Relates to #4521
+
+    Updated the header so the account menu sits in the top bar. Verified in Chromium at 1440 px and 390 px.
+
+    | Before | After |
+    | --- | --- |
+    | `header-before-desktop.png` | `header-after-desktop.png` |
+    | `header-before-mobile.png` | `header-after-mobile.png` |
+
+    Mobile: the menu collapses into the hamburger. Found and fixed an overlap with the search icon at 390 px during this check.
+  </>}
+  figurePrefix="good"
+  figure="A before/after pair the agent captured during its own verification, plus one line on what it found and fixed"
+/>
+
+The last sentence in the good example is the point of the rule. The agent found the overlap, fixed it, and told the reviewer. The reviewer sees a finished change instead of a bug report.
+
+## Assert on the accessibility tree, show the screenshot
+
+The agent should not check its work by comparing pixels. Screenshots change with fonts, animations, and viewport sizes, so a pixel comparison breaks for reasons that have nothing to do with the change. The accessibility tree is stable, so use it for the checks:
+
+* **Assertions** - the agent confirms that a button exists, a heading has the right text, or a dialog is open by reading the accessibility tree
+* **Evidence** - the agent takes a screenshot so a human can see the result at a glance
+
+Both come from the same browser session. The tree tells the agent whether the change worked. The screenshot tells the reviewer.
+
+## Tips
+
+* **Keep images small** - crop to the component that changed and follow [Do you make sure your screenshots are readable?](/readable-screenshots). A full-page capture of a 3,000 px page helps nobody
+* **Name the files** - `header-after-mobile.png` is easy to match to its caption. `screenshot-1.png` is not
+* **Caption every image** - one line saying what the reviewer should look at. See [Do you use screenshots instead of a 'wall of text'?](/screenshots-avoid-walls-of-text)
+* **Never capture secrets or customer data** - the agent runs against a local or test environment with seed data. Apply the same care as [Do you hide sensitive information?](/hide-sensitive-information), because the image ends up in a PR that stays visible forever
+* **Prefer the PR body over a comment** - the body is what GitHub shows first, and it survives when comments are collapsed
+* **Put the steps in the agent's instructions** - add the verify-then-capture loop to your `AGENTS.md`, a skill, or the PR template so the agent does it every time
+
+## Tooling
+
+* **[Playwright MCP and Playwright CLI](/playwright-with-ai)** - the agent navigates, reads the accessibility tree, and takes screenshots or records video from the same session
+* **[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)** - gives the agent a real Chrome instance with screenshots, performance traces, and console access
+* **[Screengrabs for Pull Requests](https://mcpmarket.com/tools/skills/screengrabs-for-pull-requests)** - a Claude Code skill that automates before/after PR screenshots with Playwright
+* **[GitHub CLI](https://cli.github.com/)** - lets the agent write the PR description and attach the images without leaving the terminal
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** This is the developer-side twin of [Do you walk through UI changes using DevTools and screen recordings?](/devtools-design-changes). A designer records the change they want. The agent records the change it made. Both replace a paragraph of description with something the other person can see.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -44,10 +44,8 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
 
 1. **Open the page** - the agent drives a real browser with the [Playwright MCP or CLI](/playwright-with-ai) or the [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 2. **Check against the acceptance criteria** - it walks the flow the PBI describes and compares what it sees with what the [acceptance criteria](/acceptance-criteria) say
-3. **Fix what it finds** - a layout that breaks at a narrow width, a button that does nothing, a state that never loads. The agent fixes these before a human looks
-4. **Keep the capture** - the screenshot or short video from the last pass becomes the evidence
-
-Step 3 is where the time saving comes from. Step 4 is what most teams forget.
+3. **Fix what it finds** - the agent fixes these before a human looks
+4. **Keep the capture** - use screenshots or videos as evidence of the work
 
 <boxEmbed
   style="greybox"

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -66,7 +66,7 @@ Match the capture to the change:
 
 ## Put the evidence where reviewers look
 
-The capture is only useful if it lands where the next person will see it:
+The agent already has the capture, so put it where the review normally happens:
 
 * **The PR description** - this fills the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request). Put it in the body, not in a comment that scrolls away
 * **The Done comment on the PBI** - [Definition of Done](/definition-of-done) already lists screenshots and Done videos as evidence. Reuse the same image instead of taking a second one by hand

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -66,7 +66,7 @@ Match the capture to the change:
 
 ## Put the evidence where reviewers look
 
-The agent already has the capture, so put it where the review normally happens:
+The agent already has the capture, so put it where the review normally happens.
 
 * **The PR description** - this fills the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request). Put it in the body, not in a comment that scrolls away
 * **The Done comment on the PBI** - [Definition of Done](/definition-of-done) already lists screenshots and Done videos as evidence. Reuse the same image instead of taking a second one by hand

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -29,10 +29,12 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <endIntro />
 
+<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI - It's a Skill Issue | Calum Simpson (watch from 1:14:21 - 1:20:07)" />
+
 <boxEmbed
   style="todo"
   body={<>
-    **TODO:** Record an SSW video for this rule and embed it here. The closest existing video is [3 Ways to Supercharge Playwright with AI Agents | Hark Singh | SSW Rules (18 min)](https://www.youtube.com/watch?v=EUhQ1J-69KY), which covers the browser side but not the evidence side.
+    **TODO:** Record a dedicated SSW video for this rule and replace the clip above.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -44,13 +44,13 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
 
 1. **Open the page** - the agent drives a real browser with the [Playwright MCP or CLI](/playwright-with-ai) or the [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 2. **Check against the acceptance criteria** - it walks the flow the PBI describes and compares what it sees with what the [acceptance criteria](/acceptance-criteria) say
-3. **Fix what it finds** - the agent fixes these before a human looks
+3. **Fix what it finds** - the agent fixes issues before a human looks
 4. **Keep the capture** - use screenshots or videos as evidence of the work
 
 <boxEmbed
   style="greybox"
   body={<>
-    Once the header change looks right in the browser at desktop and mobile widths, take a screenshot of each and save them to `.pr-assets/header-after-desktop.png` and `.pr-assets/header-after-mobile.png`. Take the same two screenshots on `main` first so we have a before pair.
+    Screenshot the header on `main` at desktop and mobile widths, then make the change and screenshot it again at the same widths. Fix anything that looks broken before you show me the pair.
   </>}
   figurePrefix="good"
   figure="A prompt that asks for the capture as part of the verification, not as an afterthought"

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -23,7 +23,7 @@ archivedreason: null
 isArchived: false
 ---
 
-An AI agent changes a header component, runs the build, and reports "done". The code compiles, so as far as the agent can tell, the job is finished. The reviewer opens the PR, checks out the branch, and finds the header overlapping the navigation on mobile. Now the PBI goes back, the agent fixes it, and the reviewer looks again. Every bug the agent could not see costs a full round trip.
+An AI agent changes a header component, sees the code compile, and reports "done". The reviewer checks out the branch and finds the header overlapping the nav on mobile - a full round trip for a bug the agent could not see.
 
 The fix has two halves. First, the agent looks at its own change in a real browser and fixes what it finds. Second, it keeps the screenshot or video from that check, and that evidence goes on the PR and the Done comment. Most teams do the first half by hand and the second half not at all.
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -117,7 +117,6 @@ There is a third option when you are developing against a pre-existing reference
 ## Tips
 
 * **Keep images small** - crop to the component that changed and follow [Do you make sure your screenshots are readable?](/readable-screenshots). A full-page capture of a 3,000 px page helps nobody
-* **Name the files** - `header-after-mobile.png` is easy to match to its caption. `screenshot-1.png` is not
 * **Caption every image** - one line saying what the reviewer should look at. See [Do you use screenshots instead of a 'wall of text'?](/screenshots-avoid-walls-of-text)
 * **Never capture secrets or customer data** - the agent runs against a local or test environment with seed data. Apply the same care as [Do you hide sensitive information?](/hide-sensitive-information), because the image ends up in a PR that stays visible forever
 * **Prefer the PR body over a comment** - the body is what GitHub shows first, and it survives when comments are collapsed

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -64,7 +64,7 @@ Match the capture to the change:
 * **A short video** for flows. Playwright can record the run, and 10 to 30 seconds is enough
 * **One screenshot per state** for conditional UI. These are the states a reviewer rarely clicks through by hand
 
-## Put the evidence where reviewers look
+## Where the screenshots go
 
 The agent already has the capture, so put it where the review normally happens.
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -25,7 +25,7 @@ isArchived: false
 
 An AI agent changes a header component, sees the code compile, and reports "done". The reviewer checks out the branch and finds the header overlapping the nav on mobile - a full round trip for a bug the agent could not see.
 
-The fix has two halves. First, the agent looks at its own change in a real browser and fixes what it finds. Second, it keeps the screenshot or video from that check, and that evidence goes on the PR and the Done comment. Most teams do the first half by hand and the second half not at all.
+Loop AI into the visual review, and it can resolve obvious visual bugs before they ever reach you. To do this, the agent takes screenshots in a real browser and fixes obvious issues. Double dip by using these screenshots to document your work.
 
 <endIntro />
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -9,13 +9,8 @@ authors:
   - title: Brady Stroud
     url: https://www.ssw.com.au/people/brady-stroud
 related:
-  - rule: public/uploads/rules/playwright-with-ai/rule.mdx
-  - rule: public/uploads/rules/write-a-good-pull-request/rule.mdx
-  - rule: public/uploads/rules/definition-of-done/rule.mdx
   - rule: public/uploads/rules/done-video/rule.mdx
   - rule: public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
-  - rule: public/uploads/rules/devtools-design-changes/rule.mdx
-  - rule: public/uploads/rules/screenshots-avoid-walls-of-text/rule.mdx
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
   - category: categories/project-delivery/rules-to-better-pull-requests.mdx
@@ -29,7 +24,9 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <endIntro />
 
-<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI - It's a Skill Issue | Calum Simpson (watch from 1:14:21 - 1:20:07)" />
+<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group (watch from 1:14:21 - 1:20:07, 6 min)" />
+
+**✅ Video: Good example - Watch from 1:14:21 - 1:20:07 (6 min) - Calum Simpson shows an AI agent recording its own Done video with Playwright and text-to-speech**
 
 ## How the agent checks its own work
 
@@ -109,8 +106,8 @@ There is a third option when you are developing against a pre-existing reference
 
 ## Tips
 
-* **Keep images small** - crop to the component that changed and follow [Do you make sure your screenshots are readable?](/readable-screenshots). A full-page capture of a 3,000 px page helps nobody
-* **Caption every image** - one line saying what the reviewer should look at. See [Do you use screenshots instead of a 'wall of text'?](/screenshots-avoid-walls-of-text)
+* **Keep images small** - crop to the component that changed and follow [Do you make sure your screenshots are readable?](/readable-screenshots). A full-page capture of a 3,000 px page helps nobody. If the reviewer needs to look at one spot, [add a box or arrow](/screenshots-avoid-walls-of-text)
+* **Caption every image** - one line saying what the reviewer should look at. See [Do you add useful text captions to images and videos?](/add-useful-and-concise-figure-captions)
 * **Never capture secrets or customer data** - the agent runs against a local or test environment with seed data. Apply the same care as [Do you hide sensitive information?](/hide-sensitive-information), because the image ends up in a PR that stays visible forever
 * **Prefer the PR body over a comment** - the body is what GitHub shows first, and it survives when comments are collapsed
 
@@ -118,6 +115,7 @@ There is a third option when you are developing against a pre-existing reference
 
 * **[Playwright MCP and Playwright CLI](/playwright-with-ai)** - the agent navigates, reads the accessibility tree, and takes screenshots or records video from the same session
 * **[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)** - gives the agent a real Chrome instance with screenshots, performance traces, and console access
+* **[Steel](https://steel.dev/)** - open-source cloud browser sessions for agents, with screenshots and session recordings built in. Useful when the agent runs in CI or a sandbox with no local browser
 * **[GitHub CLI](https://cli.github.com/)** - lets the agent write the PR description without leaving the terminal. It cannot upload images, so the agent leaves the placeholders and you drag the screenshots in
 
 <boxEmbed

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -60,9 +60,9 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
 
 Match the capture to the change:
 
-* **Before and after screenshots** for visual changes - spacing, colours, layout, new components. Take both at the same viewport size so the reviewer can compare them
-* **A short video** for flows - a form submission, a wizard, a drag and drop. Playwright can record the run, and 10 to 30 seconds is enough
-* **One screenshot per state** for conditional UI - empty state, loading state, error state. These are the states a reviewer rarely clicks through by hand
+* **Before and after screenshots** for visual changes. Take both at the same viewport size so the reviewer can compare them
+* **A short video** for flows. Playwright can record the run, and 10 to 30 seconds is enough
+* **One screenshot per state** for conditional UI. These are the states a reviewer rarely clicks through by hand
 
 ## Put the evidence where reviewers look
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -110,7 +110,7 @@ The agent already has the capture, so put it where the review normally happens.
 
 ## Use both the accessibility tree and the screenshot
 
-There are two methods available for the agent to verify with. The **accessibility tree** tells the agent whether the button exists and the heading reads correctly. It says nothing about colour, spacing, or a modal covering half the page, so the agent needs to **look at a screenshot** as well.
+There are two methods available for the agent to verify with. The **accessibility tree** gives the agent the page as structured data - what exists and what state it is in. It says nothing about colour, spacing, or a modal covering half the page, so the agent needs to **look at a screenshot** as well.
 
 There is a third option when you are developing against a pre-existing reference, like a Figma mockup or a page that should not have changed - **pixel comparison** against a committed baseline image. Tools like [Playwright visual comparisons](https://playwright.dev/docs/test-snapshots) can flag any difference, so mask the parts that move and set a threshold, or the check fails on a font or an animation.
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -82,7 +82,7 @@ The agent already has the capture, so put it where the review normally happens.
     Updated the header so the account menu sits in the top bar.
   </>}
   figurePrefix="bad"
-  figure="The reviewer has to check out the branch and run the app to see what changed"
+  figure="The reviewer has to stop what they're doing, check out the branch, and run the app just to see what changed"
 />
 
 <boxEmbed
@@ -100,13 +100,11 @@ The agent already has the capture, so put it where the review normally happens.
     | `header-before-desktop.png` | `header-after-desktop.png` |
     | `header-before-mobile.png` | `header-after-mobile.png` |
 
-    Mobile: the menu collapses into the hamburger. Found and fixed an overlap with the search icon at 390 px during this check.
+    Mobile: the menu collapses into the hamburger.
   </>}
   figurePrefix="good"
-  figure="A before/after pair the agent captured during its own verification, plus one line on what it found and fixed"
+  figure="A before/after pair the agent captured during its own verification"
 />
-
-The last sentence in the good example is the point of the rule. The agent found the overlap, fixed it, and told the reviewer. The reviewer sees a finished change instead of a bug report.
 
 ## Assert on the accessibility tree, show the screenshot
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -125,13 +125,12 @@ There is a third option when you are developing against a pre-existing reference
 
 * **[Playwright MCP and Playwright CLI](/playwright-with-ai)** - the agent navigates, reads the accessibility tree, and takes screenshots or records video from the same session
 * **[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)** - gives the agent a real Chrome instance with screenshots, performance traces, and console access
-* **[Screengrabs for Pull Requests](https://mcpmarket.com/tools/skills/screengrabs-for-pull-requests)** - a Claude Code skill that automates before/after PR screenshots with Playwright
-* **[GitHub CLI](https://cli.github.com/)** - lets the agent write the PR description and attach the images without leaving the terminal
+* **[GitHub CLI](https://cli.github.com/)** - lets the agent write the PR description without leaving the terminal. It cannot upload images, so the agent leaves the placeholders and you drag the screenshots in
 
 <boxEmbed
   style="tips"
   body={<>
-    **Tip:** This is the developer-side twin of [Do you walk through UI changes using DevTools and screen recordings?](/devtools-design-changes). A designer records the change they want. The agent records the change it made. Both replace a paragraph of description with something the other person can see.
+    **Tip:** This is the developer-side twin of [Do you walk through UI changes using DevTools and screen recordings?](/devtools-design-changes). A designer records the change they want. The agent records the change it made.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -38,7 +38,7 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
   figure=""
 />
 
-## Verify first, evidence second
+## How the agent checks its own work
 
 The screenshot is a by-product of a verification loop, not a separate step. Give the agent a browser and make the loop part of its definition of done for any UI change:
 
@@ -56,7 +56,7 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
   figure="A prompt that asks for the capture as part of the verification"
 />
 
-## Keep the right artefact
+## What to capture
 
 Match the capture to the change:
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -31,15 +31,6 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI - It's a Skill Issue | Calum Simpson (watch from 1:14:21 - 1:20:07)" />
 
-<boxEmbed
-  style="todo"
-  body={<>
-    **TODO:** Record a dedicated SSW video for this rule and replace the clip above.
-  </>}
-  figurePrefix="none"
-  figure=""
-/>
-
 ## How the agent checks its own work
 
 The screenshot is a by-product of a verification loop, not a separate step. Give the agent a browser and make the loop part of its definition of done for any UI change:

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -25,7 +25,7 @@ isArchived: false
 
 An AI agent changes a header component, sees the code compile, and reports "done". The reviewer checks out the branch and finds the header overlapping the nav on mobile - a full round trip for a bug the agent could not see.
 
-Loop AI into the visual review, and it can resolve obvious visual bugs before they ever reach you. To do this, the agent takes screenshots in a real browser and fixes obvious issues. Double dip by using these screenshots to document your work.
+Loop AI into the visual review, and it can resolve obvious visual bugs before they ever reach you. To do this, the agent takes screenshots in a real browser and fixes obvious issues. Double dip by using these screenshots to document your work on the PR and in a Done comment.
 
 <endIntro />
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -69,7 +69,7 @@ Match the capture to the change:
 The agent already has the capture, so put it where the review normally happens.
 
 * **The PR description** - taking advantage of screenshots or Done videos is an awesome way to improve the review process, see the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request)
-* **The Done comment on the PBI** - [Definition of Done](/definition-of-done) already lists screenshots and Done videos as evidence. Reuse the same image instead of taking a second one by hand
+* **The Done comment on the PBI** - [Definition of Done](/definition-of-done) lists these kinds of screenshots or Done videos as good evidence when you close out the PBI
 
 <boxEmbed
   style="greybox"

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -56,6 +56,8 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
   figure="A prompt that asks for the capture as part of the verification"
 />
 
+Better still, bake the loop into `AGENTS.md`, a skill, or the PR template, so every UI change gets the same visual review without anyone asking for it.
+
 ## What to capture
 
 Match the capture to the change:
@@ -122,7 +124,6 @@ Both come from the same browser session. The tree tells the agent whether the ch
 * **Caption every image** - one line saying what the reviewer should look at. See [Do you use screenshots instead of a 'wall of text'?](/screenshots-avoid-walls-of-text)
 * **Never capture secrets or customer data** - the agent runs against a local or test environment with seed data. Apply the same care as [Do you hide sensitive information?](/hide-sensitive-information), because the image ends up in a PR that stays visible forever
 * **Prefer the PR body over a comment** - the body is what GitHub shows first, and it survives when comments are collapsed
-* **Put the steps in the agent's instructions** - add the verify-then-capture loop to your `AGENTS.md`, a skill, or the PR template so the agent does it every time
 
 ## Tooling
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -53,7 +53,7 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
     Screenshot the header on `main` at desktop and mobile widths, then make the change and screenshot it again at the same widths. Fix anything that looks broken before you show me the pair.
   </>}
   figurePrefix="good"
-  figure="A prompt that asks for the capture as part of the verification, not as an afterthought"
+  figure="A prompt that asks for the capture as part of the verification"
 />
 
 ## Keep the right artefact

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -68,7 +68,7 @@ Match the capture to the change:
 
 The agent already has the capture, so put it where the review normally happens.
 
-* **The PR description** - this fills the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request). Put it in the body, not in a comment that scrolls away
+* **The PR description** - taking advantage of screenshots or Done videos is an awesome way to improve the review process, see the `{{ SCREENSHOT / DONE VIDEO }}` line in [Do you know how to write a great Pull Request?](/write-a-good-pull-request)
 * **The Done comment on the PBI** - [Definition of Done](/definition-of-done) already lists screenshots and Done videos as evidence. Reuse the same image instead of taking a second one by hand
 
 <boxEmbed

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -108,14 +108,11 @@ The agent already has the capture, so put it where the review normally happens.
   figure="A before/after pair the agent captured during its own verification"
 />
 
-## Assert on the accessibility tree, show the screenshot
+## Use both the accessibility tree and the screenshot
 
-The agent should not check its work by comparing pixels. Screenshots change with fonts, animations, and viewport sizes, so a pixel comparison breaks for reasons that have nothing to do with the change. The accessibility tree is stable, so use it for the checks:
+There are two methods available for the agent to verify with. The **accessibility tree** tells the agent whether the button exists and the heading reads correctly. It says nothing about colour, spacing, or a modal covering half the page, so the agent needs to **look at a screenshot** as well.
 
-* **Assertions** - the agent confirms that a button exists, a heading has the right text, or a dialog is open by reading the accessibility tree
-* **Evidence** - the agent takes a screenshot so a human can see the result at a glance
-
-Both come from the same browser session. The tree tells the agent whether the change worked. The screenshot tells the reviewer.
+There is a third option when you are developing against a pre-existing reference, like a Figma mockup or a page that should not have changed - **pixel comparison** against a committed baseline image. Tools like [Playwright visual comparisons](https://playwright.dev/docs/test-snapshots) can flag any difference, so mask the parts that move and set a threshold, or the check fails on a font or an animation.
 
 ## Tips
 

--- a/public/uploads/rules/definition-of-done/rule.mdx
+++ b/public/uploads/rules/definition-of-done/rule.mdx
@@ -22,7 +22,6 @@ related:
 - rule: public/uploads/rules/comments-do-you-enforce-comments-with-check-ins/rule.mdx
 - rule: public/uploads/rules/do-you-enforce-work-item-association-with-check-in/rule.mdx
 - rule: public/uploads/rules/before-starting-do-you-follow-a-test-driven-process/rule.mdx
-- rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 seoDescription: Having a clear Definition of Done for your team is crucial to ensure
   quality management and success in Scrum.
 title: Done - Do you go beyond 'Done' and follow a 'Definition of Done'?

--- a/public/uploads/rules/definition-of-done/rule.mdx
+++ b/public/uploads/rules/definition-of-done/rule.mdx
@@ -22,6 +22,7 @@ related:
 - rule: public/uploads/rules/comments-do-you-enforce-comments-with-check-ins/rule.mdx
 - rule: public/uploads/rules/do-you-enforce-work-item-association-with-check-in/rule.mdx
 - rule: public/uploads/rules/before-starting-do-you-follow-a-test-driven-process/rule.mdx
+- rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 seoDescription: Having a clear Definition of Done for your team is crucial to ensure
   quality management and success in Scrum.
 title: Done - Do you go beyond 'Done' and follow a 'Definition of Done'?
@@ -60,6 +61,15 @@ Every team is different, but all need to agree on which items are in their "Defi
 * Sending a "Done" email
 * Recording a quick and dirty "[Done Video](/record-a-quick-and-dirty-done-video)"
 * Code (showing a full scenario, e.g. a user story)
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** When an AI agent makes a UI change, it can produce the screenshots and short videos itself. Get it to verify the change in a real browser, fix what it finds, and keep the capture for the PR and the Done comment. See [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes).
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
 ## There are 8 levels of 'Done' in software quality
 

--- a/public/uploads/rules/devtools-design-changes/rule.mdx
+++ b/public/uploads/rules/devtools-design-changes/rule.mdx
@@ -18,6 +18,7 @@ related:
   - rule: public/uploads/rules/css-changes/rule.mdx
   - rule: public/uploads/rules/keep-developers-away-from-design-work/rule.mdx
   - rule: public/uploads/rules/hand-over-mockups-to-developers/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 guid: a7201bd1-965d-4854-877b-25952fb94a74
 seoDescription: >-
   Designers often struggle to explain small UI tweaks to developers. Instead of
@@ -116,3 +117,12 @@ In those cases, it is better to:
 
 * Create wireframes in Figma and [hand over mockups to developers](/hand-over-mockups-to-developers)
 * [Prototype the functionality with AI-assisted code](/ai-for-prototype-development)
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** The same principle works in the other direction. When an AI agent implements the change, get it to capture a screenshot or short video of the result so the designer can check it without running the app. See [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes).
+  </>}
+  figurePrefix="none"
+  figure=""
+/>

--- a/public/uploads/rules/devtools-design-changes/rule.mdx
+++ b/public/uploads/rules/devtools-design-changes/rule.mdx
@@ -18,7 +18,6 @@ related:
   - rule: public/uploads/rules/css-changes/rule.mdx
   - rule: public/uploads/rules/keep-developers-away-from-design-work/rule.mdx
   - rule: public/uploads/rules/hand-over-mockups-to-developers/rule.mdx
-  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 guid: a7201bd1-965d-4854-877b-25952fb94a74
 seoDescription: >-
   Designers often struggle to explain small UI tweaks to developers. Instead of

--- a/public/uploads/rules/done-video/rule.mdx
+++ b/public/uploads/rules/done-video/rule.mdx
@@ -26,7 +26,6 @@ related:
   - rule: public/uploads/rules/craft-and-deliver-engaging-presentations/rule.mdx
   - rule: public/uploads/rules/recording-screen/rule.mdx
   - rule: public/uploads/rules/screen-recording-spotlight/rule.mdx
-  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 redirects:
   - do-you-know-how-to-record-a-quick-and-dirty-done-video
   - record-a-quick-and-dirty-done-video

--- a/public/uploads/rules/done-video/rule.mdx
+++ b/public/uploads/rules/done-video/rule.mdx
@@ -26,6 +26,7 @@ related:
   - rule: public/uploads/rules/craft-and-deliver-engaging-presentations/rule.mdx
   - rule: public/uploads/rules/recording-screen/rule.mdx
   - rule: public/uploads/rules/screen-recording-spotlight/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 redirects:
   - do-you-know-how-to-record-a-quick-and-dirty-done-video
   - record-a-quick-and-dirty-done-video
@@ -52,6 +53,15 @@ When deciding whether a PBI might be a good contender to record a Done Video for
 3. Is it UI heavy? i.e. Would the video be compelling?
 
 <youtubeEmbed description="Video: How to record a done video in SSW | Sylvia Huang" url="https://youtu.be/aib-RTN9fvs" />
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **AI can help:** If an AI agent built the change, it can record a short clip of the flow while it verifies its own work in a browser. That clip is a good fit for the PR and the Done comment on the PBI. It does not replace a Done Video for a high-value PBI, where the Product Owner wants to hear you explain the pain and the solution. See [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes).
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
 ## Tip 1: Choose the right software
 

--- a/public/uploads/rules/playwright-with-ai/rule.mdx
+++ b/public/uploads/rules/playwright-with-ai/rule.mdx
@@ -21,7 +21,6 @@ related:
   - rule: public/uploads/rules/playwright-page-object-model/rule.mdx
   - rule: public/uploads/rules/mcp-servers-for-context/rule.mdx
   - rule: public/uploads/rules/ai-cli-tools/rule.mdx
-  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 guid: 05f8fdb2-bbf8-4c93-a94c-eedd362cc218
 seoDescription: 'Learn the different ways to combine Playwright with AI coding agents - the Playwright MCP server, the Playwright CLI, codegen, and the official Playwright Test Agents - for UI testing, frontend development, and browser automation.'
 created: 2026-05-05T05:12:20.286Z

--- a/public/uploads/rules/playwright-with-ai/rule.mdx
+++ b/public/uploads/rules/playwright-with-ai/rule.mdx
@@ -21,6 +21,7 @@ related:
   - rule: public/uploads/rules/playwright-page-object-model/rule.mdx
   - rule: public/uploads/rules/mcp-servers-for-context/rule.mdx
   - rule: public/uploads/rules/ai-cli-tools/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 guid: 05f8fdb2-bbf8-4c93-a94c-eedd362cc218
 seoDescription: 'Learn the different ways to combine Playwright with AI coding agents - the Playwright MCP server, the Playwright CLI, codegen, and the official Playwright Test Agents - for UI testing, frontend development, and browser automation.'
 created: 2026-05-05T05:12:20.286Z
@@ -54,7 +55,7 @@ By giving the Agent access to Playwright, we can bridge this gap, giving your Ag
 * **Automated UI testing** - generating end-to-end tests for the frontend by exploring the layout of the app itself and self-healing the tests when certain selectors drift during development. *See also: **[Do you do automated UI testing?](https://www.ssw.com.au/rules/automated-ui-testing)***
 * **Frontend development** - allow the Agent to open the page that it just built, click through the page, and verify that the changes made work as intended before claiming that it is done
 * **Reproduce reported bugs** - when a bug report comes in, the Agent can use Playwright to follow the reported steps, inspect the app state, and confirm the bug in a real browser. If the steps are incomplete, it can explore the flow to find a reliable reproduction path before proposing a fix
-* **Automation and scraping** - have Agents drive multi-step web workflows (form fills, data extraction, scheduled checks, etc.) using the existing structured accessibility data instead of brittle screenshots that break with the slightest UI change
+* **Automation and scraping** - have Agents drive multi-step web workflows (form fills, data extraction, scheduled checks, etc.) using the existing structured accessibility data for navigation and assertions, rather than driving from screenshots that break with the slightest UI change. Screenshots still have a place as evidence for humans (see below)
 * **Easy handling of popups and modals** - it allows your Agent to see and interact with popups within the context of your own application and frontend tests
 
 ### Development - Using Playwright for AI-assisted frontend dev
@@ -69,6 +70,17 @@ This unlocks a few high-value workflows:
 * **Component playground verification** - Agent navigates Storybook, Histoire, or your component sandbox after a change and confirms each variant still renders correctly
 * **Network interception during dev** - Agent uses Playwright's route mocking to test edge cases (slow API, 500 errors, empty states) without needing to touch the real backend
 * **Check acceptance criteria** - For PBIs with UI changes, the Agent can use Playwright to verify the user flow against the Acceptance Criteria before merging. *See also: **[Do you write Acceptance Tests to verify Acceptance Criteria?](https://www.ssw.com.au/rules/does-your-team-write-acceptance-tests-to-verify-acceptance-criteria)***
+
+### Capture the evidence, not just the check
+
+The verification loop above produces something worth keeping. When the Agent has confirmed the change in the browser, get it to take a screenshot or record a short video from that same session, then put the capture on the PR description and the Done comment. The reviewer sees the result without checking out the branch, and the Agent has already fixed whatever it found along the way.
+
+Use the two outputs for different jobs:
+
+* **Accessibility tree** - for the Agent's own assertions. It is deterministic and does not change when a font or animation does
+* **Screenshot or video** - for the human reading the PR. It shows the result at a glance
+
+See [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes) for what to capture and where to put it.
 
 ## How can you pair Playwright with an AI Agent?
 

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -28,6 +28,7 @@ related:
   - rule: public/uploads/rules/which-emojis-to-use-in-scrum/rule.mdx
   - rule: public/uploads/rules/reply-done/rule.mdx
   - rule: public/uploads/rules/refer-to-email-subject/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 redirects:
   - do-you-know-how-to-write-a-good-pull-request
 guid: d35b49bf-bdd1-48eb-bc1d-944cdc5be4dc
@@ -131,6 +132,15 @@ Examples of sentences to have in a good PR description:
 > "This PR is to **&#123;&#123; ACHIEVE THE FEATURE / FIX THE BUG / OTHER GOAL(S) &#125;&#125;**" (anything that was not possible to explain in the title)
 
 > "See **&#123;&#123; SCREENSHOT / DONE VIDEO &#125;&#125;** for more details" (to help the reviewer to understand the changes. E.g. styling changes)
+
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** If an AI agent made the UI change, it can take the screenshot or record the video itself while it verifies the change in a browser. See [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes).
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
 If you noticed that a change needed to be made and had no specific task/issue, use:
 
@@ -237,7 +247,7 @@ If the PR is closing an email task after merged, remember to refer back to it:
 ##### **Q:** Are the changes big and complex?
 
 **A:** You should include a demonstration of the change.
-E.g. A [screenshot](/screenshots-avoid-walls-of-text) to show text/UI changes, or a [Done video](/record-a-quick-and-dirty-done-video) to demo functionality changes.
+E.g. A [screenshot](/screenshots-avoid-walls-of-text) to show text/UI changes, or a [Done video](/record-a-quick-and-dirty-done-video) to demo functionality changes. If an AI agent built the change, [get it to capture the evidence](/ai-capture-ui-changes) as part of its own verification.
 
 ***
 

--- a/public/uploads/rules/write-a-good-pull-request/rule.mdx
+++ b/public/uploads/rules/write-a-good-pull-request/rule.mdx
@@ -28,7 +28,6 @@ related:
   - rule: public/uploads/rules/which-emojis-to-use-in-scrum/rule.mdx
   - rule: public/uploads/rules/reply-done/rule.mdx
   - rule: public/uploads/rules/refer-to-email-subject/rule.mdx
-  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 redirects:
   - do-you-know-how-to-write-a-good-pull-request
 guid: d35b49bf-bdd1-48eb-bc1d-944cdc5be4dc


### PR DESCRIPTION
New rule: Do you get your AI agent to capture its own UI changes?

## What this adds

A new rule — **Do you get your AI agent to capture its own UI changes?** (`ai-capture-ui-changes`).

The idea: an agent that cannot see its own UI change reports "done" when the code merely compiles. A human then finds the broken layout in review, which costs a full round trip. The agent should drive the browser, verify the change, fix what it finds, and **keep the screenshot or short video from that same loop** — then put it on the PR and the Done comment.

Two halves of this already existed in the rules, but nothing joined them:

- `playwright-with-ai` covers the agent verifying its own frontend changes, but stops at verification and never keeps the artefact.
- `write-a-good-pull-request`, `definition-of-done` and `done-video` all expect a screenshot or Done video, but assume a human captures it by hand.

## Changes

| File | Change |
|---|---|
| `ai-capture-ui-changes` | **New rule** — the verify-then-capture loop, what to capture, where the evidence goes, and how the accessibility tree, screenshots and pixel comparison each fit |
| `playwright-with-ai` | New "Capture the evidence, not just the check" section. The "brittle screenshots" bullet is now split: accessibility tree for assertions, screenshot for human evidence |
| `write-a-good-pull-request` | Tips box at the `{{ SCREENSHOT / DONE VIDEO }}` placeholder — the agent can capture it |
| `definition-of-done` | Tips box in the "3 levels of Done in communication" section |
| `done-video` | "AI can help" box. An agent clip suits the PR and the Done comment, but does not replace a Done Video for a high-value PBI |
| `ai-assisted-desktop-pr-preview` | The existing tip line now names the agent as the capturer |
| `devtools-design-changes` | Tips box linking the developer-side twin of the designer workflow |

Both category indexes updated: `rules-to-better-ai-assisted-development` and `rules-to-better-pull-requests`.

## Copy review

The first draft was written quickly with AI, so the whole rule has been walked paragraph by paragraph with a human. Notable corrections:

- **The accessibility tree section was wrong.** It said the agent "should not check its work by comparing pixels" and implied the tree was sufficient. The tree is blind to the exact defect class this rule is about — overlap, spacing, colour, clipping, CSS not loading. Playwright's own MCP docs say snapshots exclude colours, fonts and layout, and recommend combining with screenshots. Rewritten to cover the tree, the screenshot, and pixel comparison as a third option when developing against a pre-existing reference.
- **Two tooling entries removed.** The Screengrabs skill only appears on a third-party aggregator with no named author or repo. The GitHub CLI bullet claimed `gh` can attach images to a PR — it cannot; the line now says so and suggests templating the placeholders instead.
- **Trimmed throughout** — the AI-sounding example lists, the restated closing sentences, and the pithy headings are gone. The `AGENTS.md` advice was promoted out of Tips and into the verification section.

## Open items before merge

- [ ] **Video TODO.** The rule has a visible `style="todo"` box asking for an SSW video. Either record one, or drop the box. It links Hark Singh's [3 Ways to Supercharge Playwright with AI Agents](https://www.youtube.com/watch?v=EUhQ1J-69KY) as the closest existing reference.
- [ ] **Example is fictional.** The good/bad PR example uses a Northwind-style header change and a made-up issue number. A real SSW example would be stronger — Calum Simpson's Armada agent records a narrated Done video with Playwright plus text-to-speech ([User Group talk, 76:32](https://www.youtube.com/watch?v=7yty_Abk7uw&t=4592s)).

## Validation

Frontmatter, check-mdx, malformed-bold, category-sync and endIntro checks all pass. Markdownlint is clean on the new rule. The 6 edited rules carry 30 pre-existing markdownlint errors, and the count is identical before and after these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
