### PR TITLE
Update cold start rule - platforms replaced the warm-up hacks

### DIFF
--- a/public/uploads/rules/keep-serverless-application-warm/rule.mdx
+++ b/public/uploads/rules/keep-serverless-application-warm/rule.mdx
@@ -32,15 +32,15 @@ The old fix was a timer-triggered function that pinged your own app every few mi
 
 ## Azure Functions
 
-* **Flex Consumption** - set an **always ready** instance count per function, which keeps instances running and skips the on-demand scale-out wait
+* **[Flex Consumption](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)** - set an **always ready** instance count per function, which keeps instances running and skips the on-demand scale-out wait
 * **Premium plan** - supports prewarmed and always ready instances with a minimum of one, and is generally available rather than the preview it was when this rule was written
 * **Dedicated App Service plan** - compute is always allocated, so there is nothing to warm, but you give up automatic scale-out
 
 ## AWS Lambda
 
 * **Provisioned concurrency** - pre-initialises a set number of execution environments so they are ready before the request arrives
-* **SnapStart** - caches a snapshot of the initialised environment and restores it, taking Java, Python, and .NET cold starts to sub-second at no extra charge. You cannot use it and provisioned concurrency on the same function version
-* **Attach a VPC only when you need it** - the network interface setup adds latency, so AWS advises using it only where access to VPC resources is genuinely required
+* **[SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html)** - caches a snapshot of the initialised environment and restores it, taking Java, Python, and .NET cold starts to sub-second at no extra charge. You cannot use it and provisioned concurrency on the same function version
+* **Attach a VPC only when you need it** - the network interface setup adds latency, so [AWS advises](https://aws.amazon.com/blogs/compute/understanding-and-remediating-cold-starts-an-aws-lambda-perspective/) using it only where access to VPC resources is genuinely required
 
 <boxEmbed style="info" figurePrefix="none" figure="" body={<>
 
@@ -52,7 +52,7 @@ The old fix was a timer-triggered function that pinged your own app every few mi
 
 Formerly Cloud Functions, and the same settings apply to Cloud Functions for Firebase.
 
-* **Minimum instances** - keep a number of instances warm during quiet periods, which is the supported replacement for a self-built ping
+* **[Minimum instances](https://docs.cloud.google.com/run/docs/configuring/min-instances)** - keep a number of instances warm during quiet periods, which is the supported replacement for a self-built ping
 * **Startup CPU boost** - allocates extra CPU during startup, which halves start time for some workloads
 
 ## Is it worth paying for?
@@ -61,12 +61,3 @@ Always-warm instances bill while idle, so match the setting to real traffic rath
 
 * **Worth it** - a user-facing agent, an API behind a UI, or anything a person waits on
 * **Usually not** - batch jobs, queue processing, and overnight work, where a few seconds of startup costs nothing
-
-***
-
-### Learn more
-
-* [Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan) - always ready instances and per-function scaling
-* [Improving startup performance with Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) - supported runtimes and how snapshots work
-* [Understanding and remediating cold starts on Lambda](https://aws.amazon.com/blogs/compute/understanding-and-remediating-cold-starts-an-aws-lambda-perspective/) - AWS's own guidance on causes and fixes
-* [Set minimum instances for Cloud Run services](https://docs.cloud.google.com/run/docs/configuring/min-instances) - keeping instances warm on Google Cloud

--- a/public/uploads/rules/keep-serverless-application-warm/rule.mdx
+++ b/public/uploads/rules/keep-serverless-application-warm/rule.mdx
@@ -14,7 +14,9 @@ lastUpdatedByEmail: tiagov8@gmail.com
 redirects:
 - do-you-keep-your-serverless-application-warm-to-avoid-cold-starts
 - do-you-keep-your-serverless-application-warm-(to-avoid-cold-starts)
-seoDescription: Do you keep your serverless application warm to avoid cold starts?
+seoDescription: Azure Functions, AWS Lambda, and Cloud Run functions all have a
+  first-party setting for keeping instances warm. Use it instead of writing timer
+  triggers that ping your own app.
 title: Do you keep your serverless application warm (to avoid cold starts)?
 categories:
   - category: categories/software-engineering/rules-to-better-bots.mdx
@@ -22,38 +24,49 @@ type: rule
 uri: keep-serverless-application-warm
 ---
 
-When designing your Bot, you will very likely leverage some Bot Frameworks or AI Services to take care of the Natural Language Processing (NLP) so that you can focus on implementing your business logic.
+The first user of the morning waits eight seconds for a reply. Everyone after them waits under a second. Your serverless platform shut the instance down overnight and had to build a new one, which is a **cold start**.
 
-To host your business logic, it is common to use serverless applications such as [Azure Function](https://azure.microsoft.com/en-au/services/functions/?WT.mc_id=AZ-MVP-33518), [Google Firebase](https://firebase.google.com/) or [Amazon Web Service Lambda Functions](https://aws.amazon.com/lambda/). Serverless applications come with amazing scaling abilities and simplified programming models, but they also suffer from at least one well-known side-effect that is commonly referred to as **Cold Starts**.
+The old fix was a timer-triggered function that pinged your own app every few minutes. You do not need to write that any more. Every major platform now has a setting for it.
 
 <endIntro />
 
-Here are some recommended solutions to eliminate Cold Starts:
+## Azure Functions
 
-#### Microsoft Azure Functions
+* **Flex Consumption** - set an **always ready** instance count per function, which keeps instances running and skips the on-demand scale-out wait
+* **Premium plan** - supports prewarmed and always ready instances with a minimum of one, and is generally available rather than the preview it was when this rule was written
+* **Dedicated App Service plan** - compute is always allocated, so there is nothing to warm, but you give up automatic scale-out
 
-* **Add warm-up request**
-  Use a timer trigger function to keep the Azure Functions application warm. If you know that at a certain time of a day the Function App is likely to be cold and so you wake it up just before you expect users to send out requests.
+## AWS Lambda
 
-* **Move to App Service Plan**
-  Azure Functions can be hosted using dedicated App Service Plans instead of the serverless Consumption plan. Now you no longer need to worry about cold starts since the compute resource is always available and ready. The only caveat is that the Azure Functions won't automatically scale out as they do with the Consumption plan. So, think ahead and measure your compute requirements, and make the right decision.
+* **Provisioned concurrency** - pre-initialises a set number of execution environments so they are ready before the request arrives
+* **SnapStart** - caches a snapshot of the initialised environment and restores it, taking Java, Python, and .NET cold starts to sub-second at no extra charge. You cannot use it and provisioned concurrency on the same function version
+* **Attach a VPC only when you need it** - the network interface setup adds latency, so AWS advises using it only where access to VPC resources is genuinely required
 
-* **Upgrade to Premium Plan**
-  If you want a dedicated instance that is always available and ready, and you also require the ability to automatically scale out under high try the Azure Functions Premium Plan (preview). The premium plan always has at least 1 core ready to process requests and your application will not suffer from cold starts. The premium plan does come at a price, so plan ahead.
+<boxEmbed style="info" figurePrefix="none" figure="" body={<>
 
-### Firebase Functions on Google Cloud Platform
+**Note:** Choosing Node.js or Python over Java or .NET used to be standard cold start advice. Interpreted runtimes still initialise faster, but SnapStart narrows the gap enough that runtime choice should no longer decide your language.
 
-* In Node.js code, export all the functions your want to deploy to cloud functions. And import / require dependencies inside the function. So that each function call will only load the dependency it needs instead of loading all dependencies in the index.ts file.
-* Warm up request - Create a separate function that works on a timer. The function can run at some time interval that you know your app will not be cold.
-* If cold starts are unbearable, convert to other infrastructure such as App Engine .
+</>} />
 
-### Amazon Web Service
+## Cloud Run functions
 
-* Instead of using statically typed programming languages like Java and C#, you may prefer dynamically typed languages like Python, Node.js etc.
-* Avoid deploying Lambdas in Amazon Virtual Private Cloud (VPC).
-* Avoid making HTTPS or TCP client calls inside your lambda. Handshake or other security related calls are CPU bound and will increase the cold starts to your function.
-* Send dummy requests to your functions with some frequency.
-* Make necessary changes on your Lambda to distinguish warm-up calls from customer calls.
-* Be mindful about the potential drawbacks of the warm-up requests
-  * Warm-up calls will potentially keep all your containers busy and a real customer request could not find a place to run
-  * A Lambda function in one container can catch all calls at once and this can make other containers down after a while
+Formerly Cloud Functions, and the same settings apply to Cloud Functions for Firebase.
+
+* **Minimum instances** - keep a number of instances warm during quiet periods, which is the supported replacement for a self-built ping
+* **Startup CPU boost** - allocates extra CPU during startup, which halves start time for some workloads
+
+## Is it worth paying for?
+
+Always-warm instances bill while idle, so match the setting to real traffic rather than turning it on everywhere.
+
+* **Worth it** - a user-facing agent, an API behind a UI, or anything a person waits on
+* **Usually not** - batch jobs, queue processing, and overnight work, where a few seconds of startup costs nothing
+
+***
+
+### Learn more
+
+* [Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan) - always ready instances and per-function scaling
+* [Improving startup performance with Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) - supported runtimes and how snapshots work
+* [Understanding and remediating cold starts on Lambda](https://aws.amazon.com/blogs/compute/understanding-and-remediating-cold-starts-an-aws-lambda-perspective/) - AWS's own guidance on causes and fixes
+* [Set minimum instances for Cloud Run services](https://docs.cloud.google.com/run/docs/configuring/min-instances) - keeping instances warm on Google Cloud

--- a/public/uploads/rules/keep-serverless-application-warm/rule.mdx
+++ b/public/uploads/rules/keep-serverless-application-warm/rule.mdx
@@ -14,8 +14,8 @@ lastUpdatedByEmail: LukeMao@ssw.com.au
 redirects:
 - do-you-keep-your-serverless-application-warm-to-avoid-cold-starts
 - do-you-keep-your-serverless-application-warm-(to-avoid-cold-starts)
-seoDescription: Azure Functions, AWS Lambda, and Cloud Run functions all have a
-  first-party setting for keeping instances warm. Use it instead of writing timer
+seoDescription: Azure Functions, AWS Lambda, and Google Cloud Run functions all
+  have a first-party setting for keeping instances warm. Use it instead of writing timer
   triggers that ping your own app.
 title: Do you keep your serverless application warm (to avoid cold starts)?
 categories:
@@ -48,7 +48,7 @@ The old fix was a timer-triggered function that pinged your own app every few mi
 
 </>} />
 
-## Cloud Run functions
+## Google Cloud Run functions
 
 Formerly Cloud Functions, and the same settings apply to Cloud Functions for Firebase.
 

--- a/public/uploads/rules/keep-serverless-application-warm/rule.mdx
+++ b/public/uploads/rules/keep-serverless-application-warm/rule.mdx
@@ -8,9 +8,9 @@ createdBy: Patrick Zhao
 createdByEmail: PatrickZhao@ssw.com.au
 guid: ad45aab9-657e-4286-9799-209958ad11ed
 isArchived: false
-lastUpdated: 2021-03-15 22:21:29.816000+00:00
-lastUpdatedBy: Tiago Araújo [SSW]
-lastUpdatedByEmail: tiagov8@gmail.com
+lastUpdated: 2026-09-09T00:00:00.000Z
+lastUpdatedBy: Luke Mao
+lastUpdatedByEmail: LukeMao@ssw.com.au
 redirects:
 - do-you-keep-your-serverless-application-warm-to-avoid-cold-starts
 - do-you-keep-your-serverless-application-warm-(to-avoid-cold-starts)


### PR DESCRIPTION
>
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Reviewing [Rules to Better Bots](https://www.ssw.com.au/rules/rules-to-better-bots) while updating the bot framework rule (#13294).

[Do you keep your serverless application warm?](https://www.ssw.com.au/rules/keep-serverless-application-warm) was written in 2019 and carries **factual errors**, not just stale framing.

> 2. What was changed?

**Corrections**

| Rule said | Actually |
| --- | --- |
| "Azure Functions Premium Plan (preview)" | **GA**, and has been for years |
| Flex Consumption not mentioned | It is the current plan, with an **always ready** instance count |
| SnapStart not mentioned | Takes Java, Python and .NET cold starts to **sub-second at no extra cost** |
| "Prefer Python/Node over Java and C#" | SnapStart narrows that gap enough that it should not decide your language |
| "Firebase Functions on Google Cloud Platform" | Cloud Functions is now **Cloud Run functions**; **minimum instances** is the supported answer |

**The bigger point.** The rule's core advice was to write a timer-triggered function that pings your own app. That was correct in 2019. All three platforms have since shipped a first-party setting - Azure always ready, AWS provisioned concurrency, Google minimum instances - so the rule was teaching a workaround that is now the wrong answer. The rewrite leads with that.

**Also**

- Added a short "is it worth paying for?" section, since always-warm instances bill while idle and the rule never mentioned cost
- Kept the AWS VPC advice but softened it to match AWS's own wording: the ENI setup adds latency, so attach a VPC when you genuinely need the resources
- Added a Learn more section, all four links verified

**One for the reviewer to decide**

This rule lives in **Rules to Better Bots** but has nothing to do with bots beyond its old opening sentence, which I removed. It is a serverless rule. It probably belongs in an Azure or architecture category - happy to move it in a follow-up if you agree.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017R8BMRfESCukyLPBDvkkTG
