### PR TITLE
Rule/safely make GitHub repository public

### DIFF
--- a/categories/project-delivery/rules-to-better-github.mdx
+++ b/categories/project-delivery/rules-to-better-github.mdx
@@ -24,6 +24,7 @@ index:
   - rule: public/uploads/rules/adding-changes-to-pull-requests/rule.mdx
   - rule: public/uploads/rules/indent/rule.mdx
   - rule: public/uploads/rules/do-you-know-to-the-requirements-to-create-a-new-repository/rule.mdx
+  - rule: public/uploads/rules/safely-make-github-repository-public/rule.mdx
   - rule: public/uploads/rules/use-emojis-in-your-commits/rule.mdx
   - rule: public/uploads/rules/turn-emails-into-a-github-issue/rule.mdx
   - rule: public/uploads/rules/mention-when-you-make-a-pull-request-or-comment-on-github/rule.mdx

--- a/public/uploads/rules/safely-make-github-repository-public/rule.mdx
+++ b/public/uploads/rules/safely-make-github-repository-public/rule.mdx
@@ -17,6 +17,7 @@ related:
   - rule: public/uploads/rules/team-as-code-owners/rule.mdx
   - rule: public/uploads/rules/awesome-readme/rule.mdx
   - rule: public/uploads/rules/find-your-license/rule.mdx
+  - rule: public/uploads/rules/security-email-account/rule.mdx
 categories:
   - category: categories/project-delivery/rules-to-better-github.mdx
 ---
@@ -40,9 +41,9 @@ Check for:
 - Commercially sensitive internal information
 - Third-party code or assets that cannot be redistributed
 
-If the repository is intended to be open source, choose an appropriate licence. See [Do you know the best license for your project?](/find-your-license).
+If the repository is intended to be open source, choose an appropriate license. See [Do you know the best license for your project?](/find-your-license).
 
-Making a repository public does not automatically make the code open source. The licence defines what others are allowed to do with it.
+Making a repository public does not automatically make the code open source. The license defines what others are allowed to do with it.
 
 ## 2. Scan the entire Git history
 
@@ -71,7 +72,7 @@ Look for internal infrastructure, customer information, cloud environment detail
 
 For example, a screenshot containing an Azure SAS URL with delete permissions is just as sensitive as putting the SAS token directly in source code.
 
-GitHub Issues and comments can also retain sensitive information in revision history. See [Do you know how to completely remove confidential information from a GitHub Issue?](/remove-confidential-information-from-github).
+GitHub issues and comments can also retain sensitive information in revision history. See [Do you know how to completely remove confidential information from a GitHub Issue?](/remove-confidential-information-from-github).
 
 ## 4. Perform a security audit
 
@@ -101,10 +102,10 @@ Review all workflows and check that:
 - `GITHUB_TOKEN` has the minimum required permissions
 - Secrets cannot be exposed to untrusted pull requests
 - `pull_request_target` is not being used unsafely
-- Third-party Actions are trusted and preferably pinned
-- Existing Actions logs and artifacts do not contain sensitive information
+- Third-party actions are trusted and preferably pinned
+- Existing GitHub Actions logs and artifacts do not contain sensitive information
 
-For workflows that deploy to real environments, use appropriate GitHub Environment protections. See [GitHub Environments - Do you use gated deployments?](/use-gated-deployments).
+For workflows that deploy to real environments, use appropriate GitHub environment protections. See [GitHub Environments - Do you use gated deployments?](/use-gated-deployments).
 
 ### Check self-hosted runners
 
@@ -116,7 +117,7 @@ A malicious pull request could access credentials, internal services or other re
 
 Protect important branches such as `main`.
 
-Configure appropriate Rulesets or branch protection to:
+Configure appropriate rulesets or branch protection to:
 
 - Require pull requests and approvals
 - Require status checks
@@ -139,7 +140,7 @@ Also enable the applicable GitHub security features:
 
 Making the repository public exposes more than the source tree.
 
-Review existing Issues, Pull Requests, Discussions, Wiki pages, releases, branches, tags, Actions history, logs and workflow artifacts. Remove anything that was written or uploaded with the expectation that only internal users could see it.
+Review existing issues, pull requests, discussions, wiki pages, releases, branches, tags, GitHub Actions history, logs and workflow artifacts. Remove anything that was written or uploaded with the expectation that only internal users could see it.
 
 GitHub Actions history and logs become visible to everyone when a private repository is made public.
 
@@ -153,9 +154,11 @@ Depending on the project, also consider:
 - `SECURITY.md`
 - `CONTRIBUTING.md`
 - `CODEOWNERS`
-- Pull Request and Issue templates
+- Pull request and issue templates
 
-For public projects, a `SECURITY.md` gives security researchers a private way to report vulnerabilities instead of opening a public Issue.
+For public projects, a `SECURITY.md` gives security researchers a private way to report vulnerabilities instead of opening a public issue.
+
+For repositories associated with a public website or service, also ensure the service publishes a `security.txt` file at `/.well-known/security.txt`. This complements `SECURITY.md` by making the security contact easy for researchers and automated tools to find. See [Do you have a security@ email account?](/security-email-account).
 
 ## 9. Record the decision and get another person to review it
 
@@ -180,6 +183,6 @@ See [GitHub - Setting repository visibility](https://docs.github.com/en/reposito
 Afterwards:
 
 1. Open the repository in an incognito/private browser and confirm what an unauthenticated user can see
-2. Re-check branch protections and Rulesets
-3. Confirm Secret Scanning and Push Protection are enabled
+2. Re-check branch protections and rulesets
+3. Confirm secret scanning and push protection are enabled
 4. Confirm GitHub Actions still have the expected permissions

--- a/public/uploads/rules/safely-make-github-repository-public/rule.mdx
+++ b/public/uploads/rules/safely-make-github-repository-public/rule.mdx
@@ -1,0 +1,185 @@
+---
+type: rule
+title: Do you know how to safely make a GitHub repository public?
+uri: safely-make-github-repository-public
+guid: accc8579-0818-4bbf-8b5e-22809fc1388c
+seoDescription: Check Git history, secrets, sensitive content, vulnerabilities, CI/CD, repository protections and licensing before changing a GitHub repository from private to public.
+created: 2026-09-09T01:50:00.000Z
+authors:
+  - title: Kaique Biancatti
+    url: https://www.ssw.com.au/people/kaique-biancatti
+related:
+  - rule: public/uploads/rules/architectural-decision-records/rule.mdx
+  - rule: public/uploads/rules/prevent-secrets-leaking-from-repo/rule.mdx
+  - rule: public/uploads/rules/developer-cybersecurity-tools/rule.mdx
+  - rule: public/uploads/rules/use-branch-protection/rule.mdx
+  - rule: public/uploads/rules/use-gated-deployments/rule.mdx
+  - rule: public/uploads/rules/team-as-code-owners/rule.mdx
+  - rule: public/uploads/rules/awesome-readme/rule.mdx
+  - rule: public/uploads/rules/find-your-license/rule.mdx
+categories:
+  - category: categories/project-delivery/rules-to-better-github.mdx
+---
+
+Changing a GitHub repository from **private** to **public** can expose years of source code, Git history, screenshots, documentation and CI/CD information to the internet. Once it is public, assume anything exposed can be copied immediately.
+
+Before making a repository public, it should pass a publication security review.
+
+<endIntro />
+
+## 1. Confirm the repository can be public
+
+Confirm that SSW has the right to publish everything in the repository.
+
+Check for:
+
+- Client-owned or licensed source code
+- Client data or confidential information
+- Personal information
+- Content covered by an NDA
+- Commercially sensitive internal information
+- Third-party code or assets that cannot be redistributed
+
+If the repository is intended to be open source, choose an appropriate licence. See [Do you know the best license for your project?](/find-your-license).
+
+Making a repository public does not automatically make the code open source. The licence defines what others are allowed to do with it.
+
+## 2. Scan the entire Git history
+
+Checking the current `main` branch is not enough. A credential or sensitive file deleted years ago may still be available in Git history.
+
+Scan the **entire repository history, including branches and tags**, for secrets such as API keys, Personal Access Tokens, Azure SAS tokens, passwords, connection strings, private keys, `.env` files and webhook URLs containing secrets.
+
+Use an automated scanner that supports full Git history, but do not rely on automated scanning alone. See [Do you know the best way to prevent secrets leaking from your code repository?](/prevent-secrets-leaking-from-repo).
+
+If a secret is found:
+
+1. **Revoke or rotate it first**
+2. Remove it from the current repository and Git history where appropriate
+3. Re-run the scan
+4. Investigate whether the credential was used unexpectedly
+
+Deleting a secret from the latest commit does not remove it from Git history.
+
+## 3. Review sensitive files and information
+
+Secret scanners will not find everything that should remain private.
+
+Review the current repository and its history for sensitive content in screenshots, photos, architecture or network diagrams, office floor plans, documents, logs, test data and exported configuration.
+
+Look for internal infrastructure, customer information, cloud environment details, credentials and anything else that was never intended to be public.
+
+For example, a screenshot containing an Azure SAS URL with delete permissions is just as sensitive as putting the SAS token directly in source code.
+
+GitHub Issues and comments can also retain sensitive information in revision history. See [Do you know how to completely remove confidential information from a GitHub Issue?](/remove-confidential-information-from-github).
+
+## 4. Perform a security audit
+
+Review the code from the perspective of someone who now has unlimited access to inspect it.
+
+Run the security checks appropriate for the technology, such as:
+
+- Static application security testing
+- Dependency vulnerability scanning
+- Dependabot
+- CodeQL or other code scanning
+- Infrastructure as Code scanning
+- Container scanning
+
+See [Do you use the right cybersecurity tools when writing code?](/developer-cybersecurity-tools).
+
+Also manually review authentication, authorization, unsafe defaults, debug endpoints and anything that previously relied on the repository being private for security.
+
+Critical or High vulnerabilities that present a realistic attack path should normally be fixed before publication.
+
+## 5. Review GitHub Actions and CI/CD
+
+A public repository has a different threat model because anyone can fork it and submit a pull request.
+
+Review all workflows and check that:
+
+- `GITHUB_TOKEN` has the minimum required permissions
+- Secrets cannot be exposed to untrusted pull requests
+- `pull_request_target` is not being used unsafely
+- Third-party Actions are trusted and preferably pinned
+- Existing Actions logs and artifacts do not contain sensitive information
+
+For workflows that deploy to real environments, use appropriate GitHub Environment protections. See [GitHub Environments - Do you use gated deployments?](/use-gated-deployments).
+
+### Check self-hosted runners
+
+Do not allow arbitrary public pull request code to execute on an SSW self-hosted runner.
+
+A malicious pull request could access credentials, internal services or other resources available to that runner. GitHub-hosted ephemeral runners are generally the safer default for public repositories.
+
+## 6. Add repository protections
+
+Protect important branches such as `main`.
+
+Configure appropriate Rulesets or branch protection to:
+
+- Require pull requests and approvals
+- Require status checks
+- Block force pushes and branch deletion
+
+See [Do you use branch protection?](/use-branch-protection).
+
+Where appropriate, use `CODEOWNERS` so changes are reviewed by the people responsible for that area of the repository. See [Do you make your repo's team the code owners?](/team-as-code-owners).
+
+Also enable the applicable GitHub security features:
+
+- Secret scanning
+- Push protection
+- Dependabot alerts and security updates
+- Code scanning
+
+> **Important:** GitHub disables all push rulesets when a repository changes from private to public. Re-check the repository protections after changing visibility.
+
+## 7. Check the rest of GitHub
+
+Making the repository public exposes more than the source tree.
+
+Review existing Issues, Pull Requests, Discussions, Wiki pages, releases, branches, tags, Actions history, logs and workflow artifacts. Remove anything that was written or uploaded with the expectation that only internal users could see it.
+
+GitHub Actions history and logs become visible to everyone when a private repository is made public.
+
+## 8. Make the repository ready for the public
+
+Make sure the repository has a useful `README.md`. See [Do you have an awesome README?](/awesome-readme).
+
+Depending on the project, also consider:
+
+- `LICENSE`
+- `SECURITY.md`
+- `CONTRIBUTING.md`
+- `CODEOWNERS`
+- Pull Request and Issue templates
+
+For public projects, a `SECURITY.md` gives security researchers a private way to report vulnerabilities instead of opening a public Issue.
+
+## 9. Record the decision and get another person to review it
+
+Changing repository visibility is an important decision. Create an ADR that records why the repository is being made public, who approved it, what security checks were completed, and any known risks or exceptions.
+
+See [Do you use Architectural Decision Records (ADRs)?](/architectural-decision-records).
+
+Before changing the visibility, get another developer or someone from the **SysAdmin or Security team** to review the repository. Higher-risk repositories should have a formal security review before publication.
+
+## 10. Make the repository public
+
+Once the review is complete and approved:
+
+1. Open the repository on GitHub
+2. Go to **Settings | General | Danger Zone**
+3. Under **Change repository visibility**, click **Change visibility | Public**
+4. Confirm that you are changing the correct repository and understand the effects
+5. Click **Make this repository public**
+
+See [GitHub - Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility).
+
+Afterwards:
+
+1. Open the repository in an incognito/private browser and confirm what an unauthenticated user can see
+2. Re-check branch protections and Rulesets
+3. Confirm Secret Scanning and Push Protection are enabled
+4. Confirm GitHub Actions still have the expected permissions

--- a/public/uploads/rules/safely-make-github-repository-public/rule.mdx
+++ b/public/uploads/rules/safely-make-github-repository-public/rule.mdx
@@ -30,7 +30,7 @@ Before making a repository public, it should pass a publication security review.
 
 ## 1. Confirm the repository can be public
 
-Confirm that SSW has the right to publish everything in the repository.
+Confirm that your organization has the right to publish everything in the repository.
 
 Check for:
 

--- a/public/uploads/rules/safely-make-github-repository-public/rule.mdx
+++ b/public/uploads/rules/safely-make-github-repository-public/rule.mdx
@@ -22,167 +22,166 @@ categories:
   - category: categories/project-delivery/rules-to-better-github.mdx
 ---
 
-Changing a GitHub repository from **private** to **public** can expose years of source code, Git history, screenshots, documentation and CI/CD information to the internet. Once it is public, assume anything exposed can be copied immediately.
+Changing a GitHub repository from private or internal to public can expose years of source code, Git history, screenshots, documentation and CI/CD information. Assume anything exposed can be copied immediately.
 
-Before making a repository public, it should pass a publication security review.
+Review the repository and resolve sensitive findings before changing its visibility.
 
 <endIntro />
 
-## 1. Confirm the repository can be public
+## 1. Can you publish everything in the repository?
 
-Confirm that your organization has the right to publish everything in the repository.
+Confirm that your organization has the right to publish the repository’s contents.
 
-Check for:
+Check for client-owned code, confidential information, personal data, NDA-covered content, and third-party code or assets with redistribution restrictions.
 
-- Client-owned or licensed source code
-- Client data or confidential information
-- Personal information
-- Content covered by an NDA
-- Commercially sensitive internal information
-- Third-party code or assets that cannot be redistributed
+If the repository is intended to be open source, choose an appropriate license.
 
-If the repository is intended to be open source, choose an appropriate license. See [Do you know the best license for your project?](/find-your-license).
+See [Do you know the best license for your project?](/find-your-license)
 
-Making a repository public does not automatically make the code open source. The license defines what others are allowed to do with it.
+Making a repository public does not automatically make the code open source.
 
-## 2. Scan the entire Git history
+## 2. Have you scanned the entire Git history?
 
-Checking the current `main` branch is not enough. A credential or sensitive file deleted years ago may still be available in Git history.
+Checking the current `main` branch is not enough. A credential deleted years ago may still be available in Git history.
 
-Scan the **entire repository history, including branches and tags**, for secrets such as API keys, Personal Access Tokens, Azure SAS tokens, passwords, connection strings, private keys, `.env` files and webhook URLs containing secrets.
+Scan the entire history, including branches and tags, for API keys, personal access tokens, Azure SAS tokens, passwords, connection strings, private keys, `.env` files and webhook URLs containing secrets.
 
-Use an automated scanner that supports full Git history, but do not rely on automated scanning alone. See [Do you know the best way to prevent secrets leaking from your code repository?](/prevent-secrets-leaking-from-repo).
+Use an automated scanner that supports full Git history, but do not rely on automated scanning alone.
 
-If a secret is found:
+See [Do you know the best way to prevent secrets leaking from your code repository?](/prevent-secrets-leaking-from-repo)
 
-1. **Revoke or rotate it first**
-2. Remove it from the current repository and Git history where appropriate
-3. Re-run the scan
-4. Investigate whether the credential was used unexpectedly
+If you find a secret:
 
-Deleting a secret from the latest commit does not remove it from Git history.
+1. Revoke or rotate it first, and update affected applications
+2. Investigate whether the credential was used unexpectedly
+3. Remove it from current files and assess whether history cleanup is also needed
+4. Re-run the scan
 
-## 3. Review sensitive files and information
+Rewriting history does not guarantee removal. Old commits may remain accessible through cached views, pull requests, clones and forks. Coordinate cleanup with the owners of other copies.
+
+GitHub Support only assists with sensitive-data removal when rotating credentials cannot mitigate the risk.
+
+See [GitHub - Removing sensitive data from a repository](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository)
+
+## 3. Have you reviewed sensitive files and information?
 
 Secret scanners will not find everything that should remain private.
 
-Review the current repository and its history for sensitive content in screenshots, photos, architecture or network diagrams, office floor plans, documents, logs, test data and exported configuration.
+Review screenshots, photos, architecture and network diagrams, office floor plans, documents, logs, test data and exported configuration, including historical versions.
 
-Look for internal infrastructure, customer information, cloud environment details, credentials and anything else that was never intended to be public.
+Look for customer information, credentials and internal details that should not be published. A screenshot containing an Azure SAS URL with delete permissions is just as sensitive as putting the token in source code.
 
-For example, a screenshot containing an Azure SAS URL with delete permissions is just as sensitive as putting the SAS token directly in source code.
+GitHub issues and comments can also retain sensitive information in revision history.
 
-GitHub issues and comments can also retain sensitive information in revision history. See [Do you know how to completely remove confidential information from a GitHub Issue?](/remove-confidential-information-from-github).
+See [Do you know how to completely remove confidential information from a GitHub Issue?](/remove-confidential-information-from-github)
 
-## 4. Perform a security audit
+## 4. Have you checked for exploitable vulnerabilities?
 
-Review the code from the perspective of someone who now has unlimited access to inspect it.
+Run security checks appropriate for the project, including code, dependency, infrastructure and container scanning. Tools may include Dependabot and CodeQL.
 
-Run the security checks appropriate for the technology, such as:
+See [Do you use the right cybersecurity tools when writing code?](/developer-cybersecurity-tools)
 
-- Static application security testing
-- Dependency vulnerability scanning
-- Dependabot
-- CodeQL or other code scanning
-- Infrastructure as Code scanning
-- Container scanning
+Manually review authentication, authorization, unsafe defaults, debug endpoints and anything that relies on the repository being private for security.
 
-See [Do you use the right cybersecurity tools when writing code?](/developer-cybersecurity-tools).
+Fix critical or high-severity vulnerabilities with a realistic attack path before publication. Record any accepted exceptions and who approved them.
 
-Also manually review authentication, authorization, unsafe defaults, debug endpoints and anything that previously relied on the repository being private for security.
+## 5. Can public contributions abuse your workflows?
 
-Critical or High vulnerabilities that present a realistic attack path should normally be fixed before publication.
+Anyone can submit a pull request to a public repository. Review workflows before allowing them to process untrusted contributions.
 
-## 5. Review GitHub Actions and CI/CD
+* **Permissions** - Give `GITHUB_TOKEN` only the permissions each job needs
+* **Secrets** - Keep credentials away from untrusted pull request code
+* **Privileged triggers** - Do not check out and execute untrusted code in privileged `pull_request_target` or `workflow_run` workflows
+* **Third-party actions** - Review the actions you use and pin them to full commit SHAs
+* **Logs and artifacts** - Remove sensitive information from previous workflow runs
 
-A public repository has a different threat model because anyone can fork it and submit a pull request.
+See [GitHub - Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
 
-Review all workflows and check that:
+Require maintainer approval before an external contribution can provision paid preview environments. Limit resource sizes, concurrent environments and run duration, and automatically remove unused environments. Repeated pull requests must not be able to create an uncontrolled cloud bill.
 
-- `GITHUB_TOKEN` has the minimum required permissions
-- Secrets cannot be exposed to untrusted pull requests
-- `pull_request_target` is not being used unsafely
-- Third-party actions are trusted and preferably pinned
-- Existing GitHub Actions logs and artifacts do not contain sensitive information
+For workflows that deploy to real environments, configure GitHub environment protections.
 
-For workflows that deploy to real environments, use appropriate GitHub environment protections. See [GitHub Environments - Do you use gated deployments?](/use-gated-deployments).
+See [GitHub Environments - Do you use gated deployments?](/use-gated-deployments)
 
-### Check self-hosted runners
+Do not allow arbitrary public pull request code to execute on self-hosted runners. It could access credentials or internal services available to the runner. Use GitHub-hosted runners for untrusted contributions.
 
-Do not allow arbitrary public pull request code to execute on an SSW self-hosted runner.
+## 6. Are repository protections configured?
 
-A malicious pull request could access credentials, internal services or other resources available to that runner. GitHub-hosted ephemeral runners are generally the safer default for public repositories.
+Protect important branches such as `main`. Require pull requests, approvals and status checks, and block force pushes and branch deletion.
 
-## 6. Add repository protections
+See [Do you use branch protection?](/use-branch-protection)
 
-Protect important branches such as `main`.
+Use `CODEOWNERS` to identify responsible reviewers. Configure required code owner reviews where their approval must be enforced.
 
-Configure appropriate rulesets or branch protection to:
+See [Do you make your repo's team the code owners?](/team-as-code-owners)
 
-- Require pull requests and approvals
-- Require status checks
-- Block force pushes and branch deletion
+Enable applicable security features, including secret scanning, push protection, Dependabot alerts and updates, and code scanning.
 
-See [Do you use branch protection?](/use-branch-protection).
+<boxEmbed
+  style="info"
+  body={<>
+    GitHub disables all push rulesets when a repository changes from private or internal to public. Re-check the remaining rulesets and branch protections after changing visibility.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
-Where appropriate, use `CODEOWNERS` so changes are reviewed by the people responsible for that area of the repository. See [Do you make your repo's team the code owners?](/team-as-code-owners).
+## 7. Have you checked the rest of GitHub and existing forks?
 
-Also enable the applicable GitHub security features:
+Review issues, pull requests, discussions, wiki pages, releases, Actions history, logs and workflow artifacts. Remove sensitive material that was written or uploaded for internal readers.
 
-- Secret scanning
-- Push protection
-- Dependabot alerts and security updates
-- Code scanning
+Actions history and logs become publicly visible when you publish the repository.
 
-> **Important:** GitHub disables all push rulesets when a repository changes from private to public. Re-check the repository protections after changing visibility.
+<boxEmbed
+  style="warning"
+  body={<>
+    When you make a repository public, GitHub detaches its private forks into standalone private repositories. Cleaning the original repository does not clean those copies. Identify existing forks and coordinate any sensitive-data cleanup with their owners before changing visibility.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
-## 7. Check the rest of GitHub
+## 8. Is the repository ready for public readers?
 
-Making the repository public exposes more than the source tree.
+Provide a useful `README.md` explaining the project and how to use it.
 
-Review existing issues, pull requests, discussions, wiki pages, releases, branches, tags, GitHub Actions history, logs and workflow artifacts. Remove anything that was written or uploaded with the expectation that only internal users could see it.
+See [Do you have an awesome README?](/awesome-readme)
 
-GitHub Actions history and logs become visible to everyone when a private repository is made public.
+Add a `LICENSE` appropriate to the intended use. Depending on the project, also provide `CONTRIBUTING.md` and pull request and issue templates.
 
-## 8. Make the repository ready for the public
+Use `SECURITY.md` to document supported versions and a private vulnerability-reporting channel. Verify that the channel works.
 
-Make sure the repository has a useful `README.md`. See [Do you have an awesome README?](/awesome-readme).
+For a public website or service, also publish `security.txt` at `/.well-known/security.txt`. It helps researchers find your security contact and complements the repository policy.
 
-Depending on the project, also consider:
+See [Do you have a security@ email account?](/security-email-account)
 
-- `LICENSE`
-- `SECURITY.md`
-- `CONTRIBUTING.md`
-- `CODEOWNERS`
-- Pull request and issue templates
+## 9. Has another person reviewed and approved publication?
 
-For public projects, a `SECURITY.md` gives security researchers a private way to report vulnerabilities instead of opening a public issue.
+Create an ADR recording why the repository will become public, who approved it, the checks completed, and any accepted risks or exceptions.
 
-For repositories associated with a public website or service, also ensure the service publishes a `security.txt` file at `/.well-known/security.txt`. This complements `SECURITY.md` by making the security contact easy for researchers and automated tools to find. See [Do you have a security@ email account?](/security-email-account).
+See [Do you use Architectural Decision Records (ADRs)?](/architectural-decision-records)
 
-## 9. Record the decision and get another person to review it
+Get another developer or someone from your SysAdmin or Security team to review the repository and findings. Use a formal security review for higher-risk repositories.
 
-Changing repository visibility is an important decision. Create an ADR that records why the repository is being made public, who approved it, what security checks were completed, and any known risks or exceptions.
+Keep confidential findings in an access-controlled record. Do not publish the sensitive details in the ADR.
 
-See [Do you use Architectural Decision Records (ADRs)?](/architectural-decision-records).
+## 10. How do you change visibility and verify the result?
 
-Before changing the visibility, get another developer or someone from the **SysAdmin or Security team** to review the repository. Higher-risk repositories should have a formal security review before publication.
+After the review is complete and publication is approved, open **Settings | General | Danger Zone**. Choose **Change visibility**, select **Public**, and complete GitHub’s confirmation steps.
 
-## 10. Make the repository public
-
-Once the review is complete and approved:
-
-1. Open the repository on GitHub
-2. Go to **Settings | General | Danger Zone**
-3. Under **Change repository visibility**, click **Change visibility | Public**
-4. Confirm that you are changing the correct repository and understand the effects
-5. Click **Make this repository public**
-
-See [GitHub - Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility).
+See [GitHub - Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility)
 
 Afterwards:
 
-1. Open the repository in an incognito/private browser and confirm what an unauthenticated user can see
+1. Open the repository while signed out and check what visitors can see
 2. Re-check branch protections and rulesets
 3. Confirm secret scanning and push protection are enabled
-4. Confirm GitHub Actions still have the expected permissions
+4. Verify workflow permissions and approval requirements for deployments and preview environments
+
+***
+
+### Learn more
+
+* [GitHub - Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility) - Visibility changes and their consequences
+* [GitHub - Removing sensitive data](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) - History cleanup and its limits
+* [GitHub - Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use) - Workflow permissions, untrusted code and runners


### PR DESCRIPTION
<!--  **Tip: Use [SSW Rule Writer GPT](https://chat.openai.com/g/g-cOvrRzEnU-ssw-rules-writer) for help with writing rules 🤖** -->

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Email subject: "RE: SSW Design System - from private to public"

I also recently reviewed a private GitHub repository before making it public and found a few things that could easily have been exposed, including Azure SAS tokens with delete permissions in screenshots and internal images/office plans.

That highlighted that we didn't have a clear SSW Rule for the checks required before changing a repository from private to public.

> 2. What was changed?

Added a new rule: **Do you know how to safely make a GitHub repository public?**

The rule covers:

- Reviewing the full Git history for secrets
- Checking screenshots, diagrams and other non-code content for sensitive information
- Running a security audit for vulnerabilities
- Reviewing GitHub Actions, CI/CD and self-hosted runners
- Configuring branch protection, Rulesets and CODEOWNERS
- Checking licensing and public-facing documentation
- Recording the decision in an ADR
- Getting a second review from a developer, SysAdmin or Security team member
- The GitHub steps to change the repository visibility and the checks to perform afterwards

It also links to existing SSW Rules where we already have detailed guidance, rather than duplicating it.

> 3. I paired or mob programmed with:

Luke Cook

<!--
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->