### PR TITLE
Archive the LUIS rule

### DIFF
--- a/public/uploads/rules/luis/rule.mdx
+++ b/public/uploads/rules/luis/rule.mdx
@@ -14,6 +14,8 @@ authors:
     url: https://www.ssw.com.au/people/piers-sinclair
 created: 2021-11-18T06:23:33.649Z
 guid: 9aa306ef-cb33-4bed-b9a6-40d67515c4a6
+isArchived: true
+archivedreason: "Microsoft retired LUIS on 31 March 2026 and the luis.ai portal is gone. For choosing a current platform, see [Do you choose the right platform for your AI agent?](/rules/ai-agent-platform)"
 ---
 
 When building a chat bot, it needs some way to understand natural language text to simulate a person and provide a conversational experience for users. If you are using [Microsoft Bot Framework](https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0&WT.mc_id=AZ-MVP-33518), you can use [LUIS](https://www.luis.ai). LUIS is a natural language processing service and it provides some awesome benefits...

--- a/public/uploads/rules/luis/rule.mdx
+++ b/public/uploads/rules/luis/rule.mdx
@@ -13,6 +13,9 @@ authors:
   - title: Piers Sinclair
     url: https://www.ssw.com.au/people/piers-sinclair
 created: 2021-11-18T06:23:33.649Z
+lastUpdated: 2026-09-09T00:00:00.000Z
+lastUpdatedBy: Luke Mao
+lastUpdatedByEmail: LukeMao@ssw.com.au
 guid: 9aa306ef-cb33-4bed-b9a6-40d67515c4a6
 isArchived: true
 archivedreason: "Microsoft retired LUIS on 31 March 2026 and the luis.ai portal is gone. For choosing a current platform, see [Do you choose the right platform for your AI agent?](/rules/ai-agent-platform)"


### PR DESCRIPTION
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Reviewing [Rules to Better Bots](https://www.ssw.com.au/rules/rules-to-better-bots) while updating the bot framework rule (#13294).

[Do you use LUIS?](https://www.ssw.com.au/rules/luis) recommends a product that no longer exists. Microsoft [retired LUIS on 1 October 2025](https://learn.microsoft.com/en-us/answers/questions/1031241/retirement-announcement-language-understanding-(lu), took the portal down on 31 October 2025, and fully retired it on **31 March 2026**. `luis.ai` now redirects to Microsoft's `previous-versions` archive.

> 2. What was changed?

Archived it.

- `isArchived: true`
- `archivedreason` explains the retirement and points at [Do you choose the right platform for your AI agent?](/rules/ai-agent-platform)

**Why archive rather than rewrite:** the rule is LUIS-specific end to end - the portal, intents, utterances, phrase list features, and six portal screenshots. There is no general advice underneath to carry forward. Its replacement guidance already lives in the platform rule, which covers grounding and generative answers as the modern alternative to intent matching.

**Notes for the reviewer**

- Nothing outside the category linked to this rule, so no inbound links needed fixing
- It stays in the `rules-to-better-bots` index, matching how other archived rules are handled
- The `archivedreason` links to `/rules/ai-agent-platform`, which lands with #13294 - **merge that one first**

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017R8BMRfESCukyLPBDvkkTG
