### PR TITLE
fix: standardize CC'd spelling across the repo

### DIFF
--- a/public/uploads/rules/how-to-avoid-being-blocked/rule.mdx
+++ b/public/uploads/rules/how-to-avoid-being-blocked/rule.mdx
@@ -26,7 +26,7 @@ You need techniques so you're not blocked, so here is a process you can follow:
 1. Attempt to warn then call, explaining that you're blocked
 2. If no luck, message with "Tried to call - will try again in 1 hour", then set yourself a reminder or an appointment
 3. If no luck again, message with "I haven't been able to get you, so I'll go to &#123;&#123; SOMEONE ELSE &#125;&#125; instead for the approval"
-4. Once approved, message with something like "&#123;&#123; SOMEONE ELSE &#125;&#125; approved it... See the email that you're CCed on for details 🙂"
+4. Once approved, message with something like "&#123;&#123; SOMEONE ELSE &#125;&#125; approved it... See the email that you're CC'd on for details 🙂"
 
 For the above, your escalation path for something that usually needs a particular person should go something like this:
 

--- a/public/uploads/rules/manage-multiple-email-accounts/rule.mdx
+++ b/public/uploads/rules/manage-multiple-email-accounts/rule.mdx
@@ -57,6 +57,6 @@ When replying to emails from shared company accounts, you have an alternative:
   size="large"
   showBorder={false}
   figurePrefix="good"
-  figure="Reply from your personal email, then keep the public email cc'd so the thread is tracked"
+  figure="Reply from your personal email, then keep the public email CC'd so the thread is tracked"
   src="/uploads/rules/manage-multiple-email-accounts/Pic-2.png"
 />

--- a/public/uploads/rules/request-a-test-please/rule.mdx
+++ b/public/uploads/rules/request-a-test-please/rule.mdx
@@ -152,14 +152,14 @@ See subject: Test Please - &#123;&#123; PRODUCT/DESIGN &#125;&#125; &#123;&#123;
 
 ## Getting input from extra people
 
-If you require input from a few people that were not originally cc'd on the email or on the ['To Myself'](/send-to-myself-emails), like getting feedback on a design, it's nice to give everyone the entire task context.
+If you require input from a few people that were not originally CC'd on the email or on the ['To Myself'](/send-to-myself-emails), like getting feedback on a design, it's nice to give everyone the entire task context.
 
 You have 2 options:
 
 1. **Keep the "test" in the same thread** (recommended)\
 In this case, just add the people you need to the thread, asking them specifically for a 'Test Please' on what you need
 2. **Create a new thread for the 'Test Please'**
-This is for when you have a good reason not to (e.g. avoiding too long email threads; too many people cc'ed, etc).
+This is for when you have a good reason not to (e.g. avoiding too long email threads; too many people CC'd, etc).
 In this case, make sure you include the original thread subject in your email, so people know the main task is happening there
 
 This way everyone will have the entire history of the task and its progress.

--- a/public/uploads/rules/send-to-myself-emails/rule.mdx
+++ b/public/uploads/rules/send-to-myself-emails/rule.mdx
@@ -63,7 +63,7 @@ Another scenario is when you've found something you should work on, but don't ha
     **Tips:**
     
     * Make it clearer to everyone else [by making "To myself" a heading or bold](/include-names-as-headings)\
-    Always add "To myself" in the email body - not on the subject - so that other people Cc'd know what is going on
+    Always add "To myself" in the email body - not on the subject - so that other people CC'd know what is going on
     * When replying "Done", address it to the Product Owner (or another person), not to yourself... Only crazy people talk to themselves :-)
     * Include an estimate and priority too...so the expectations are set better. With this estimate, the Product Owner can stop you if they think the amount of time doesn't provide good ROI
     * If there are other people addressed in the email, put the "To myself" at the top so the tasks aren't buried at the bottom of the email.


### PR DESCRIPTION
as per @adamcogan 's email: **Re: CC’ed or CC’d**

cc @Aibono1225 

## Problem

The term was spelled inconsistently across the codebase: `cc'd`, `Cc'd`, `CCed`, and `cc'ed` were all in use alongside the dominant form `CC'd`.

## Changes

Standardized 4 non-conforming occurrences to `CC'd` across 4 files:

- `manage-multiple-email-accounts` — `cc'd` → `CC'd`
- `request-a-test-please` — `cc'd` + `cc'ed` → `CC'd`
- `how-to-avoid-being-blocked` — `CCed` → `CC'd`
- `send-to-myself-emails` — `Cc'd` → `CC'd`

The remaining 16 occurrences were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)