### PR TITLE
Add Isaac Lombard and Ben Neoh as authors of the AI capture rule

### DIFF
--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -8,6 +8,10 @@ created: 2026-09-03T01:04:28.000Z
 authors:
   - title: Brady Stroud
     url: https://www.ssw.com.au/people/brady-stroud
+  - title: Isaac Lombard
+    url: https://www.ssw.com.au/people/isaac-lombard
+  - title: Ben Neoh
+    url: https://www.ssw.com.au/people/ben-neoh
 related:
   - rule: public/uploads/rules/done-video/rule.mdx
   - rule: public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx


### PR DESCRIPTION
Adds Isaac Lombard and Ben Neoh to the `authors` list of **Do you get your AI agent to capture its own UI changes?** (`ai-capture-ui-changes`).

Follows #13272, which added the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG4q4SABArdapUR4FYUbBT