### PR TITLE
AI artifacts: shorter intro

### DIFF
--- a/public/uploads/rules/use-ai-artifacts/rule.mdx
+++ b/public/uploads/rules/use-ai-artifacts/rule.mdx
@@ -20,11 +20,7 @@ archivedreason: null
 isArchived: false
 ---
 
-You work out the answer on Tuesday. The stakeholders see it on Friday, because Wednesday and Thursday went into a deck that flattens it into six bullets and a screenshot. They skim it, ask the one question the deck does not answer, and you book another meeting.
-
-AI artifacts close that gap. Describe what you want to show and the assistant builds a working version of it beside the conversation. It renders in about a minute, changes while the room watches, and publishes as a link you send when the call ends.
-
-Anything you currently explain in a document is a candidate.
+Instead of sending a client a deck or a PDF, ask the AI for a live page - a clickable screen, a cost calculator, a dashboard over the client's own numbers - and share the link. The client clicks through and answers their own "what if" during the call 🚀
 
 <endIntro />
 


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Follow-up to #13314, which merged before this intro change was pushed. The Tuesday-to-Friday story ran long for an intro.

> 2. What was changed?

`public/uploads/rules/use-ai-artifacts/rule.mdx`, intro only. One paragraph in the style of this week's CTF description: instead of a deck or a PDF, ask the AI for a live page, share the link, and the client answers their own "what if" during the call.

Validation: `check-mdx`, `find-rules-missing-endintro`, `markdownlint` and `git diff --check` all pass.

> 3. I paired or mob programmed with:

@lukecookssw wrote the original rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9ggcB2tT4x9hvmXKTMdD8