### PR TITLE
Add Tina GEO tip and llms.txt adoption note to make-your-website-llm-friendly

### DIFF
--- a/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+++ b/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
@@ -116,7 +116,7 @@ Important notes:
 <boxEmbed
   style="info"
   body={<>
-    **Tip:** Run your site through [Tina GEO](https://tina.io/geo) - a free tool that scores your pages for AI search readiness. It reports whether an `llms.txt` file is present, alongside the signals that carry real weight such as Markdown content negotiation.
+    **Tip:** Run your site through [Tina GEO](https://tina.io/geo) - a free tool that scores your pages for AI search readiness. It reports whether an `llms.txt` file is present, alongside other GEO metrics such as crawlability, structured data and Markdown content negotiation.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+++ b/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
@@ -27,9 +27,9 @@ Implementing an `llms.txt` file addresses this challenge by providing a streamli
 <boxEmbed
   style="warning"
   body={<>
-    **Note:** `llms.txt` is an emerging convention, not an established standard. No major AI provider has confirmed reading it, and Google has stated that Search ignores the file entirely.
+    **Note:** `llms.txt` is an emerging convention, not an established standard. The crawlers behind AI search products do not read it, and Google has stated that Search ignores the file entirely.
 
-    Today it is most useful for technical documentation, where coding agents such as Cursor, GitHub Copilot and Claude fetch it to find the right pages. Adopt it there as a low-cost, forward-looking step, but treat [serving Markdown to AI agents](/serve-markdown-to-ai-agents) as the higher-value change.
+    Where it does help today is technical documentation. Coding agents such as Cursor, GitHub Copilot and Claude Code will fetch an `llms.txt` when a developer points them at your docs, and use it to find the right pages. Adopt it there as a low-cost, forward-looking step, but treat [serving Markdown to AI agents](/serve-markdown-to-ai-agents) as the higher-value change.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+++ b/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
@@ -61,6 +61,15 @@ An effective `llms.txt` file includes:
 * **Enhancing backlink profiles** - Acquiring high-quality backlinks from trusted sources signals authority, increasing the likelihood of content being referenced by LLMs
 * **Incorporating quotable content** - Embedding unique statistics, expert quotes, and proprietary insights makes content more likely to be cited by AI models seeking authoritative information
 
+<boxEmbed
+  style="info"
+  body={<>
+    **Tip:** Run your site through [Tina GEO](https://tina.io/geo) - a free tool that scores your pages for AI search readiness. It reports whether an `llms.txt` file is present, alongside other GEO metrics such as crawlability, structured data and Markdown content negotiation.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
 ### Examples
 
 Here is a mock example of the format:
@@ -112,15 +121,6 @@ Important notes:
 ```
 
 **Figure: Excerpt of an in-use llms.txt**
-
-<boxEmbed
-  style="info"
-  body={<>
-    **Tip:** Run your site through [Tina GEO](https://tina.io/geo) - a free tool that scores your pages for AI search readiness. It reports whether an `llms.txt` file is present, alongside other GEO metrics such as crawlability, structured data and Markdown content negotiation.
-  </>}
-  figurePrefix="none"
-  figure=""
-/>
 
 ### Directories
 

--- a/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
+++ b/public/uploads/rules/make-your-website-llm-friendly/rule.mdx
@@ -24,6 +24,17 @@ Implementing an `llms.txt` file addresses this challenge by providing a streamli
 
 <youtubeEmbed url="https://www.youtube.com/watch?v=_Lx1DmMMJbg" description={"Video: Do you provide an llms.txt file to make your website LLM-friendly? | Isaac Lombard | Rules (1 min)"} />
 
+<boxEmbed
+  style="warning"
+  body={<>
+    **Note:** `llms.txt` is an emerging convention, not an established standard. No major AI provider has confirmed reading it, and Google has stated that Search ignores the file entirely.
+
+    Today it is most useful for technical documentation, where coding agents such as Cursor, GitHub Copilot and Claude fetch it to find the right pages. Adopt it there as a low-cost, forward-looking step, but treat [serving Markdown to AI agents](/serve-markdown-to-ai-agents) as the higher-value change.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
+
 
 ## What is an `llms.txt`?
 
@@ -101,6 +112,15 @@ Important notes:
 ```
 
 **Figure: Excerpt of an in-use llms.txt**
+
+<boxEmbed
+  style="info"
+  body={<>
+    **Tip:** Run your site through [Tina GEO](https://tina.io/geo) - a free tool that scores your pages for AI search readiness. It reports whether an `llms.txt` file is present, alongside the signals that carry real weight such as Markdown content negotiation.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
 ### Directories
 


### PR DESCRIPTION
Updates the [llms.txt rule](https://www.ssw.com.au/rules/make-your-website-llm-friendly).

- Adds an info box pointing to [Tina GEO](https://tina.io/geo), matching the Tina tip boxes used in other rules
- Adds a warning box after the video noting that `llms.txt` is an emerging convention: no major AI provider has confirmed reading it and Google Search ignores it. It recommends it today for technical documentation consumed by coding agents, and links to the serve-markdown-to-ai-agents rule as the higher-value step

🤖 Generated with [Claude Code](https://claude.com/claude-code)