### PR TITLE
Add video to appointment changes rule

### DIFF
--- a/public/uploads/rules/explain-deleted-or-modified-appointments/rule.mdx
+++ b/public/uploads/rules/explain-deleted-or-modified-appointments/rule.mdx
@@ -33,6 +33,8 @@ lastUpdatedByEmail: TiagoAraujo@ssw.com.au
 archivedreason: null
 ---
 
+<youtubeEmbed url="qXGKOevGW1w" description={"Video: Do you explain why you've deleted or updated an appointment? | Adam Cogan | SSW Rules (3 min)"} />
+
 Every appointment change is disruptive, so always explain **why** it was necessary.
 
 Unlike email, appointment updates don’t keep a visible history of the original content. It is a good idea to add a version number at the top to make changes transparent and track the timeline.


### PR DESCRIPTION
## What triggered this change?
Requested adding https://youtu.be/qXGKOevGW1w at the top of the appointment changes rule.

## What was changed?
Added a YouTube embed before the opening paragraph, with the verified video title and rounded duration (3 min).

## Validation
- MDX compilation, frontmatter, malformed bold, endIntro, and git diff checks passed.
- Markdown lint reports three existing trailing-whitespace errors in unchanged content.
