### PR TITLE
Fix duplicate video caption on ai-capture-ui-changes

### DIFF
--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -24,9 +24,7 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <endIntro />
 
-<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group (watch from 1:14:21 - 1:20:07, 6 min)" />
-
-**✅ Video: Good example - Watch from 1:14:21 - 1:20:07 (6 min) - Calum Simpson shows an AI agent recording its own Done video with Playwright and text-to-speech**
+<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group - Calum shows an AI agent recording its own Done video with Playwright and text-to-speech (watch from 1:14:21 - 1:20:07, 6 min)" />
 
 ## How the agent checks its own work
 


### PR DESCRIPTION
The `youtubeEmbed` description already renders as the caption, so the bold line under it repeated the same title and timestamps twice on the page.

Removed the bold line and folded its useful detail (what Calum actually demos) into the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)