### PR TITLE
fix: remove bold markdown from figure captions (renders as literal stars)

### DIFF
--- a/public/uploads/rules/highlight-template-differences/rule.mdx
+++ b/public/uploads/rules/highlight-template-differences/rule.mdx
@@ -36,7 +36,7 @@ Done - my voice message is "Hi, you've reached Jane Northwind from SSW. I don't 
 
   </>}
   figurePrefix="bad"
-  figure="**Figure: Bad example - The deviation from the standard template isn't highlighted**"
+  figure="The deviation from the standard template isn't highlighted"
 />
 
 

--- a/public/uploads/rules/meetings-do-you-go-to-meetings-prepared/rule.mdx
+++ b/public/uploads/rules/meetings-do-you-go-to-meetings-prepared/rule.mdx
@@ -36,7 +36,7 @@ For example, when talking to a client about their ice cream chain...
 Where is the main outlet?
   </>}
   figurePrefix="bad"
-  figure="**Figure: Bad example - You should already know the answers to these questions by visiting their website**"
+  figure="You should already know the answers to these questions by visiting their website"
 />
 
 
@@ -55,7 +55,7 @@ Do you have a customer loyalty program? Is it working?
 Where are some of the biggest challenges / opportunities for you at the moment / in the future?
   </>}
   figurePrefix="good"
-  figure="**Figure: Good example - By asking questions, you show interest as well as initiating conversation - remember to get the customer talking**"
+  figure="By asking questions, you show interest as well as initiating conversation - remember to get the customer talking"
 />
 
 

--- a/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
+++ b/public/uploads/rules/the-application-do-you-make-the-app-do-the-work/rule.mdx
@@ -67,7 +67,7 @@ Regards,
 Dave
   </>}
   figurePrefix="ok"
-  figure="**Figure: Better example - run SQL scripts using another package**"
+  figure="Run SQL scripts using another package"
 />
 
 
@@ -88,7 +88,7 @@ Regards,
 Dave
   </>}
   figurePrefix="ok"
-  figure="**Figure: Better example - run SQL scripts in the application. There is a tool called [SQL Deploy | Reconcile](https://sqldeploy.com/)**"
+  figure="Run SQL scripts in the application. There is a tool called [SQL Deploy | Reconcile](https://sqldeploy.com/)"
 />
 
 
@@ -106,5 +106,5 @@ Regards,
 Dave
   </>}
   figurePrefix="good"
-  figure="**Figure: Good example - All done as part of the release pipeline**"
+  figure="All done as part of the release pipeline"
 />


### PR DESCRIPTION
Extra rules found as per https://github.com/SSWConsulting/SSW.Rules/issues/2707

cc @jeoffreyfischer @adamcogan @Aibono1225 

## Problem

Figure captions in `boxEmbed` and `imageEmbed` components were written with `**...**` bold markers and a redundant prefix label (e.g. `Figure: Bad example - `). Since the component already renders the prefix via `figurePrefix`, these stars render as literal `**` characters on the page — a visual bug.

## Files fixed (6 captions across 3 rules)

- `highlight-template-differences` — 1 caption
- `meetings-do-you-go-to-meetings-prepared` — 2 captions
- `the-application-do-you-make-the-app-do-the-work` — 3 captions

## Change

Stripped `**` and the redundant `Figure: X example - ` prefix from each `figure="..."` attribute, leaving only the description text (which is what the component expects).