### PR TITLE
Link back pressure and AI UI capture rules

### DIFF
--- a/public/uploads/rules/ai-capture-ui-changes/rule.mdx
+++ b/public/uploads/rules/ai-capture-ui-changes/rule.mdx
@@ -15,6 +15,7 @@ authors:
 related:
   - rule: public/uploads/rules/done-video/rule.mdx
   - rule: public/uploads/rules/ai-assisted-desktop-pr-preview/rule.mdx
+  - rule: public/uploads/rules/utilize-back-pressure-for-agents/rule.mdx
 categories:
   - category: categories/artificial-intelligence/rules-to-better-ai-assisted-development.mdx
   - category: categories/project-delivery/rules-to-better-pull-requests.mdx
@@ -48,7 +49,7 @@ The screenshot is a by-product of a verification loop, not a separate step. Give
   figure="A prompt that asks for the capture as part of the verification"
 />
 
-Better still, bake the loop into `AGENTS.md`, a skill, or the PR template, so every UI change gets the same visual review without anyone asking for it.
+Better still, bake the loop into `AGENTS.md`, a skill, or the PR template, so every UI change gets the same visual review without anyone asking for it. This is [back pressure](/utilize-back-pressure-for-agents) for UI work - the browser gives the agent a signal it can act on, the same way a linter or a failing test does.
 
 ## What to capture
 

--- a/public/uploads/rules/utilize-back-pressure-for-agents/rule.mdx
+++ b/public/uploads/rules/utilize-back-pressure-for-agents/rule.mdx
@@ -12,6 +12,7 @@ related:
   - rule: public/uploads/rules/use-mcp-to-standardize-llm-connections/rule.mdx
   - rule: public/uploads/rules/critical-agent/rule.mdx
   - rule: public/uploads/rules/mcp-servers-for-context/rule.mdx
+  - rule: public/uploads/rules/ai-capture-ui-changes/rule.mdx
 guid: f63f04e9-36c1-4e06-b21c-217bae75811f
 seoDescription: 'Learn how to use back pressure (compilers, linters, tests, MCP servers) to improve AI agent reliability and reduce manual review time.'
 created: 2026-01-29T00:00:00.000Z
@@ -139,7 +140,7 @@ This is already built into coding agents, so you don't need to worry about it.
 
 Advanced agents can use [Model Context Protocol (MCP) servers](/mcp-server) to interact with real runtime environments. This allows them to "spin things up" and verify they actually work.
 
-[Playwright](/microsoft-recommended-frameworks-for-automated-ui-driven-functional-testing): The agent can write a web app, start a local server, and run Playwright tests against it to verify the UI works as expected, it can even take screenshots of the UI and compare them to the expected state.
+[Playwright](/microsoft-recommended-frameworks-for-automated-ui-driven-functional-testing): The agent can write a web app, start a local server, and run Playwright tests against it to verify the UI works as expected, it can even take screenshots of the UI and compare them to the expected state. Those screenshots are worth keeping - see [Do you get your AI agent to capture its own UI changes?](/ai-capture-ui-changes)
 
 .NET Aspire MCP: The agent can use Aspire to orchestrate a distributed application and verify service-to-service communication, by reading console logs etc.
 


### PR DESCRIPTION
The back pressure rule already mentions an agent taking Playwright screenshots and comparing them to the expected state, which is the same loop `ai-capture-ui-changes` describes - it just stops before keeping the screenshot.

Added a link in each direction, plus reciprocal `related` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)