### PR TITLE
polish(use-ai-artifacts): tips box, vendor info box, list rewrite, paragraph break, US English

### DIFF
--- a/public/uploads/rules/use-ai-artifacts/rule.mdx
+++ b/public/uploads/rules/use-ai-artifacts/rule.mdx
@@ -27,6 +27,7 @@ archivedreason: null
 
 In the old world, consultants had to rely on static images, heavy documentation, and boardroom gesticulation to communicate information and concepts to stakeholders and decision makers.
 Inevitably, someone would ask a question your pre-prepared literature didn't anticipate, and no amount of hand-waving would be able to fill the gap.
+
 AI artifacts address that gap. In real-time, you describe what you want to show, and the assistant builds a working version of it beside the conversation. It renders in about a minute, and publishes as a link you can share directly with your audience.
 It is absolutely the fastest way to convey the same information you always have, in a much more dynamic, iterative, and engaging format.
 
@@ -38,14 +39,21 @@ Anything you currently explain in a document is a candidate.
 
 ## What is an AI artifact?
 
-An artifact is a working page the assistant builds and renders beside the chat. It is not a picture of a screen or a dashboard. It runs.
+An artifact is a working page the assistant builds and renders beside the chat. It is not a picture of a screen or a dashboard. It runs and it:
 
-Every vendor has the same idea under a different name - Anthropic calls them Artifacts, OpenAI calls them Sites, Google calls it Canvas. What matters is what they let you do:
+* **Responds** - Stakeholders click through the flow instead of imagining it from a flat image
+* **Changes mid-sentence** - "Make that wizard 2 steps instead of 4" is a 30-second edit, not a backlog item
+* **Ships as a link** - Publish it and the GM who missed the call opens it on their phone
+* **Takes their data** - Paste a sample export or a photo of the workshop whiteboard and the artifact is built on the thing they recognize
 
-* **It responds** - Stakeholders click through the flow instead of imagining it from a flat image
-* **It changes mid-sentence** - "Make that wizard 2 steps instead of 4" is a 30-second edit, not a backlog item
-* **It ships as a link** - Publish it and the GM who missed the call opens it on their phone
-* **It takes their data** - Paste a sample export or a photo of the workshop whiteboard and the artifact is built on the thing they recognise
+<boxEmbed
+  style="info"
+  body={<>
+    Every vendor has the same idea under a different name - Anthropic calls them **Artifacts**, OpenAI calls them **Sites**, Google calls it **Canvas**.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>
 
 Take a cloud spend review. The data is the same in both cases. What changes is whether the client can read it.
 
@@ -99,7 +107,7 @@ Because a document can only show what you already decided. An artifact lets the 
 
 Almost anything you currently send as a PDF, a slide, or a spreadsheet:
 
-| What you send today                                 | What you could send instead                                                                                                                            |
+| What you send today                                 | What you could send as an AI artifact                                                                                                                            |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Wireframes and UI mockups in Figma                  | A clickable screen the client drives themselves                                                                                                        |
 | A hosting options comparison table                  | A cost calculator with a user-count slider, so they watch the Azure bill move                                                                          |
@@ -129,7 +137,7 @@ Copilot Pages is the odd one out. It is a shared document you and Copilot edit t
 <boxEmbed
   style="info"
   body={<>
-    This corner of the market moves fast, so check the vendor's own docs rather than trusting a comparison you read six months ago. OpenAI's equivalent was **Canvas** until mid-2026, when it was dropped from the current GPT-5.5 models in favour of Sites, with writing and code moving inline into the chat.
+    This corner of the market moves fast, so check the vendor's own docs rather than trusting a comparison you read six months ago. OpenAI's equivalent was **Canvas** until mid-2026, when it was dropped from the current GPT-5.5 models in favor of Sites, with writing and code moving inline into the chat.
   </>}
   figurePrefix="none"
   figure=""
@@ -145,4 +153,11 @@ So instead of spending 20 minutes asking client requirements questions, you show
 
 In simple terms: give people something to edit, not a blank page to describe.
 
-Tip: Use the client's real data. Artifacts are private to you until you share them, so building one on their real export is no different from opening that export on your laptop. Never publish an artifact with real data to a public link.
+<boxEmbed
+  style="tips"
+  body={<>
+    **Tip:** Use the client's real data. Artifacts are private to you until you share them, so building one on their real export is no different from opening that export on your laptop. Never publish an artifact with real data to a public link.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>

--- a/public/uploads/rules/use-ai-artifacts/rule.mdx
+++ b/public/uploads/rules/use-ai-artifacts/rule.mdx
@@ -25,13 +25,7 @@ isArchived: false
 archivedreason: null
 ---
 
-In the old world, consultants had to rely on static images, heavy documentation, and boardroom gesticulation to communicate information and concepts to stakeholders and decision makers.
-Inevitably, someone would ask a question your pre-prepared literature didn't anticipate, and no amount of hand-waving would be able to fill the gap.
-
-AI artifacts address that gap. In real-time, you describe what you want to show, and the assistant builds a working version of it beside the conversation. It renders in about a minute, and publishes as a link you can share directly with your audience.
-It is absolutely the fastest way to convey the same information you always have, in a much more dynamic, iterative, and engaging format.
-
-Anything you currently explain in a document is a candidate.
+Instead of sending a client a deck or a PDF, ask the AI for a live page - a clickable screen, a cost calculator, a dashboard over the client's own numbers - and share the link. The client clicks through and answers their own "what if" during the call 🚀
 
 <endIntro />
 


### PR DESCRIPTION
Checking rule for CTF

## Changes to [use-ai-artifacts](https://www.ssw.com.au/rules/use-ai-artifacts)

1. **Tips box** - wrapped the trailing `Tip:` sentence in a `tips`-styled `boxEmbed`
2. **Table column header** - "What you could send instead" → "What you could send as an AI artifact"
3. **Intro paragraph break** - added blank line before "AI artifacts address that gap." to split into two paragraphs
4. **Vendor info box** - converted the "Every vendor has the same idea..." sentence into an `info`-styled `boxEmbed` placed after the bullet list; bolded **Artifacts**, **Sites**, and **Canvas**; removed the redundant "What matters is what they let you do:" sentence
5. **List rewrite** - sentence before the list now reads "It runs and it:"; removed leading "It " from each list item label (**Responds**, **Changes mid-sentence**, **Ships as a link**, **Takes their data**)
6. **US English** - "recognise" → "recognize", "favour" → "favor"