### PR TITLE
Start the ai-capture-ui-changes video at 1:14:21

### DIFF
--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -24,7 +24,7 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <endIntro />
 
-<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group - Calum shows an AI agent recording its own Done video with Playwright and text-to-speech (watch from 1:14:21 - 1:20:07, 6 min)" />
+<youtubeEmbed url="https://www.youtube.com/embed/7yty_Abk7uw?start=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group - Calum shows an AI agent recording its own Done video with Playwright and text-to-speech (watch from 1:14:21 - 1:20:07, 6 min)" />
 
 ## How the agent checks its own work
 

--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -24,9 +24,7 @@ Loop AI into the visual review, and it can resolve obvious visual bugs before th
 
 <endIntro />
 
-<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group (watch from 1:14:21 - 1:20:07, 6 min)" />
-
-**✅ Video: Good example - Watch from 1:14:21 - 1:20:07 (6 min) - Calum Simpson shows an AI agent recording its own Done video with Playwright and text-to-speech**
+<youtubeEmbed url="https://youtu.be/7yty_Abk7uw?t=4461" description="Video: AI: It's a Skill Issue | Calum Simpson | SSW User Group - Calum shows an AI agent recording its own Done video with Playwright and text-to-speech (watch from 1:14:21 - 1:20:07, 6 min)" />
 
 ## How the agent checks its own work
 


### PR DESCRIPTION
The embed used `youtu.be/...?t=4461`. That parameter only works on the YouTube watch page - embedded players ignore it and start from 0.

Switched to `youtube.com/embed/...?start=4461`, which is the form the embedded player honours (same pattern as `use-azure-machine-learning-to-make-predictions-from-your-data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)