### PR TITLE
fix(video-editing-terms): move video after endIntro, set all image borders to true

### DIFF
--- a/public/uploads/rules/video-editing-terms/rule.mdx
+++ b/public/uploads/rules/video-editing-terms/rule.mdx
@@ -35,9 +35,9 @@ isArchived: false
 
 Understanding basic video editing terminology allows for better communication during the post-production workflow. It's important for anyone involved to know the basic terms to keep feedback clear and concise.
 
-<youtubeEmbed url="https://www.youtube.com/embed/GwWqoN8ajAo" description="Video: Video Editing Terminology | Adam and Eve Cogan | SSW Rules (4 min)" />
-
 <endIntro />
+
+<youtubeEmbed url="https://www.youtube.com/embed/GwWqoN8ajAo" description="Video: Video Editing Terminology | Adam and Eve Cogan | SSW Rules (4 min)" />
 
 ## 1. Primary Footage (aka Main Footage)
 
@@ -238,9 +238,9 @@ In editing software, video scrubbing can be done by moving the cursor forwards o
 
 For example, just like skipping forward or back in YouTube by using the arrow keys, in Premiere Pro, you can do the same by moving the play head.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Scrubbing this YouTube video 10s" src="/uploads/rules/video-editing-terms/rules-video-terminologies-youtube-scubbing-v7.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Scrubbing this YouTube video 10s" src="/uploads/rules/video-editing-terms/rules-video-terminologies-youtube-scubbing-v7.gif" />
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Scrubbing this Premiere Pro video in the timeline" src="/uploads/rules/video-editing-terms/rules-video-terminologies-premiere-scrubbing-v10.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Scrubbing this Premiere Pro video in the timeline" src="/uploads/rules/video-editing-terms/rules-video-terminologies-premiere-scrubbing-v10.gif" />
 
 **Feedback example:** "Hey Sam starting at 2:22, please scrub through the primary footage and see which take is my best to use. Thanks!"
 
@@ -254,7 +254,7 @@ For example, on the SSWTV channel, we often use 16:9 for online media platforms 
 
 See the image below for more aspect ratios.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Aspect ratio example" src="/uploads/rules/video-editing-terms/aspect-ratio-example.png" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Aspect ratio example" src="/uploads/rules/video-editing-terms/aspect-ratio-example.png" />
 
 **Feedback example:** "This video export is the wrong size, it's not SSW TV standards. Can we check the aspect ratio?"
 
@@ -264,7 +264,7 @@ A proper white balance is characterized by the whites in an image truly being th
 
 For instance, in an improper white balance, the whites may have tints of yellow, green, red, or some other colour. White balance’s formal definition is the process of gathering accurate colours for the available light. Your camera may come with a white balance menu and an auto white balance feature.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="The bad example and good example of white balance" src="/uploads/rules/video-editing-terms/white-balance-example-v3.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="The bad example and good example of white balance" src="/uploads/rules/video-editing-terms/white-balance-example-v3.gif" />
 
 **Feedback example:** "At 2:22, Jason's shirt seems a little too yellow, can we check the white balance?"
 
@@ -272,7 +272,7 @@ For instance, in an improper white balance, the whites may have tints of yellow,
 
 When the audio is recorded separately from the camera, you will need to sync the recording to the camera audio during the edit.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Clapping at the beginning of the recording can help synchronize the audio" src="/uploads/rules/video-editing-terms/audio-sync-example-v2.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Clapping at the beginning of the recording can help synchronize the audio" src="/uploads/rules/video-editing-terms/audio-sync-example-v2.gif" />
 
 **Feedback example:** "At 2:22, Adam's mouth moving at a different time than the recording audio, it has an audio sync error."
 
@@ -288,7 +288,7 @@ When video editing, it's important to have standard audio levelling.
 
 For example, if the presenter's voice is too quiet, it can be improved by increasing the gain of the audio clip. Vice versa if the dialogue/music is too loud, the audio levels would need to be lowered to reduce peaking.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="The speaker's face was away from the microphone" src="/uploads/rules/video-editing-terms/audio-levels-example.png" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="The speaker's face was away from the microphone" src="/uploads/rules/video-editing-terms/audio-levels-example.png" />
 
 **Feedback example:** "At 2:22, Adam's audio sounds soft because he turns his head away from the microphone, please increase the levels."
 
@@ -333,7 +333,7 @@ Is a transition effect in which one video clip (or picture) gradually fades out 
 
 For example, when transitioning from a full-screen share to the presenter on stage, using a cross dissolve makes the edit smoother.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Cross dissolution makes the video transition more natural" src="/uploads/rules/video-editing-terms/rules-video-terminologies-cross-dissolve-v6.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Cross dissolution makes the video transition more natural" src="/uploads/rules/video-editing-terms/rules-video-terminologies-cross-dissolve-v6.gif" />
 
 **Feedback example:** "At 2:22, add in a cross dissolve from the intro to the presenter."
 
@@ -343,7 +343,7 @@ Is a transition effect in which one video clip (or picture) fades out gradually 
 
 For example, "Fade to Black" is commonly used to visually signal the end of a scene or when changing from one subject to another.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Fade to black at the end of the scene" src="/uploads/rules/video-editing-terms/fade-to-black-example-v2.gif" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Fade to black at the end of the scene" src="/uploads/rules/video-editing-terms/fade-to-black-example-v2.gif" />
 
 **Feedback example:** "At 2:22, fade to black at the end of the demo."
 
@@ -371,4 +371,4 @@ The video has been approved and the feedback loop is closed. It is the stage of 
 
 Here is a sample email that you can use to provide feedback to the video editor.
 
-<imageEmbed alt="Image" size="large" showBorder={false} figurePrefix="none" figure="Sample email when sending video feedback including timestamps" src="/uploads/rules/video-editing-terms/sample-feedback-email.jpg" />
+<imageEmbed alt="Image" size="large" showBorder={true} figurePrefix="none" figure="Sample email when sending video feedback including timestamps" src="/uploads/rules/video-editing-terms/sample-feedback-email.jpg" />


### PR DESCRIPTION
## Changes to [video-editing-terms](https://www.ssw.com.au/rules/video-editing-terms)

1. **Video placement** - moved the `youtubeEmbed` to after `<endIntro />` so it appears in the rule body rather than the intro section
2. **Image borders** - set `showBorder={true}` on all 9 `imageEmbed` components (were all `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)